### PR TITLE
Eval actions during destroy

### DIFF
--- a/internal/command/views/json_view_test.go
+++ b/internal/command/views/json_view_test.go
@@ -484,8 +484,6 @@ func testJSONViewOutputEqualsFull(t *testing.T, output string, want []map[string
 		}
 
 		if !cmp.Equal(wantStruct, gotStruct, options...) {
-			fmt.Printf("WANT: %#v\n", wantStruct)
-			fmt.Printf("GOT: %#v\n", gotStruct)
 			t.Errorf("unexpected output on line %d:\n%s", i, cmp.Diff(wantStruct, gotStruct))
 		}
 	}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -78,6 +78,30 @@ func (g *AcyclicGraph) FirstAncestorsWith(v Vertex, match func(Vertex) bool) Set
 	return s
 }
 
+// PrunedAncestors returns the ancestors of v, skipping all edges from vertices
+// which match the pruning function.
+func (g *AcyclicGraph) PrunedAncestors(v Vertex, pruneFunc func(Vertex) bool) Set {
+	s := make(Set)
+
+	searchFunc := func(v Vertex, d int) error {
+		if pruneFunc(v) {
+			return errStopWalkBranch
+		}
+		s.Add(v)
+		return nil
+	}
+
+	start := make(Set)
+	for _, dep := range g.downEdgesNoCopy(v) {
+		start.Add(dep)
+	}
+
+	// our memoFunc doesn't return an error
+	g.DepthFirstWalk(start, searchFunc)
+
+	return s
+}
+
 // MatchAncestor returns true if the given match function returns true for any
 // descendants of the given Vertex.
 func (g *AcyclicGraph) MatchAncestor(v Vertex, match func(Vertex) bool) bool {

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -230,6 +230,7 @@ func TestAcyclicGraphValidate_cycleSelf(t *testing.T) {
 
 func TestAcyclicGraphAncestors(t *testing.T) {
 	var g AcyclicGraph
+	g.Add(0)
 	g.Add(1)
 	g.Add(2)
 	g.Add(3)
@@ -244,6 +245,37 @@ func TestAcyclicGraphAncestors(t *testing.T) {
 	actual := g.Ancestors(2)
 
 	expected := []Vertex{3, 4, 5}
+
+	if actual.Len() != len(expected) {
+		t.Fatalf("bad length! expected %#v to have len %d", actual, len(expected))
+	}
+
+	for _, e := range expected {
+		if !actual.Include(e) {
+			t.Fatalf("expected: %#v to include: %#v", expected, actual)
+		}
+	}
+}
+
+func TestAcyclicGraphPrunedAncestors(t *testing.T) {
+	var g AcyclicGraph
+	g.Add(0)
+	g.Add(1)
+	g.Add(2)
+	g.Add(3)
+	g.Add(4)
+	g.Add(5)
+	g.Connect(BasicEdge(0, 1))
+	g.Connect(BasicEdge(0, 2))
+	g.Connect(BasicEdge(0, 3))
+	g.Connect(BasicEdge(2, 4))
+	g.Connect(BasicEdge(3, 5))
+
+	actual := g.PrunedAncestors(0, func(v Vertex) bool {
+		return v == 2
+	})
+
+	expected := []Vertex{1, 3, 5}
 
 	if actual.Len() != len(expected) {
 		t.Fatalf("bad length! expected %#v to have len %d", actual, len(expected))

--- a/internal/plans/action_invocation.go
+++ b/internal/plans/action_invocation.go
@@ -25,7 +25,6 @@ type ActionInvocationInstance struct {
 	// used to apply it.
 	ProviderAddr addrs.AbsProviderConfig
 
-	// FIXME: sensitive paths are missing
 	ConfigValue cty.Value
 
 	Caller addrs.Referenceable
@@ -149,7 +148,6 @@ func (t *InvokeActionTrigger) Less(other ActionTrigger) bool {
 // serialized so it can be written to a plan file. Pass the implied type of the
 // corresponding resource type schema for correct operation.
 func (ai *ActionInvocationInstance) Encode(schema *providers.ActionSchema) (*ActionInvocationInstanceSrc, error) {
-
 	ret := &ActionInvocationInstanceSrc{
 		Addr:          ai.Addr,
 		ActionTrigger: ai.ActionTrigger,

--- a/internal/terraform/action_trigger_instance_apply.go
+++ b/internal/terraform/action_trigger_instance_apply.go
@@ -21,16 +21,22 @@ type actionTriggerApplyInstance struct {
 	// actionNode links the trigger to it's action config node.
 	// This is connected by the diff transformer.
 	actionNode *NodeActionConfig
+
+	// The original caller may no longer be available when we get around to
+	// evaluating destroy actions, so we need to get the prior value from the
+	// planned changes. This is done before provider execution however, so we
+	// only have the encoded version of the change available.
+	callerChange *plans.ResourceInstanceChangeSrc
 }
 
 var (
 	// this doesn't operate as an independent node in the graph, but we obtain
-	// the relevant information for evaluataion via these interfaces
+	// the relevant information for evaluation via these interfaces
 	_ GraphNodeReferencer       = (*actionTriggerApplyInstance)(nil)
 	_ GraphNodeProviderConsumer = (*actionTriggerApplyInstance)(nil)
 )
 
-func (n *actionTriggerApplyInstance) Invoke(ctx EvalContext, caller addrs.Referenceable, callerVal cty.Value, fromPlan bool) tfdiags.Diagnostics {
+func (n *actionTriggerApplyInstance) Invoke(ctx EvalContext, caller addrs.Referenceable, callerVal cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	diagsWith := n.ActionInvocation.Addr.String()
@@ -38,7 +44,7 @@ func (n *actionTriggerApplyInstance) Invoke(ctx EvalContext, caller addrs.Refere
 		diagsWith = fmt.Sprintf("%s, called from %s", diagsWith, caller)
 	}
 
-	provider, actionProviderSchema, err := getProvider(ctx, n.ActionInvocation.ProviderAddr)
+	provider, _, err := getProvider(ctx, n.ActionInvocation.ProviderAddr)
 	if err != nil {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
@@ -59,35 +65,12 @@ func (n *actionTriggerApplyInstance) Invoke(ctx EvalContext, caller addrs.Refere
 		return diags
 	}
 
-	var configVal cty.Value
-
-	// fromPlan indicates we can use the entire planned value for the action,
-	// and should not attempt to reevaluate the config.
-	if fromPlan {
-		actionSchema, ok := actionProviderSchema.Actions[n.ActionInvocation.Addr.Action.Action.Type]
-		if !ok {
-			// This should have been caught earlier, but we don't want to panic
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  fmt.Sprintf("Action %s not found in provider schema", n.ActionInvocation.Addr),
-				Detail:   fmt.Sprintf("The action %s was not found in the provider schema for %s", n.ActionInvocation.Addr, n.ActionInvocation.ProviderAddr),
-				Subject:  n.actionNode.Config.DeclRange.Ptr(),
-			})
-			return diags
-		}
-		inv, err := n.ActionInvocation.Decode(&actionSchema)
-		if err != nil {
-			return diags.Append(err)
-		}
-		configVal = inv.ConfigValue
-	} else {
-		val, actionDiags := n.actionNode.EvalInstance(ctx, n.ActionInvocation.Addr, nil, caller, callerVal)
-		diags = diags.Append(actionDiags)
-		if diags.HasErrors() {
-			return diags
-		}
-		configVal = val
+	val, actionDiags := n.actionNode.EvalInstance(ctx, n.ActionInvocation.Addr, nil, caller, callerVal)
+	diags = diags.Append(actionDiags)
+	if diags.HasErrors() {
+		return diags
 	}
+	configVal := val
 
 	if !configVal.IsWhollyKnown() {
 		return diags.Append(&hcl.Diagnostic{

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -3217,6 +3217,164 @@ resource "test_object" "a" {
 	}
 }
 
+func TestContextApply_delete_actions_using_ephemeral_resources(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+// the replacement of this resource could cause a cycle with a destroy action,
+// so we can't allow it to exist in the shared dependencies of test_object.a and
+// action_example.bye.
+resource test_object root {
+  name = "secret"
+}
+
+ephemeral "test_ephem" "secret" {
+}
+
+action "action_example" "bye" {
+  config {
+    attr = ephemeral.test_ephem.secret.token
+  }
+}
+
+action "action_example" "hello" {
+  config {
+    attr = test_object.root.name
+  }
+}
+
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events  = [before_destroy]
+      actions = [action.action_example.bye]
+    }
+	action_trigger {
+      events  = [after_create]
+      actions = [action.action_example.hello]
+    }
+  }
+}
+`,
+	})
+
+	testProvider := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"name": {
+								Type:     cty.String,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			EphemeralResourceTypes: map[string]providers.Schema{
+				"test_ephem": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"token": {
+								Type:     cty.String,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		ApplyResourceChangeFn: func(arcr providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+			time.Sleep(100 * time.Millisecond)
+			return providers.ApplyResourceChangeResponse{
+				NewState:    arcr.PlannedState,
+				NewIdentity: arcr.PlannedIdentity,
+			}
+		},
+		OpenEphemeralResourceFn: func(req providers.OpenEphemeralResourceRequest) (resp providers.OpenEphemeralResourceResponse) {
+			resp.Result = cty.ObjectVal(map[string]cty.Value{
+				"token": cty.StringVal("secret"),
+			})
+			return resp
+		},
+		CloseEphemeralResourceFn: func(req providers.CloseEphemeralResourceRequest) (resp providers.CloseEphemeralResourceResponse) {
+			return resp
+		},
+	}
+
+	actionProvider := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Actions: map[string]providers.ActionSchema{
+				"action_example": {
+					ConfigSchema: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"attr": {
+								Type:      cty.String,
+								Optional:  true,
+								WriteOnly: true,
+							},
+						},
+					},
+				},
+			},
+			ResourceTypes: map[string]providers.Schema{},
+		},
+
+		InvokeActionFn: func(req providers.InvokeActionRequest) (resp providers.InvokeActionResponse) {
+			resp.Events = func(yield func(providers.InvokeActionEvent) bool) {
+				yield(providers.InvokeActionEvent_Completed{})
+			}
+			attr := req.PlannedActionData.GetAttr("attr")
+			if attr.IsNull() || attr.AsString() != "secret" {
+				resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf(`expected "secret", got: %#v`, attr))
+			}
+
+			return resp
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"):   testProviderFuncFixed(testProvider),
+			addrs.NewDefaultProvider("action"): testProviderFuncFixed(actionProvider),
+		},
+	})
+
+	// Just a sanity check that the module is valid
+	diags := ctx.Validate(m, &ValidateOpts{})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	// planOpts := SimplePlanOpts(plans.DestroyMode, InputValues{})
+	planOpts := SimplePlanOpts(plans.NormalMode, InputValues{})
+
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectTainted,
+				AttrsJSON: []byte(`{"name":"old"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+		s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.root"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectTainted,
+				AttrsJSON: []byte(`{"name":"old"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	})
+
+	plan, diags := ctx.Plan(m, state, planOpts)
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	_, diags = ctx.Apply(plan, m, nil)
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	if !actionProvider.InvokeActionCalled {
+		t.Fatal("InvokeAction not called")
+	}
+}
+
 func testContextActionProvider(invokeActionFn func(req providers.InvokeActionRequest) providers.InvokeActionResponse) *testing_provider.MockProvider {
 	return &testing_provider.MockProvider{
 		InvokeActionFn: invokeActionFn,

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1012,7 +1013,7 @@ resource "test_object" "a" {
 					return diags.Append(&hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  "Reference to non-existent action instance",
-						Detail:   `The given key ["c"] does not identify an instance of action.test_action.hello`,
+						Detail:   `The given key ["c"] does not identify an instance of action.test_action.hello["c"]`,
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
 							Start:    hcl.Pos{Line: 13, Column: 18, Byte: 224},
@@ -1047,7 +1048,7 @@ resource "test_object" "a" {
 					return diags.Append(&hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  "Reference to non-existent action instance",
-						Detail:   "The given key [2] does not identify an instance of action.test_action.hello",
+						Detail:   "The given key [2] does not identify an instance of action.test_action.hello[2]",
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
 							Start:    hcl.Pos{Line: 13, Column: 18, Byte: 208},
@@ -1494,7 +1495,7 @@ resource "test_object" "a" {
 				expectPlanActionCalled: true,
 			},
 
-			"no ephemeral in destroy": {
+			"basic ephemeral in destroy": {
 				module: map[string]string{
 					"main.tf": `
 action "test_action_wo" "test" {
@@ -1529,19 +1530,7 @@ resource "test_object" "a" {
 						mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 					)
 				},
-				expectPlanActionCalled: false,
-				expectPlanDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
-					return diags.Append(&hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "Action config contains ephemeral values",
-						Detail:   "A destroy action configuration must be fully planned, and cannot contain ephemeral values.",
-						Subject: &hcl.Range{
-							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 2, Column: 1, Byte: 1},
-							End:      hcl.Pos{Line: 2, Column: 31, Byte: 31},
-						},
-					})
-				},
+				expectPlanActionCalled: true,
 			},
 
 			"destroy action must be known": {
@@ -4489,4 +4478,164 @@ resource "test_object" "a" {
 	if diags.Err().Error() != expectedErr {
 		t.Fatalf("wrong error!, got %q, expected %q", diags.Err().Error(), expectedErr)
 	}
+}
+
+func TestContextPlan_delete_actions_shared_dependencies_cause_cycle(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+// the replacement of this resource could cause a cycle with a destroy action,
+// so we can't allow it to exist in the shared dependencies of test_object.a and
+// action_example.bye.
+resource test_object root {}
+
+action "action_example" "bye" {
+  config {
+    attr = test_object.root.name
+  }
+}
+
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events  = [before_destroy]
+      actions = [action.action_example.bye]
+    }
+  }
+  depends_on = [test_object.root]
+}
+`,
+	})
+
+	testProvider := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"name": {
+								Type:     cty.String,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	actionProvider := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Actions: map[string]providers.ActionSchema{
+				"action_example": {
+					ConfigSchema: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"attr": {
+								Type:      cty.String,
+								Optional:  true,
+								WriteOnly: true,
+							},
+						},
+					},
+				},
+			},
+			ResourceTypes: map[string]providers.Schema{},
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"):   testProviderFuncFixed(testProvider),
+			addrs.NewDefaultProvider("action"): testProviderFuncFixed(actionProvider),
+		},
+	})
+
+	// Just a sanity check that the module is valid
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if !strings.Contains(diags.Err().Error(), "The destroy action config must not also depend on any dependencies of the calling resource") {
+		t.Fatal("expected error about overlappign dependencies, got:", diags.ErrWithWarnings())
+	}
+}
+
+func TestContextPlan_delete_and_create_with_deifferent_deps(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+// the replacement of this resource could cause a cycle with a destroy action,
+// so we can't allow it to exist in the shared dependencies of test_object.a and
+// action_example.bye.
+resource test_object root {}
+
+action "action_example" "bye" {
+  config {
+    attr = "bye"
+  }
+}
+
+action "action_example" "hello" {
+  config {
+    attr = test_object.root.name
+  }
+}
+
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events  = [before_destroy]
+      actions = [action.action_example.bye]
+    }
+    action_trigger {
+      events  = [after_create]
+      actions = [action.action_example.hello]
+    }
+  }
+  depends_on = [test_object.root]
+}
+`,
+	})
+
+	testProvider := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"name": {
+								Type:     cty.String,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	actionProvider := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Actions: map[string]providers.ActionSchema{
+				"action_example": {
+					ConfigSchema: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"attr": {
+								Type:      cty.String,
+								Optional:  true,
+								WriteOnly: true,
+							},
+						},
+					},
+				},
+			},
+			ResourceTypes: map[string]providers.Schema{},
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"):   testProviderFuncFixed(testProvider),
+			addrs.NewDefaultProvider("action"): testProviderFuncFixed(actionProvider),
+		},
+	})
+
+	// Just a sanity check that the module is valid
+	diags := ctx.Validate(m, &ValidateOpts{})
+	tfdiags.AssertNoDiagnostics(t, diags)
 }

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -33,6 +33,13 @@ type GraphNodeActionCaller interface {
 	// Action calls returns all action references so they can be connected to
 	// any of the actions which use the caller symbol
 	ActionCalls() []addrs.ConfigAction
+
+	// DestroyActionCalls is used in the reference transformer to validate
+	// destroy action references. A destroy action can contain ephemeral values,
+	// but those require it to be reevaluated during apply, and the dependencies
+	// required to do so can cause cycles. If there are no destroy events
+	// possible, the action call is exempt from this validation.
+	DestroyActionCalls() []addrs.ConfigAction
 }
 
 // GraphNodeActionInvoker attaches planned action invocations to a node which
@@ -436,7 +443,7 @@ func (n *NodeActionConfig) EvalInstance(ctx EvalContext, inst addrs.AbsActionIns
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Reference to non-existent action instance",
-			Detail:   fmt.Sprintf("The given key %s does not identify an instance of action.test_action.hello", inst.Action.Key),
+			Detail:   fmt.Sprintf("The given key %s does not identify an instance of %s", inst.Action.Key, inst),
 			Subject:  callRange,
 		})
 		return cty.DynamicVal, diags

--- a/internal/terraform/node_action_invoke.go
+++ b/internal/terraform/node_action_invoke.go
@@ -276,7 +276,7 @@ func (n *nodeActionInvokeApplyInstance) Execute(ctx EvalContext, op walkOperatio
 		}
 	}
 
-	return n.Invoke(ctx, caller, cty.DynamicVal, true)
+	return n.Invoke(ctx, caller, cty.NilVal)
 }
 
 func (n *nodeActionInvokeApplyInstance) References() []*addrs.Reference {

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -411,6 +411,25 @@ func (n *NodeAbstractResource) ActionCalls() []addrs.ConfigAction {
 	return calls
 }
 
+// This is very specific to determining during plan if a destroy action might
+// fail to reevaluate an ephemeral resource. Since we need to statically
+// validate the config, we check if the resource has any destroy action events,
+// and any actions depend on ephemeral resources.
+func (n *NodeAbstractResource) DestroyActionCalls() []addrs.ConfigAction {
+	var calls []addrs.ConfigAction
+
+	for _, trigger := range n.actionTriggers {
+		for _, event := range trigger.config.Events {
+			if event.IsDestroy() {
+				for _, actionRef := range trigger.actionRefs {
+					calls = append(calls, actionRef.actionNode.Addr)
+				}
+			}
+		}
+	}
+	return calls
+}
+
 // GraphNodeProvisionerConsumer
 func (n *NodeAbstractResource) ProvisionedBy() []string {
 	// If we have no configuration, then we have no provisioners

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -120,10 +120,10 @@ func (n *NodeAbstractResourceInstance) ReferenceableAddrs() []addrs.Referenceabl
 	}
 }
 
-// destroyActionReferences are used by destroy nodes to ensure that only actions
+// destroyActionPlanReferences are used by destroy nodes to ensure that only actions
 // are connected by references, since a destroy node cannot reference anything
 // else from the config.
-func (n *NodeAbstractResourceInstance) destroyActionReferences() []*addrs.Reference {
+func (n *NodeAbstractResourceInstance) destroyActionPlanReferences() []*addrs.Reference {
 	var refs []*addrs.Reference
 	// Resources are destroyed using their state, but we do need to evaluate any
 	// potential destroy actions.
@@ -141,6 +141,23 @@ func (n *NodeAbstractResourceInstance) destroyActionReferences() []*addrs.Refere
 
 		rs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, trigger.config.Condition)
 		refs = append(refs, rs...)
+	}
+	return refs
+}
+
+// destroyActionApplyReferences are used by destroy nodes to ensure that only actions
+// are connected by references, since a destroy node cannot reference anything
+// else from the config.
+func (n *NodeAbstractResourceInstance) destroyActionApplyReferences() []*addrs.Reference {
+	var refs []*addrs.Reference
+	// Resources are destroyed using their state, but we may need to evaluate any
+	// potential destroy actions.
+	for _, trigger := range n.actionApplyTriggers {
+		// the condition must be known during plan, so the only reference we
+		// need for correct evaluation is the action config itself
+		refs = append(refs, &addrs.Reference{
+			Subject: trigger.ActionInvocation.Addr.Action,
+		})
 	}
 	return refs
 }
@@ -3284,16 +3301,6 @@ func (n *NodeAbstractResourceInstance) planActionTrigger(ctx EvalContext, resRep
 			})
 			return
 		}
-
-		if len(ephemeral.EphemeralValuePaths(actionVal)) > 0 {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Action config contains ephemeral values",
-				Detail:   "A destroy action configuration must be fully planned, and cannot contain ephemeral values.",
-				Subject:  actionRef.actionNode.Config.DeclRange.Ptr(),
-			})
-			return
-		}
 	}
 
 	provider, _, err := getProvider(ctx, actionRef.actionNode.ResolvedProvider)
@@ -3336,7 +3343,8 @@ func (n *NodeAbstractResourceInstance) planActionTrigger(ctx EvalContext, resRep
 	}
 
 	ai.ConfigValue = ephemeral.RemoveEphemeralValues(actionVal)
-	return
+
+	return ai, deferred, diags
 }
 
 // invokeDestroyAction currently cannot reevaluate the action config due to not
@@ -3352,8 +3360,16 @@ func (n *NodeAbstractResourceInstance) invokeDestroyActions(ctx EvalContext, for
 			continue
 		}
 
+		// get the last known prior value of the caller, so that we can be sure
+		// it's value is available during execution
+		change, err := trigger.callerChange.Decode(*n.Schema)
+		if err != nil {
+			diags = diags.Append(err)
+			continue
+		}
+
 		log.Printf("[DEBUG] NodeAbstractResourceInstance: invoking destroy action %s", trigger.ActionInvocation.Addr)
-		diags = diags.Append(trigger.Invoke(ctx, n.Addr.Resource, cty.DynamicVal, true))
+		diags = diags.Append(trigger.Invoke(ctx, n.Addr.Resource, change.Before))
 		if diags.HasErrors() {
 			break
 		}
@@ -3387,7 +3403,7 @@ func (n *NodeAbstractResourceInstance) invokeActions(ctx EvalContext, repData in
 			continue
 		}
 
-		invokeDiags := trigger.Invoke(ctx, n.Addr.Resource, callerVal, false)
+		invokeDiags := trigger.Invoke(ctx, n.Addr.Resource, callerVal)
 		if invokeDiags.HasErrors() {
 			switch onFailure {
 			case configs.ActionOnFailureHalt:

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -89,7 +89,7 @@ func (n *NodeDestroyResourceInstance) ReferenceableAddrs() []addrs.Referenceable
 func (n *NodeDestroyResourceInstance) References() []*addrs.Reference {
 	// destroyers don't reference, except when we need destroy actions to be
 	// reevaluated.
-	return n.destroyActionReferences()
+	return n.destroyActionApplyReferences()
 }
 
 // GraphNodeExecutable

--- a/internal/terraform/node_resource_plan_destroy.go
+++ b/internal/terraform/node_resource_plan_destroy.go
@@ -56,7 +56,7 @@ func (n *NodePlanDestroyableResourceInstance) ReferenceableAddrs() []addrs.Refer
 }
 
 func (n *NodePlanDestroyableResourceInstance) References() (refs []*addrs.Reference) {
-	return n.destroyActionReferences()
+	return n.destroyActionPlanReferences()
 }
 
 func (n *NodePlanDestroyableResourceInstance) AttachActionTriggers(triggers []*resourceActionTrigger) {

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -89,7 +89,7 @@ func (n *NodePlannableResourceInstanceOrphan) ReferenceableAddrs() []addrs.Refer
 }
 
 func (n *NodePlannableResourceInstanceOrphan) References() (refs []*addrs.Reference) {
-	return n.destroyActionReferences()
+	return n.destroyActionPlanReferences()
 }
 
 func (n *NodePlannableResourceInstanceOrphan) AttachActionTriggers(triggers []*resourceActionTrigger) {

--- a/internal/terraform/transform_action_diff.go
+++ b/internal/terraform/transform_action_diff.go
@@ -5,6 +5,7 @@ package terraform
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -34,16 +35,21 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 	}
 
 	for _, ai := range t.Changes.ActionInvocations {
+		actionConfig, ok := actionConfigNodes.GetOk(ai.Addr.ConfigAction())
+		if !ok {
+			return fmt.Errorf("no action config node found for action trigger %s", ai.ActionTrigger)
+		}
+
+		actionTriggerInstance := &actionTriggerApplyInstance{
+			ActionInvocation: ai,
+			actionNode:       actionConfig,
+		}
+
 		switch actionTrigger := ai.ActionTrigger.(type) {
 		case *plans.ResourceActionTrigger:
 			resourceInstances, ok := resourceInstanceNodes.GetOk(actionTrigger.TriggeringResourceAddr)
 			if !ok {
 				return fmt.Errorf("no resource node found for action trigger %s", actionTrigger.TriggeringResourceAddr)
-			}
-
-			actionConfig, ok := actionConfigNodes.GetOk(ai.Addr.ConfigAction())
-			if !ok {
-				return fmt.Errorf("no action config node found for action trigger %s", actionTrigger.TriggeringResourceAddr)
 			}
 
 			foundNode := false
@@ -55,37 +61,43 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 					return fmt.Errorf("node %s type %T is not a GraphNodeActionInvoker", resourceInstance.ResourceInstanceAddr(), resourceInstance)
 				}
 
-				if actionTrigger.ActionTriggerEvent.IsDestroy() {
-					// we may have both create and destroy nodes under ths same
-					// address, so match make sure the destroy action trigger is
-					// only attached to a destroyer node
-					if _, ok := resourceInstance.(GraphNodeDestroyer); !ok {
+				switch resourceInstance.(type) {
+				case GraphNodeDestroyer:
+					if !actionTrigger.ActionTriggerEvent.IsDestroy() {
+						// we may have both create and destroy nodes under ths
+						// same address, so make sure only destroy action triggers
+						// are attached to destroyer nodes
 						continue
 					}
-				}
 
-				invoker.AttachActionApplyTrigger(&actionTriggerApplyInstance{
-					ActionInvocation: ai,
-					actionNode:       actionConfig,
-				})
-				foundNode = true
+					// A destroy node might need to reevaluate the action in the
+					// case of ephemeral values, so store the caller's change in
+					// case it's needed later. We can't decode the change
+					// however, so leave that to the caller to handle.
+					changeSrc := t.Changes.ResourceInstance(actionTrigger.TriggeringResourceAddr)
+					log.Printf("[DEBUG] ActionDiffTransformer: storing action destroy change src for %s", actionTrigger.TriggeringResourceAddr)
+					actionTriggerInstance.callerChange = changeSrc
+
+					invoker.AttachActionApplyTrigger(actionTriggerInstance)
+					foundNode = true
+
+				default:
+					if actionTrigger.ActionTriggerEvent.IsDestroy() {
+						continue
+					}
+
+					invoker.AttachActionApplyTrigger(actionTriggerInstance)
+					foundNode = true
+				}
 			}
+
 			if !foundNode {
 				return fmt.Errorf("no resource node found for action trigger %s", actionTrigger.TriggeringResourceAddr)
 			}
-		case *plans.InvokeActionTrigger:
-			actionConfig, ok := actionConfigNodes.GetOk(ai.Addr.ConfigAction())
-			if !ok {
-				panic(fmt.Sprintf("FIXME: missing action for invoke: %s", ai.Addr))
-			}
 
+		case *plans.InvokeActionTrigger:
 			// Add nodes for each action invocation
-			node := &nodeActionInvokeApplyInstance{
-				&actionTriggerApplyInstance{
-					ActionInvocation: ai,
-					actionNode:       actionConfig,
-				},
-			}
+			node := &nodeActionInvokeApplyInstance{actionTriggerInstance}
 			g.Add(node)
 		}
 	}

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 
@@ -114,13 +115,18 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 	vertices := g.Vertices()
 	m := NewReferenceMap(vertices)
 
+	actionConfigNodes := addrs.MakeMap[addrs.ConfigAction, GraphNodeConfigAction]()
+
 	// Find the things that reference things and connect them
 	for _, v := range vertices {
-		if _, ok := v.(GraphNodeConfigAction); ok {
+		if action, ok := v.(GraphNodeConfigAction); ok {
 			// Because actions were allowed to reference the calling resource in
 			// configuration, we need to deal with the resulting cycles. Skip
 			// action nodes in the first round so that any triggers can be
 			// connected first and cycles can be detected.
+
+			// record these for later validation
+			actionConfigNodes.Put(action.ActionAddr(), action)
 			continue
 		}
 
@@ -177,6 +183,82 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 		}
 	}
 
+	return t.validateDestroyActionReferences(g, actionConfigNodes)
+}
+
+// validateDestroyActionReferences checks that actions referencing resources
+// won't create dependency cycles when inserted into resource replacement
+// graphs. Evaluating destroy actions requires that the destroy node be
+// connected the action config, which in turn could connect to other managed
+// resources. If the action's dependencies overlap with the destroy instance's
+// resource dependencies, we get a cycle during replacement. A form of this
+// cycle can also happen when a provider depends on managed resources, but since
+// that was allowed in legacy Terraform configurations, the
+// DestroyEdgeTransformer breaks the cycle rather than pre-validate it on the
+// grounds that inter-provider dependencies need not be as strict.
+func (t *ReferenceTransformer) validateDestroyActionReferences(g *Graph, actionConfigNodes addrs.Map[addrs.ConfigAction, GraphNodeConfigAction]) error {
+	// we only want to check for resource nodes in the overlapping dependencies,
+	// because they are the only ones which create replacement subgraphs
+	resourceFilter := func(v any) bool {
+		_, ok := v.(GraphNodeConfigResource)
+		return ok
+	}
+
+	// And now finally, another exception for actions is that they might need to
+	// re-evaluate during a destroy from within a destroy node. This usually
+	// isn't allowed because references will introduce cycles, so we pre-vet the
+	// allowed cases from here. This must be statically validated, so we can't
+	// pre-check for known-ness of the config, nor can we be sure no ephemeral
+	// value will be inserted, but we can trigger the exception when an
+	// ephemeral resource exists in the dependency chain.
+	for _, v := range g.Vertices() {
+		caller, isActionCaller := v.(GraphNodeActionCaller)
+		if !isActionCaller {
+			continue
+		}
+
+		destroyActionCalls := caller.DestroyActionCalls()
+		if len(destroyActionCalls) == 0 {
+			// no reason to validate this resource's calls, because they will
+			// never be triggered by a destroy event.
+			continue
+		}
+
+		// we want all ancestors resources without references indirectly added
+		// via action nodes
+		callerDeps := g.PrunedAncestors(caller, func(v dag.Vertex) bool {
+			_, ok := v.(GraphNodeConfigAction)
+			return ok
+		}).Filter(resourceFilter)
+
+		for _, calledAction := range destroyActionCalls {
+			actionNode, ok := actionConfigNodes.GetOk(calledAction)
+			if !ok {
+				// this should be validated already, but make sure nothing missing here
+				return fmt.Errorf("missing action node for %s called from %s", calledAction, caller.ResourceAddr())
+			}
+
+			// This node references an action config. We can ensure that by
+			// verifying there is no intersection between the action node's
+			// dependencies and the resource node's dependencies.
+			actionDeps := g.Ancestors(actionNode).Filter(resourceFilter)
+
+			if intersection := callerDeps.Intersection(actionDeps); intersection.Len() > 0 {
+				// get the names of the shared dependencies to help the user
+				// locate where the intersection lies in the config
+				var intersectionNames []string
+				for res := range intersection.List() {
+					// we know these were filtered down to GraphNodeConfigResources
+					intersectionNames = append(intersectionNames, res.(GraphNodeConfigResource).ResourceAddr().String())
+				}
+
+				return fmt.Errorf("The destroy action %s and calling resource (%s) share dependencies of [%s] which can cause cycles during destroy. "+
+					"The destroy action config must not also depend on any dependencies of the calling resource.",
+					actionNode.ActionAddr(), caller.ResourceAddr(), strings.Join(intersectionNames, ", "),
+				)
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Destroy actions dependencies can be statically validated to eliminate the possibility of cycles, allowing us to evaluate destroy actions during apply. Actions need to be evaluated during apply because they may contain ephemeral values, so storing them from the plan was not going to work as a single long-term solution. In order to ensure that we don't encounter replacement cycles when faced with arbitrary changes in an already working config, we can prevent the possibility by checking that the destroy action and calling resource have no common managed dependencies.

The potential for replacement cycles can be prevented during plan by ensuring that the calling resource and the action config have entirely disjoint sets of managed resource dependencies. This is done via a new graph traversal, `PrunedAncestors`, which avoids walking across nodes matching the pruning function. That lets us get all resource dependencies minus the action config itself, then separately finding dependencies of the action config for comparison. If there are no common managed ancestors between the sets, we can be sure that the dependency flow cannot cycle back to the destroy node when replacements are in effect.

This methodology however still can't completely solve the problem within Terraform's architecture, because module expansion inherently creates shared dependencies for all module contents which can't be avoided. What that means, is if a module's expansion has any transitive dependency on a managed resource, destroy actions cannot be reevaluated within that module. Even when the action is working with replacements, orphaned module instances fail in a different manner, because we cannot evaluate an action within the scope of a module instance which does not exist at all. Some followup work will be needed to address those failure modes.