### PR TITLE
Pass null provider metadata to ReadDataSource RPC

### DIFF
--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -2161,6 +2161,103 @@ func TestContext2Plan_PolicyCallback_GetDataSource(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_PolicyCallback_GetDataSource_ProviderMeta(t *testing.T) {
+	// This tests that we pass a null provider meta to the ReadDataSource callback
+	// when the provider schema defines a provider meta block.
+	// Policy callbacks do not need to report metadata to the provider.
+	t.Parallel()
+
+	providerMetaSchema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"baz": {
+				Type:     cty.String,
+				Optional: true,
+			},
+		},
+	}
+	providerMetaType := providerMetaSchema.ImpliedType()
+
+	mockPolicyClient := policy.NewTestMockClient(t)
+	var gotResult cty.Value
+	mockPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		result, deferred, err := req.Callbacks.GetDataSource(t.Context(), "test_data_source", cty.ObjectVal(map[string]cty.Value{
+			"id":  cty.NullVal(cty.String),
+			"foo": cty.StringVal("test val"),
+		}))
+		if err != nil {
+			t.Fatalf("unexpected GetDataSource error: %v", err)
+		}
+		if deferred {
+			t.Fatal("expected GetDataSource callback not to be deferred")
+		}
+		gotResult = result
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	testProvider := testProvider("test")
+	schema := getProviderSchema(testProvider)
+	schema.ProviderMeta = providerMetaSchema
+	testProvider.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(schema)
+	testProvider.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+		if !req.ProviderMeta.IsNull() {
+			t.Fatalf("expected null ProviderMeta for policy GetDataSource callback, got %#v", req.ProviderMeta)
+		}
+		if got := req.ProviderMeta.Type(); !got.Equals(providerMetaType) {
+			t.Fatalf("unexpected ProviderMeta type: got %s, want %s", got.FriendlyName(), providerMetaType.FriendlyName())
+		}
+
+		stateVal := req.Config.AsValueMap()
+		stateVal["id"] = cty.StringVal("computed val")
+		return providers.ReadDataSourceResponse{
+			State: cty.ObjectVal(stateVal),
+		}
+	}
+
+	ctx, diags := NewContext(&ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(testProvider),
+		},
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	mod := testModuleInline(t, map[string]string{
+		"main.tf": `
+			terraform {
+				required_providers {
+					test = {
+						source = "hashicorp/test"
+						version = "1.0.0"
+					}
+				}
+			}
+
+			resource "test_resource" "foo" {
+				value = "foo"
+				defer = false
+			}
+		`,
+		"main.tfpolicy.hcl": `# policy config is not read by Terraform`,
+	})
+
+	_, diags = ctx.Plan(mod, states.NewState(), &PlanOpts{
+		Mode:         plans.NormalMode,
+		SetVariables: testInputValuesUnset(mod.Module.Variables),
+		PolicyClient: mockPolicyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	if !testProvider.ReadDataSourceCalled {
+		t.Fatal("expected ReadDataSource to be called by policy callback")
+	}
+	wantResult := cty.ObjectVal(map[string]cty.Value{
+		"id":  cty.StringVal("computed val"),
+		"foo": cty.StringVal("test val"),
+	})
+	if diff := cmp.Diff(gotResult, wantResult, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+		t.Fatalf("unexpected GetDataSource result (-got +want):\n%s", diff)
+	}
+}
+
 func TestContext2Plan_PolicyCallback_GetResources_Deferral(t *testing.T) {
 	t.Parallel()
 

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -152,10 +152,16 @@ func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interfac
 				return cty.NilVal, false, fmt.Errorf("failed to validate data source configuration: %s", err)
 			}
 
+			meta := cty.NilVal
+			if schema.ProviderMeta.Body != nil {
+				meta = cty.NullVal(schema.ProviderMeta.Body.ImpliedType())
+			}
+
 			readResp := provider.ReadDataSource(providers.ReadDataSourceRequest{
 				TypeName:           target,
 				Config:             configVal,
 				ClientCapabilities: ctx.ClientCapabilities(),
+				ProviderMeta:       meta,
 			})
 			if err := readResp.Diagnostics.Err(); err != nil {
 				return cty.NilVal, false, fmt.Errorf("failed to read data source: %s", err)


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->



`getDataSourceForPolicyCallback` was always passing `cty.NilVal` as `ProviderMeta` to `ReadDataSource` unless provider meta was explicitly populated elsewhere. That works for providers with no `ProviderMeta` schema, but it breaks the provider RPC path for providers that do declare one, because the request needs to carry a value of the expected provider meta type.

This PR ensures that we send a null value in that case, which the provider then handles appropriately.



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
