### PR TITLE
Orphaned actions need a way to continue when references are no longer valid

### DIFF
--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -634,47 +634,6 @@ resource "test_object" "a" {
 				expectPlanActionCalled: false,
 			},
 
-			"failing actions cancel next ones": {
-				module: map[string]string{
-					"main.tf": `
-action "test_action" "failure" {}
-resource "test_object" "a" {
-  lifecycle {
-    action_trigger {
-      events = [before_create]
-      actions = [action.test_action.failure, action.test_action.failure]
-    }
-    action_trigger {
-      events = [before_create]
-      actions = [action.test_action.failure]
-    }
-  }
-}
-`,
-				},
-
-				planActionFn: func(_ *testing.T, _ providers.PlanActionRequest) providers.PlanActionResponse {
-					t.Helper()
-					return providers.PlanActionResponse{
-						Diagnostics: tfdiags.Diagnostics{
-							tfdiags.Sourceless(tfdiags.Error, "Planning failed", "Test case simulates an error while planning"),
-						},
-					}
-				},
-
-				expectPlanActionCalled: true,
-				// We only expect a single diagnostic here, the other should not have been called because the first one failed.
-				expectPlanDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
-					return tfdiags.Diagnostics{}.Append(
-						&hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  "Planning failed",
-							Detail:   "Test case simulates an error while planning",
-						},
-					)
-				},
-			},
-
 			"actions with warnings don't cancel": {
 				module: map[string]string{
 					"main.tf": `
@@ -1652,7 +1611,7 @@ resource "test_object" "a" {
 					)
 				},
 				expectPlanActionCalled: false,
-				expectPlanDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+				expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
 					return diags.Append(&hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  "Condition on destroy action",

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1234,6 +1235,80 @@ resource "test_object" "a" {
 						AttrsJSON: []byte(`{}`),
 						Status:    states.ObjectReady,
 					}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+				},
+			},
+
+			// Orphaned instances might not even be able to plan, if for example
+			// the entire module instance is gone. Make sure that we can still
+			// apply, and warn about failing actions.
+			"complex orphaned module instances": {
+				module: map[string]string{
+					"main.tf": `
+resource "test_object" "root" {
+}
+
+module "mod" {
+  // the last instance was removed
+  for_each = {}
+  source = "./mod"
+}
+`,
+					"./mod/main.tf": `
+resource "test_object" "common" {
+}
+
+resource "test_object" "test" {
+  lifecycle {
+    action_trigger {
+      events  = [after_destroy]
+      actions = [action.test_action.bye[0]]
+    }
+    create_before_destroy = true
+  }
+  depends_on = [test_object.common]
+}
+
+action "test_action" "bye" {
+  count = 1
+}
+`,
+				},
+				expectPlanActionCalled: false,
+
+				buildState: func(s *states.SyncState) {
+					s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.root"), &states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{}`),
+						Status:    states.ObjectTainted,
+					}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+
+					s.SetResourceInstanceCurrent(mustResourceInstanceAddr(`module.mod["orphaned"].test_object.common`), &states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{}`),
+						Status:    states.ObjectReady,
+					}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+
+					s.SetResourceInstanceCurrent(mustResourceInstanceAddr(`module.mod["orphaned"].test_object.test`), &states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{}`),
+						Status:    states.ObjectReady,
+					}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+				},
+
+				assertPlanDiagnostics: func(t *testing.T, diags tfdiags.Diagnostics) {
+					if len(diags) != 2 {
+						t.Fatal("expected 2 diags, got", len(diags))
+					}
+
+					if diags.HasErrors() {
+						t.Fatal("expected no errors, got", diags.Err())
+					}
+
+					warnings := diags.ErrWithWarnings().Error()
+
+					if !strings.Contains(warnings, "Orphaned action failed to plan") {
+						t.Errorf("expected warning about action plan failure, got: %q", warnings)
+					}
+					if !strings.Contains(warnings, "Reference to non-existent action instance") {
+						t.Errorf("expected warning about invalid action ref, got: %q", warnings)
+					}
 				},
 			},
 		},

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -223,6 +223,12 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// done its thing.
 		&checkStartTransformer{Config: b.Config, Operation: b.Operation},
 
+		// Destruction ordering
+		&DestroyEdgeTransformer{
+			Changes:   b.Changes,
+			Operation: b.Operation,
+		},
+
 		// Detect when create_before_destroy must be forced on for a particular
 		// node due to dependency edges, to avoid graph cycles during apply.
 		//
@@ -232,11 +238,6 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// no state value, and we end up recalculating CBD for all nodes.
 		&ForcedCBDTransformer{},
 
-		// Destruction ordering
-		&DestroyEdgeTransformer{
-			Changes:   b.Changes,
-			Operation: b.Operation,
-		},
 		&CBDEdgeTransformer{
 			Config: b.Config,
 			State:  b.State,

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -121,7 +121,7 @@ var (
 	_ GraphNodeTargetable                  = (*NodeAbstractResource)(nil)
 	_ graphNodeAttachDataResourceDependsOn = (*NodeAbstractResource)(nil)
 	_ dag.GraphNodeDotter                  = (*NodeAbstractResource)(nil)
-	_ GraphNodeDestroyerCBD                = (*NodeAbstractResource)(nil)
+	_ GraphNodeCreateBeforeDestroy         = (*NodeAbstractResource)(nil)
 	_ GraphNodeActionProviderConsumer      = (*NodeAbstractResource)(nil)
 	_ GraphNodeActionCaller                = (*NodeAbstractResource)(nil)
 )
@@ -161,9 +161,8 @@ func (n *NodeAbstractResource) CreateBeforeDestroy() bool {
 	return false
 }
 
-func (n *NodeAbstractResource) ModifyCreateBeforeDestroy(v bool) error {
-	n.forceCreateBeforeDestroy = v
-	return nil
+func (n *NodeAbstractResource) ForceCreateBeforeDestroy() {
+	n.forceCreateBeforeDestroy = true
 }
 
 // GraphNodeReferencer

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -3343,7 +3343,7 @@ func (n *NodeAbstractResourceInstance) planActionTrigger(ctx EvalContext, resRep
 // being able to order dependencies without causing cycles. The entire config
 // and condition must be known at plan time, so if we have a planned action we
 // simply decode and call invoke.
-func (n *NodeAbstractResourceInstance) invokeDestroyActions(ctx EvalContext, forEvent configs.ActionTriggerEvent) tfdiags.Diagnostics {
+func (n *NodeAbstractResourceInstance) invokeDestroyActions(ctx EvalContext, forEvent configs.ActionTriggerEvent, op walkOperation) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	for _, trigger := range n.actionApplyTriggers {
@@ -3353,7 +3353,16 @@ func (n *NodeAbstractResourceInstance) invokeDestroyActions(ctx EvalContext, for
 		}
 
 		log.Printf("[DEBUG] NodeAbstractResourceInstance: invoking destroy action %s", trigger.ActionInvocation.Addr)
-		diags = diags.Append(trigger.Invoke(ctx, n.Addr.Resource, cty.DynamicVal, true))
+		invokeDiags := trigger.Invoke(ctx, n.Addr.Resource, cty.DynamicVal, true)
+
+		// a full destroy walk must never be blocked
+		onFailureContinue := op == walkDestroy || n.getApplyActionTriggerBlock(trigger).OnFailure == configs.ActionOnFailureContinue
+
+		if onFailureContinue {
+			invokeDiags = tfdiags.OverrideAll(invokeDiags, tfdiags.Warning, nil)
+		}
+		diags = diags.Append(invokeDiags)
+
 		if diags.HasErrors() {
 			break
 		}

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -3190,21 +3190,11 @@ func (n *NodeAbstractResourceInstance) planActionTriggers(ctx EvalContext, resRe
 		// though because the event is set within a nested interface inside a
 		// pointer to the ActionInvocationInstance.
 		for _, event := range eventsForPlannedAction(trigger.config.Events, change.Action) {
-			if event.IsDestroy() && trigger.config.Condition != nil {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Condition on destroy action",
-					Detail:   "Condition expression may not be used with a destroy action.",
-					Subject:  trigger.config.Condition.Range().Ptr(),
-				})
-				return diags
-			}
-
 			for _, action := range trigger.actionRefs {
 				ai, deferred, planDiags := n.planActionTrigger(ctx, resRepData, action, event, change)
 				diags = diags.Append(planDiags)
 				if diags.HasErrors() {
-					return diags
+					continue
 				}
 
 				if deferred {

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -27,7 +27,7 @@ var (
 	_ GraphNodeConfigResource      = (*NodeDestroyResourceInstance)(nil)
 	_ GraphNodeResourceInstance    = (*NodeDestroyResourceInstance)(nil)
 	_ GraphNodeDestroyer           = (*NodeDestroyResourceInstance)(nil)
-	_ GraphNodeDestroyerCBD        = (*NodeDestroyResourceInstance)(nil)
+	_ GraphNodeCreateBeforeDestroy = (*NodeDestroyResourceInstance)(nil)
 	_ GraphNodeReferenceable       = (*NodeDestroyResourceInstance)(nil)
 	_ GraphNodeReferencer          = (*NodeDestroyResourceInstance)(nil)
 	_ GraphNodeExecutable          = (*NodeDestroyResourceInstance)(nil)
@@ -58,7 +58,12 @@ func (n *NodeDestroyResourceInstance) DestroyAddr() *addrs.AbsResourceInstance {
 
 // GraphNodeDestroyerCBD
 func (n *NodeDestroyResourceInstance) CreateBeforeDestroy() bool {
-	// State takes precedence during destroy.
+	// this may be forced due to teh current graph structure
+	if n.forceCreateBeforeDestroy {
+		return true
+	}
+
+	// otherwise state takes precedence during destroy.
 	// If the resource was removed, there is no config to check.
 	// If CBD was forced from descendant, it should be saved in the state
 	// already.
@@ -76,8 +81,8 @@ func (n *NodeDestroyResourceInstance) CreateBeforeDestroy() bool {
 }
 
 // GraphNodeDestroyerCBD
-func (n *NodeDestroyResourceInstance) ModifyCreateBeforeDestroy(v bool) error {
-	return nil
+func (n *NodeDestroyResourceInstance) ForceCreateBeforeDestroy() {
+	n.forceCreateBeforeDestroy = true
 }
 
 // GraphNodeReferenceable, overriding NodeAbstractResource

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -99,7 +99,7 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 	// Eval info is different depending on what kind of resource this is
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:
-		return n.managedResourceExecute(ctx)
+		return n.managedResourceExecute(ctx, op)
 	case addrs.DataResourceMode:
 		return n.dataResourceExecute(ctx)
 	default:
@@ -107,7 +107,7 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 	}
 }
 
-func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
+func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
 	// Get our state
@@ -163,7 +163,7 @@ func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (d
 	}
 
 	log.Printf("[DEBUG] NodeApplyableResourceInstance: invoking before actions for %s", n.Addr)
-	diags = diags.Append(n.invokeDestroyActions(ctx, configs.BeforeDestroy))
+	diags = diags.Append(n.invokeDestroyActions(ctx, configs.BeforeDestroy, op))
 	if diags.HasErrors() {
 		return diags
 	}
@@ -185,7 +185,7 @@ func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (d
 	n.addPolicyNode(ctx, changeApply, state)
 
 	// after destroy we continue to use the before value, since there is no after
-	diags = diags.Append(n.invokeDestroyActions(ctx, configs.AfterDestroy))
+	diags = diags.Append(n.invokeDestroyActions(ctx, configs.AfterDestroy, op))
 
 	// create the err value for postApplyHook
 	diags = diags.Append(n.postApplyHook(ctx, state, diags.Err()))

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -314,7 +314,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 	}
 
 	log.Printf("[DEBUG] NodeApplyableResourceInstance: invoking before actions for %s", n.Addr)
-	diags = diags.Append(n.invokeDestroyActions(ctx, configs.BeforeDestroy))
+	diags = diags.Append(n.invokeDestroyActions(ctx, configs.BeforeDestroy, op))
 	if diags.HasErrors() {
 		return diags
 	}
@@ -334,7 +334,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 	}
 
 	// after destroy we continue to use the before value, since there is no after
-	diags = diags.Append(n.invokeDestroyActions(ctx, configs.AfterDestroy))
+	diags = diags.Append(n.invokeDestroyActions(ctx, configs.AfterDestroy, op))
 
 	diags = diags.Append(n.postApplyHook(ctx, state, diags.Err()))
 

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -228,7 +228,7 @@ var (
 	_ GraphNodeConfigResource                = (*NodeDestroyDeposedResourceInstanceObject)(nil)
 	_ GraphNodeResourceInstance              = (*NodeDestroyDeposedResourceInstanceObject)(nil)
 	_ GraphNodeDestroyer                     = (*NodeDestroyDeposedResourceInstanceObject)(nil)
-	_ GraphNodeDestroyerCBD                  = (*NodeDestroyDeposedResourceInstanceObject)(nil)
+	_ GraphNodeCreateBeforeDestroy           = (*NodeDestroyDeposedResourceInstanceObject)(nil)
 	_ GraphNodeReferenceable                 = (*NodeDestroyDeposedResourceInstanceObject)(nil)
 	_ GraphNodeReferencer                    = (*NodeDestroyDeposedResourceInstanceObject)(nil)
 	_ GraphNodeExecutable                    = (*NodeDestroyDeposedResourceInstanceObject)(nil)
@@ -265,12 +265,8 @@ func (n *NodeDestroyDeposedResourceInstanceObject) CreateBeforeDestroy() bool {
 }
 
 // GraphNodeDestroyerCBD
-func (n *NodeDestroyDeposedResourceInstanceObject) ModifyCreateBeforeDestroy(v bool) error {
-	if !v {
-		// Should never happen: deposed instances are _always_ create_before_destroy.
-		return fmt.Errorf("can't deactivate create_before_destroy for a deposed instance")
-	}
-	return nil
+func (n *NodeDestroyDeposedResourceInstanceObject) ForceCreateBeforeDestroy() {
+	// noop because deposed instances are always CBD
 }
 
 // GraphNodeExecutable impl.

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -24,10 +24,10 @@ import (
 type nodeExpandPlannableResource struct {
 	*NodeAbstractResource
 
-	// ForceCreateBeforeDestroy might be set via our GraphNodeDestroyerCBD
+	// forceCreateBeforeDestroy might be set via our GraphNodeDestroyerCBD
 	// during graph construction, if dependencies require us to force this
 	// on regardless of what the configuration says.
-	ForceCreateBeforeDestroy *bool
+	forceCreateBeforeDestroy bool
 
 	// skipRefresh indicates that we should skip refreshing individual instances
 	skipRefresh bool
@@ -53,7 +53,7 @@ type nodeExpandPlannableResource struct {
 }
 
 var (
-	_ GraphNodeDestroyerCBD         = (*nodeExpandPlannableResource)(nil)
+	_ GraphNodeCreateBeforeDestroy  = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeDynamicExpandable    = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeReferenceable        = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeReferencer           = (*nodeExpandPlannableResource)(nil)
@@ -75,8 +75,8 @@ func (n *nodeExpandPlannableResource) AttachDependencies(deps []addrs.ConfigReso
 
 // GraphNodeDestroyerCBD
 func (n *nodeExpandPlannableResource) CreateBeforeDestroy() bool {
-	if n.ForceCreateBeforeDestroy != nil {
-		return *n.ForceCreateBeforeDestroy
+	if n.forceCreateBeforeDestroy {
+		return true
 	}
 
 	// If we have no config, we just assume no
@@ -88,9 +88,8 @@ func (n *nodeExpandPlannableResource) CreateBeforeDestroy() bool {
 }
 
 // GraphNodeDestroyerCBD
-func (n *nodeExpandPlannableResource) ModifyCreateBeforeDestroy(v bool) error {
-	n.ForceCreateBeforeDestroy = &v
-	return nil
+func (n *nodeExpandPlannableResource) ForceCreateBeforeDestroy() {
+	n.forceCreateBeforeDestroy = true
 }
 
 func (n *nodeExpandPlannableResource) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -230,7 +230,22 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 	}
 
 	diags = diags.Append(n.writeResourceInstanceState(ctx, nil, workingState))
-	diags = diags.Append(n.planActionTriggers(ctx, EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, nil), change))
+
+	actionDiags := n.planActionTriggers(ctx, EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, nil), change)
+	if actionDiags.HasErrors() {
+		// Orphaned destroy actions may not have enough configuration
+		// information to plan, but we can't block their progress since the
+		// config no longer exists. We'll still keep the original diags as
+		// warnings, but add an additional message to help explain the failure
+		// mode.
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Orphaned action failed to plan",
+			fmt.Sprintf("One or more actions for the orphaned instance %s does not have enough configuration information to complete a plan, and will not be invoked", n.Addr),
+		))
+	}
+	diags = diags.Append(tfdiags.OverrideAll(actionDiags, tfdiags.Warning, nil))
+
 	return diags
 }
 

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -104,6 +104,17 @@ func (n *NodeValidatableResource) validateActions(ctx EvalContext) tfdiags.Diagn
 					}
 				}
 			}
+
+			if event.IsDestroy() {
+				if event.IsDestroy() && trigger.config.Condition != nil {
+					diags = diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Condition on destroy action",
+						Detail:   "Condition expression may not be used with a destroy action.",
+						Subject:  trigger.config.Condition.Range().Ptr(),
+					})
+				}
+			}
 		}
 
 		// check condition for full address self-refs

--- a/internal/terraform/transform_destroy_cbd.go
+++ b/internal/terraform/transform_destroy_cbd.go
@@ -4,7 +4,6 @@
 package terraform
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/internal/configs"
@@ -12,18 +11,18 @@ import (
 	"github.com/hashicorp/terraform/internal/states"
 )
 
-// GraphNodeDestroyerCBD must be implemented by nodes that might be
+// GraphNodeCreateBeforeDestroy must be implemented by nodes that might be
 // create-before-destroy destroyers, or might plan a create-before-destroy
 // action.
-type GraphNodeDestroyerCBD interface {
+type GraphNodeCreateBeforeDestroy interface {
 	// CreateBeforeDestroy returns true if this node represents a node
 	// that is doing a CBD.
 	CreateBeforeDestroy() bool
 
-	// ModifyCreateBeforeDestroy is called when the CBD state of a node
+	// ForceCreateBeforeDestroy is called when the CBD state of a node
 	// is changed dynamically. This can return an error if this isn't
 	// allowed.
-	ModifyCreateBeforeDestroy(bool) error
+	ForceCreateBeforeDestroy()
 }
 
 // ForcedCBDTransformer detects when a particular CBD-able graph node has
@@ -39,7 +38,7 @@ type ForcedCBDTransformer struct {
 
 func (t *ForcedCBDTransformer) Transform(g *Graph) error {
 	for _, v := range g.Vertices() {
-		dn, ok := v.(GraphNodeDestroyerCBD)
+		dn, ok := v.(GraphNodeCreateBeforeDestroy)
 		if !ok {
 			continue
 		}
@@ -56,14 +55,8 @@ func (t *ForcedCBDTransformer) Transform(g *Graph) error {
 			// and we need to auto-upgrade this node to CBD. We do this because
 			// a CBD node depending on non-CBD will result in cycles. To avoid this,
 			// we always attempt to upgrade it.
-			log.Printf("[TRACE] ForcedCBDTransformer: forcing create_before_destroy on for %q (%T)", dag.VertexName(v), v)
-			if err := dn.ModifyCreateBeforeDestroy(true); err != nil {
-				return fmt.Errorf(
-					"%s: must have create before destroy enabled because "+
-						"a dependent resource has CBD enabled. However, when "+
-						"attempting to automatically do this, an error occurred: %s",
-					dag.VertexName(v), err)
-			}
+			log.Printf("[TRACE] ForcedCBDTransformer: forcing create_before_destroy for %q (%T)", dag.VertexName(v), v)
+			dn.ForceCreateBeforeDestroy()
 		} else {
 			log.Printf("[TRACE] ForcedCBDTransformer: %q (%T) already has create_before_destroy set", dag.VertexName(v), v)
 		}
@@ -74,15 +67,33 @@ func (t *ForcedCBDTransformer) Transform(g *Graph) error {
 // hasCBDDescendant returns true if any descendant (node that depends on this)
 // has CBD set.
 func (t *ForcedCBDTransformer) hasCBDDescendant(g *Graph, v dag.Vertex) bool {
-	return g.MatchDescendant(v, func(ov dag.Vertex) bool {
-		dn, ok := ov.(GraphNodeDestroyerCBD)
+	// in the normal case, we have a descendent config node somewhere that reports CBD
+	if g.MatchDescendant(v, func(ov dag.Vertex) bool {
+		dn, ok := ov.(GraphNodeCreateBeforeDestroy)
 		if ok && dn.CreateBeforeDestroy() {
 			// some descendant is CreateBeforeDestroy, so we need to follow suit
 			log.Printf("[TRACE] ForcedCBDTransformer: %q has CBD descendant %q", dag.VertexName(v), dag.VertexName(ov))
 			return true
 		}
 		return false
-	})
+	}) {
+		return true
+	}
+
+	// It's also possible that there are some orphaned CBD nodes from dependents
+	// that no longer exist. These will be directly connected destroy nodes.
+	for _, dep := range g.DownEdges(v) {
+		if _, destroyer := dep.(GraphNodeDestroyer); !destroyer {
+			continue
+		}
+
+		dn, ok := dep.(GraphNodeCreateBeforeDestroy)
+		if ok && dn.CreateBeforeDestroy() {
+			log.Printf("[TRACE] ForcedCBDTransformer: %q depends on CBD destroy node %q", dag.VertexName(v), dag.VertexName(dep))
+			return true
+		}
+	}
+	return false
 }
 
 // CBDEdgeTransformer modifies the edges of create-before-destroy ("CBD") nodes
@@ -120,7 +131,7 @@ type CBDEdgeTransformer struct {
 func (t *CBDEdgeTransformer) Transform(g *Graph) error {
 	// Go through and reverse any destroy edges
 	for _, v := range g.Vertices() {
-		dn, ok := v.(GraphNodeDestroyerCBD)
+		dn, ok := v.(GraphNodeCreateBeforeDestroy)
 		if !ok {
 			continue
 		}

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -125,17 +125,17 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 	// Build a map of what is being destroyed (by address string) to
 	// the list of destroyers.
-	destroyers := make(map[string][]GraphNodeDestroyer)
+	destroyers := addrs.MakeMap[addrs.AbsResourceInstance, []GraphNodeDestroyer]()
 
 	// Record the creators, which will need to depend on the destroyers if they
 	// are only being updated.
-	creators := make(map[string][]GraphNodeCreator)
+	creators := addrs.MakeMap[addrs.ConfigResource, []GraphNodeCreator]()
 
 	// destroyersByResource records each destroyer by the ConfigResource
 	// address.  We use this because dependencies are only referenced as
 	// resources and have no index or module instance information, but we will
 	// want to connect all the individual instances for correct ordering.
-	destroyersByResource := make(map[string][]GraphNodeDestroyer)
+	destroyersByResource := addrs.MakeMap[addrs.ConfigResource, []GraphNodeDestroyer]()
 	for _, v := range g.Vertices() {
 		switch n := v.(type) {
 		case GraphNodeDestroyer:
@@ -148,62 +148,57 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 
 			key := addr.String()
 			log.Printf("[TRACE] DestroyEdgeTransformer: %q (%T) destroys %s", dag.VertexName(n), v, key)
-			destroyers[key] = append(destroyers[key], n)
+			destroyers.Put(addr, append(destroyers.Get(addr), n))
 
-			resAddr := addr.ContainingResource().Config().String()
-			destroyersByResource[resAddr] = append(destroyersByResource[resAddr], n)
+			resAddr := addr.ContainingResource().Config()
+			destroyersByResource.Put(resAddr, append(destroyersByResource.Get(resAddr), n))
 		case GraphNodeCreator:
 			addr := n.CreateAddr()
-			cfgAddr := addr.ContainingResource().Config().String()
+			cfgAddr := addr.ContainingResource().Config()
 
 			if t.Changes == nil {
 				// unit tests may not have changes
-				creators[cfgAddr] = append(creators[cfgAddr], n)
+				creators.Put(cfgAddr, append(creators.Get(cfgAddr), n))
 				break
 			}
 
 			// NoOp changes should not participate in the destroy dependencies.
 			rc := t.Changes.ResourceInstance(*addr)
 			if rc != nil && rc.Action != plans.NoOp {
-				creators[cfgAddr] = append(creators[cfgAddr], n)
+				creators.Put(cfgAddr, append(creators.Get(cfgAddr), n))
 			}
 		}
 	}
 
 	// If we aren't destroying anything, there will be no edges to make
 	// so just exit early and avoid future work.
-	if len(destroyers) == 0 {
+	if destroyers.Len() == 0 {
 		return nil
 	}
 
-	// Go through and connect creators to destroyers. Going along with
-	// our example, this makes: A_d => A
+	// Go through and connect creators to destroyers.
 	for _, v := range g.Vertices() {
-		cn, ok := v.(GraphNodeCreator)
+		creator, ok := v.(GraphNodeCreator)
 		if !ok {
 			continue
 		}
 
-		addr := cn.CreateAddr()
+		addr := creator.CreateAddr()
 		if addr == nil {
 			continue
 		}
 
-		for _, d := range destroyers[addr.String()] {
-			// For illustrating our example
-			a_d := d.(dag.Vertex)
-			a := v
-
+		for _, destroyer := range destroyers.Get(*addr) {
 			log.Printf(
 				"[TRACE] DestroyEdgeTransformer: connecting creator %q with destroyer %q",
-				dag.VertexName(a), dag.VertexName(a_d))
+				dag.VertexName(creator), dag.VertexName(destroyer))
 
-			g.Connect(dag.BasicEdge(a, a_d))
+			g.Connect(dag.BasicEdge(creator, destroyer))
 		}
 	}
 
 	// connect creators to any destroyers on which they may depend
-	for _, cs := range creators {
+	for _, cs := range creators.Iter() {
 		for _, c := range cs {
 			ri, ok := c.(GraphNodeResourceInstance)
 			if !ok {
@@ -211,7 +206,7 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 			}
 
 			for _, resAddr := range ri.StateDependencies() {
-				for _, desDep := range destroyersByResource[resAddr.String()] {
+				for _, desDep := range destroyersByResource.Get(resAddr) {
 					if !graphNodesAreResourceInstancesInDifferentInstancesOfSameModule(c, desDep) {
 						log.Printf("[TRACE] DestroyEdgeTransformer: %s has stored dependency of %s\n", dag.VertexName(c), dag.VertexName(desDep))
 						g.Connect(dag.BasicEdge(c, desDep))
@@ -224,7 +219,7 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 	}
 
 	// Connect destroy dependencies as stored in the state
-	for _, ds := range destroyers {
+	for _, ds := range destroyers.Iter() {
 		for _, des := range ds {
 			ri, ok := des.(GraphNodeResourceInstance)
 			if !ok {
@@ -232,7 +227,7 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 			}
 
 			for _, resAddr := range ri.StateDependencies() {
-				for _, desDep := range destroyersByResource[resAddr.String()] {
+				for _, desDep := range destroyersByResource.Get(resAddr) {
 					if !graphNodesAreResourceInstancesInDifferentInstancesOfSameModule(desDep, des) {
 						log.Printf("[TRACE] DestroyEdgeTransformer: %s has stored dependency of %s\n", dag.VertexName(desDep), dag.VertexName(des))
 						t.tryInterProviderDestroyEdge(g, desDep, des)
@@ -244,12 +239,12 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 				// We can have some create or update nodes which were
 				// dependents of the destroy node. If they have no destroyer
 				// themselves, make the connection directly from the creator.
-				for _, createDep := range creators[resAddr.String()] {
+				for _, createDep := range creators.Get(resAddr) {
 					if !graphNodesAreResourceInstancesInDifferentInstancesOfSameModule(createDep, des) {
-						log.Printf("[DEBUG] DestroyEdgeTransformer2: %s has stored dependency of %s\n", dag.VertexName(createDep), dag.VertexName(des))
+						log.Printf("[DEBUG] DestroyEdgeTransformer: %s has stored dependency of %s\n", dag.VertexName(createDep), dag.VertexName(des))
 						t.tryInterProviderDestroyEdge(g, createDep, des)
 					} else {
-						log.Printf("[TRACE] DestroyEdgeTransformer2: skipping %s => %s inter-module-instance dependency\n", dag.VertexName(createDep), dag.VertexName(des))
+						log.Printf("[TRACE] DestroyEdgeTransformer: skipping %s => %s inter-module-instance dependency\n", dag.VertexName(createDep), dag.VertexName(des))
 					}
 				}
 			}


### PR DESCRIPTION
The example created for the orphaned action instance test triggered an obscure bug in the create-before-destroy codepath, so we start out with a fix for that. The forced create-before-destroy transformer checks nodes for CBD descendants, but it was missing the case where an orphaned instance exists and must still force the correct order for an ancestor's replacement.

There were three contributing factors to the missed check.
- The destroy edges were not inserted before the CBD checks, so there was no path to the dependent destroyer.
- The destroy dependencies are not descendants, so we need a separate check for directly connected CBD destroyers.
- The resource instance nodes didn't take into account forced CBD anyway.

Some refactoring/renaming went into the fix as well. The ModifyCreateBeforeDestroy method is only a method for forcing CBD on (you can't ever reverse it), so we can get rid of the boolean arg and the useless error to make it more clear how it's intended to work. We can also use typed maps for the destroy edge transformer to avoid common mistakes made by looking up addresses via strings.

Once the tests could run, we can handle orphaned instance action planning errors as warnings.
For a normal destroy instance, if the operation is not a full destroy the action should still be able to halt progress, unless configured as `continue`.