### PR TITLE
Allow targeting of action caller instances with -invoke

### DIFF
--- a/.changes/v1.16/ENHANCEMENTS-20260708-095111.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260708-095111.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: If `-invoke` results in multiple resource calls triggering the action, it can
+  now be combined with `-target` to specify the calling resource instance
+time: 2026-07-08T09:51:11.784345-04:00
+custom:
+  Issue: "38845"

--- a/internal/addrs/set.go
+++ b/internal/addrs/set.go
@@ -4,6 +4,7 @@
 package addrs
 
 import (
+	"iter"
 	"sort"
 )
 
@@ -60,6 +61,16 @@ func (s Set[T]) Union(other Set[T]) Set[T] {
 		ret[k] = addr
 	}
 	return ret
+}
+
+func (s Set[T]) Iter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for _, elem := range s {
+			if !yield(elem) {
+				return
+			}
+		}
+	}
 }
 
 // Intersection returns a new set which contains the intersection of all of the

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -162,15 +162,7 @@ func (o *Operation) Parse() tfdiags.Diagnostics {
 		o.ActionTargets = append(o.ActionTargets, target.Subject)
 	}
 
-	if len(o.ActionTargets) > 0 && len(o.Targets) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid arguments",
-			"The -invoke and -target arguments must not both be specified."))
-	}
-
 	if len(o.ActionTargets) > 1 {
-		// TEMP: Disallow targeting multiple actions for now.
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Invalid arguments",

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -244,7 +244,7 @@ func (c *Context) ApplyAndEval(plan *plans.Plan, config *configs.Config, opts *A
 		newState.PruneResourceHusks()
 	}
 
-	if len(plan.TargetAddrs) > 0 {
+	if len(plan.TargetAddrs) > 0 && len(plan.ActionTargetAddrs) == 0 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Warning,
 			"Applied changes may be incomplete",

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -282,17 +282,6 @@ func (c *Context) PlanAndEval(config *configs.Config, prevRunState *states.State
 	}
 
 	if len(opts.ActionTargets) > 0 {
-		if len(opts.Targets) != 0 {
-			// The CLI layer (and other similar callers) should prevent this
-			// combination of options.
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Incompatible plan options",
-				"Cannot include both targets and action invocations. This is a bug in Terraform.",
-			))
-			return nil, nil, diags
-		}
-
 		if opts.Mode != plans.RefreshOnlyMode {
 			// The CLI layer (and other similar callers) should prevent this
 			// combination of options.
@@ -315,7 +304,7 @@ func (c *Context) PlanAndEval(config *configs.Config, prevRunState *states.State
 	varDiags := checkInputVariables(config.Module.Variables, opts.SetVariables)
 	diags = diags.Append(varDiags)
 
-	if len(opts.Targets) > 0 {
+	if len(opts.Targets) > 0 && len(opts.ActionTargets) == 0 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Warning,
 			"Resource targeting is in effect",
@@ -1053,7 +1042,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			RootVariableValues:        opts.SetVariables,
 			ExternalProviderConfigs:   externalProviderConfigs,
 			Plugins:                   c.plugins,
-			Targets:                   append(opts.Targets, opts.ActionTargets...),
+			Targets:                   opts.Targets,
 			ActionTargets:             opts.ActionTargets,
 			skipRefresh:               opts.SkipRefresh,
 			skipPlanChanges:           true, // this activates "refresh only" mode.

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -3297,7 +3297,7 @@ action "test_action" "one" {
 				},
 				assertPlan: func(t *testing.T, plan *plans.Plan) {
 					if len(plan.Changes.ActionInvocations) != 2 {
-						t.Fatalf("expected exactly one invocation, and found %d", len(plan.Changes.ActionInvocations))
+						t.Fatalf("expected exactly 2 invocations, and found %d", len(plan.Changes.ActionInvocations))
 					}
 
 					ais := plan.Changes.ActionInvocations[0]
@@ -3319,6 +3319,57 @@ action "test_action" "one" {
 
 					if !ai.Addr.Equal(mustActionInstanceAddr("action.test_action.one")) {
 						t.Fatalf("wrong address in plan: %s", ai.Addr)
+					}
+				},
+			},
+
+			"invoke action with targeted caller": {
+				module: map[string]string{
+					"main.tf": `
+resource "test_object" "a" {
+  count = 2
+  name = "hello"
+  lifecycle {
+    action_trigger {
+      events = [before_update]
+	  actions = [action.test_action.one]
+	}
+  }
+}
+
+action "test_action" "one" {
+  config {
+    attr = caller.name
+  }
+}
+`,
+				},
+				planOpts: &PlanOpts{
+					Mode: plans.RefreshOnlyMode,
+					ActionTargets: []addrs.Targetable{
+						addrs.AbsAction{
+							Action: addrs.Action{
+								Type: "test_action",
+								Name: "one",
+							},
+						},
+					},
+					Targets: []addrs.Targetable{mustResourceInstanceAddr("test_object.a[0]")},
+				},
+				expectPlanActionCalled: true,
+				buildState: func(state *states.SyncState) {
+					state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a[0]"), &states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"name":"hello"}`),
+						Status:    states.ObjectReady,
+					}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+					state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a[1]"), &states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"name":"hello"}`),
+						Status:    states.ObjectReady,
+					}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+				},
+				assertPlan: func(t *testing.T, plan *plans.Plan) {
+					if len(plan.Changes.ActionInvocations) != 1 {
+						t.Fatalf("expected exactly one invocation, and found %d", len(plan.Changes.ActionInvocations))
 					}
 				},
 			},

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -2966,6 +2966,86 @@ module "mod" {
 				},
 			},
 
+			"invalid action invoke in expanded module": {
+				module: map[string]string{
+					"mod/main.tf": `
+action "test_action" "two" {
+  count = 1
+  config {
+    attr = "two"
+  }
+}
+`,
+					"main.tf": `
+module "mod" {
+  count = 2
+  source = "./mod"
+}
+`,
+				},
+				planOpts: &PlanOpts{
+					Mode: plans.RefreshOnlyMode,
+					ActionTargets: []addrs.Targetable{
+						addrs.AbsActionInstance{
+							Module: addrs.RootModuleInstance.Child("mod", addrs.IntKey(1)),
+							Action: addrs.ActionInstance{
+								Action: addrs.Action{
+									Type: "test_action",
+									Name: "one",
+								},
+								Key: addrs.IntKey(1),
+							},
+						},
+					},
+				},
+				expectPlanActionCalled: false,
+				assertPlanDiagnostics: func(t *testing.T, diags tfdiags.Diagnostics) {
+					if !strings.Contains(diags.Err().Error(), "invoke target module.mod[1].action.test_action.one[1] not found") {
+						t.Fatalf("expected 'invoke target module.mod[1].action.test_action.one[1] not found', got: '%s'", diags.Err())
+					}
+				},
+			},
+
+			"invalid action module invoke": {
+				module: map[string]string{
+					"mod/main.tf": `
+action "test_action" "two" {
+  count = 1
+  config {
+    attr = "two"
+  }
+}
+`,
+					"main.tf": `
+module "mod" {
+  count = 2
+  source = "./mod"
+}
+`,
+				},
+				planOpts: &PlanOpts{
+					Mode: plans.RefreshOnlyMode,
+					ActionTargets: []addrs.Targetable{
+						addrs.AbsActionInstance{
+							Module: addrs.RootModuleInstance.Child("mod", addrs.IntKey(3)),
+							Action: addrs.ActionInstance{
+								Action: addrs.Action{
+									Type: "test_action",
+									Name: "one",
+								},
+								Key: addrs.IntKey(0),
+							},
+						},
+					},
+				},
+				expectPlanActionCalled: false,
+				assertPlanDiagnostics: func(t *testing.T, diags tfdiags.Diagnostics) {
+					if !strings.Contains(diags.Err().Error(), "invoke target module.mod[3].action.test_action.one[0] not found") {
+						t.Fatalf("expected 'invoke target module.mod[3].action.test_action.one[0] not found', got: '%s'", diags.Err())
+					}
+				},
+			},
+
 			"action invoke with count (all)": {
 				module: map[string]string{
 					"main.tf": `

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -251,7 +251,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		},
 
 		// Target
-		&TargetsTransformer{Targets: b.Targets, ActionTargets: b.ActionTargets},
+		&TargetsTransformer{Targets: slices.Concat(b.Targets, b.ActionTargets)},
 
 		// Close any ephemeral resource instances.
 		&ephemeralResourceCloseTransformer{},

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -5,6 +5,7 @@ package terraform
 
 import (
 	"log"
+	"slices"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -290,7 +291,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		},
 
 		// Target
-		&TargetsTransformer{Targets: b.Targets},
+		&TargetsTransformer{Targets: slices.Concat(b.Targets, b.ActionTargets)},
 
 		// Filter the graph to only include nodes that are relevant to the query operation.
 		&QueryTransformer{queryPlan: b.queryPlan, validate: b.Operation == walkValidate},

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -256,10 +256,11 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// AttachSchemaTransformer so we can get all references from the action
 		// configs.
 		&ActionInvokePlanTransformer{
-			Config:        b.Config,
-			Operation:     b.Operation,
-			ActionTargets: b.ActionTargets,
-			queryPlanMode: b.queryPlan,
+			Config:          b.Config,
+			Operation:       b.Operation,
+			ActionTargets:   b.ActionTargets,
+			ResourceTargets: b.Targets,
+			queryPlanMode:   b.queryPlan,
 		},
 
 		// Create expansion nodes for all of the module calls. This must

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -6,6 +6,7 @@ package terraform
 import (
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -302,19 +303,27 @@ func (n *NodeActionConfig) SetProvider(p addrs.AbsProviderConfig) {
 // keys anyway.
 func (n *NodeActionConfig) EvalInvokedInstances(ctx EvalContext, addr addrs.ActionInstance, caller addrs.Referenceable) (addrs.Map[addrs.ActionInstance, cty.Value], tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	all := addrs.MakeMap[addrs.ActionInstance, cty.Value]()
-
-	var instances []addrs.AbsActionInstance
 
 	expander := ctx.InstanceExpander()
+	absAddr := addr.Absolute(ctx.Path())
+
+	all := addrs.MakeMap[addrs.ActionInstance, cty.Value]()
+	allInstances := addrs.MakeSet[addrs.AbsActionInstance](expander.ExpandAction(absAddr.ContainingAction())...)
+
+	var instances []addrs.AbsActionInstance
 	if addr.Key == addrs.NoKey {
 		// this might be a single instance with no key, or all instances, so we
-		// must expand for both cases
-		instances = expander.ExpandAction(n.Addr.Absolute(ctx.Path()))
+		// just use everything
+		instances = slices.Collect(allInstances.Iter())
 	} else {
 		// definitely looking for a single instance because we have an index of
-		// some sort
-		instances = []addrs.AbsActionInstance{addr.Absolute(ctx.Path())}
+		// some sort, but check if it exists first, otherwise evaluation will
+		// panic
+		if !allInstances.Has(absAddr) {
+			diags = diags.Append(fmt.Errorf("invoked target %s not found", absAddr))
+			return all, diags
+		}
+		instances = []addrs.AbsActionInstance{absAddr}
 	}
 
 	for _, instAddr := range instances {

--- a/internal/terraform/node_action_invoke.go
+++ b/internal/terraform/node_action_invoke.go
@@ -85,6 +85,7 @@ func (n *nodeActionInvokeExpand) References() []*addrs.Reference {
 
 func (n *nodeActionInvokeExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {
 	var g Graph
+	var diags tfdiags.Diagnostics
 
 	expander := ctx.InstanceExpander()
 
@@ -94,6 +95,8 @@ func (n *nodeActionInvokeExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags
 	syncState := ctx.State()
 	state := syncState.Lock()
 	defer syncState.Unlock()
+
+	found := false
 
 	for _, mod := range expander.ExpandModule(n.Module, false) {
 		if !mod.TargetContains(n.Target) {
@@ -107,6 +110,7 @@ func (n *nodeActionInvokeExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags
 				ActionConfig: n.ActionConfig,
 				ProviderAddr: n.ActionConfig.ResolvedProvider,
 			})
+			found = true
 		} else {
 			for _, caller := range n.Callers {
 				for _, res := range state.Resources(caller) {
@@ -128,6 +132,7 @@ func (n *nodeActionInvokeExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags
 							ProviderAddr: n.ActionConfig.ResolvedProvider,
 							Caller:       res.Addr.Resource.Instance(instKey),
 						})
+						found = true
 					}
 				}
 			}
@@ -135,7 +140,11 @@ func (n *nodeActionInvokeExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags
 	}
 	addRootNodeToGraph(&g)
 
-	return &g, nil
+	if !found {
+		diags = diags.Append(fmt.Errorf("invoke target %s not found", n.Target))
+	}
+
+	return &g, diags
 }
 
 var (

--- a/internal/terraform/node_action_invoke.go
+++ b/internal/terraform/node_action_invoke.go
@@ -29,6 +29,9 @@ type nodeActionInvokeExpand struct {
 	// target here to ensure we only expand the targeted instances
 	Target addrs.Targetable
 
+	// There may be specific caller instances targeted for this action
+	ResourceTargets []addrs.Targetable
+
 	Module addrs.Module
 
 	// as we have used in other targeting situations, because a single instance
@@ -54,11 +57,7 @@ func (n *nodeActionInvokeExpand) ModulePath() addrs.Module {
 }
 
 func (n *nodeActionInvokeExpand) Name() string {
-	module := n.ModulePath().String()
-	if len(module) > 0 {
-		module = module + "."
-	}
-	return fmt.Sprintf("%sinvoke.%s", module, n.Addr)
+	return n.Addr.String()
 }
 
 func (n *nodeActionInvokeExpand) References() []*addrs.Reference {
@@ -126,11 +125,12 @@ func (n *nodeActionInvokeExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags
 
 						log.Printf("[TRACE] expanding %s invoke node for caller %s", n.Addr, res.Addr.Resource)
 						g.Add(&nodeActionPlanInvoke{
-							Module:       mod,
-							Addr:         n.Addr,
-							ActionConfig: n.ActionConfig,
-							ProviderAddr: n.ActionConfig.ResolvedProvider,
-							Caller:       res.Addr.Resource.Instance(instKey),
+							Module:          mod,
+							Addr:            n.Addr,
+							ActionConfig:    n.ActionConfig,
+							ProviderAddr:    n.ActionConfig.ResolvedProvider,
+							Caller:          res.Addr.Resource.Instance(instKey),
+							ResourceTargets: n.ResourceTargets,
 						})
 						found = true
 					}
@@ -153,11 +153,12 @@ var (
 )
 
 type nodeActionPlanInvoke struct {
-	Module       addrs.ModuleInstance
-	Addr         addrs.AbsActionInstance
-	ActionConfig *NodeActionConfig
-	ProviderAddr addrs.AbsProviderConfig
-	Caller       addrs.Referenceable
+	Module          addrs.ModuleInstance
+	Addr            addrs.AbsActionInstance
+	ActionConfig    *NodeActionConfig
+	ProviderAddr    addrs.AbsProviderConfig
+	Caller          addrs.Referenceable
+	ResourceTargets []addrs.Targetable
 }
 
 func (n *nodeActionPlanInvoke) Name() string {
@@ -169,6 +170,7 @@ func (n *nodeActionPlanInvoke) Path() addrs.ModuleInstance {
 }
 
 func (n *nodeActionPlanInvoke) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
+
 	// for now each action instance will be invoked serially
 	return n.planActions(ctx)
 }
@@ -199,6 +201,19 @@ func (n *nodeActionPlanInvoke) planAction(ctx EvalContext, config *configs.Actio
 	if n.Caller != nil {
 		absCaller := n.Caller.(addrs.ResourceInstance).Absolute(ctx.Path())
 		triggerAddr = &absCaller
+
+		// if we have resource targets, filter any unwanted callers
+		targeted := len(n.ResourceTargets) == 0
+		for _, resTgt := range n.ResourceTargets {
+			if resTgt.TargetContains(absCaller) {
+				targeted = true
+				break
+			}
+		}
+		if !targeted {
+			log.Printf("[DEBUG] nodeActionPlanInvoke: instance %s not targeted", absCaller)
+			return diags
+		}
 	}
 
 	ai := plans.ActionInvocationInstance{

--- a/internal/terraform/node_action_invoke.go
+++ b/internal/terraform/node_action_invoke.go
@@ -95,7 +95,9 @@ func (n *nodeActionInvokeExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags
 	state := syncState.Lock()
 	defer syncState.Unlock()
 
-	found := false
+	// if there are callers, we assume the action already exists, otherwise
+	// there would be nothing to have set the callers
+	actionFound := len(n.Callers) != 0
 
 	for _, mod := range expander.ExpandModule(n.Module, false) {
 		if !mod.TargetContains(n.Target) {
@@ -109,9 +111,10 @@ func (n *nodeActionInvokeExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags
 				ActionConfig: n.ActionConfig,
 				ProviderAddr: n.ActionConfig.ResolvedProvider,
 			})
-			found = true
+			actionFound = true
 		} else {
 			for _, caller := range n.Callers {
+				callerFound := false
 				for _, res := range state.Resources(caller) {
 					if !mod.TargetContains(res.Addr) {
 						// resource from the wrong module instance
@@ -132,15 +135,29 @@ func (n *nodeActionInvokeExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags
 							Caller:          res.Addr.Resource.Instance(instKey),
 							ResourceTargets: n.ResourceTargets,
 						})
-						found = true
+
+						// all we need is at least one valid caller to invoke
+						// this action
+						callerFound = true
 					}
+				}
+
+				if !callerFound {
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						"Partially applied configuration",
+						fmt.Sprintf("Caller %s not found for action %s. "+
+							"The resource instance calling the action has not yet been created. "+
+							"Please run a complete plan/apply cycle to ensure the state matches the configuration before using the -invoke argument.",
+							caller, n.Target),
+					))
 				}
 			}
 		}
 	}
 	addRootNodeToGraph(&g)
 
-	if !found {
+	if !actionFound {
 		diags = diags.Append(fmt.Errorf("invoke target %s not found", n.Target))
 	}
 

--- a/internal/terraform/transform_action_invoke_plan.go
+++ b/internal/terraform/transform_action_invoke_plan.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 type ActionInvokePlanTransformer struct {
@@ -22,6 +23,10 @@ func (t *ActionInvokePlanTransformer) Transform(g *Graph) error {
 	if t.Operation != walkPlan || t.queryPlanMode || len(t.ActionTargets) == 0 {
 		return nil
 	}
+
+	// we need to track the targets we've made use of so we can report back to
+	// the user when some target is not found.
+	targetSet := addrs.MakeSet[addrs.Targetable](t.ActionTargets...)
 
 	// We could be invoking an action which is triggered from a resource,
 	// requiring us to resolve `caller`. In that case the calling resource
@@ -97,8 +102,14 @@ func (t *ActionInvokePlanTransformer) Transform(g *Graph) error {
 				ActionConfig: actionNode,
 				Callers:      resourceCallers,
 			})
+			targetSet.Remove(target)
 		}
 	}
 
-	return nil
+	var diags tfdiags.Diagnostics
+	for target := range targetSet.Iter() {
+		diags = diags.Append(fmt.Errorf("invoke target %s not found", target))
+	}
+
+	return diags.ErrWithWarnings()
 }

--- a/internal/terraform/transform_action_invoke_plan.go
+++ b/internal/terraform/transform_action_invoke_plan.go
@@ -12,9 +12,10 @@ import (
 )
 
 type ActionInvokePlanTransformer struct {
-	Config        *configs.Config
-	ActionTargets []addrs.Targetable
-	Operation     walkOperation
+	Config          *configs.Config
+	ActionTargets   []addrs.Targetable
+	ResourceTargets []addrs.Targetable
+	Operation       walkOperation
 
 	queryPlanMode bool
 }
@@ -96,11 +97,12 @@ func (t *ActionInvokePlanTransformer) Transform(g *Graph) error {
 			}
 
 			g.Add(&nodeActionInvokeExpand{
-				Target:       target,
-				Module:       actionNode.Addr.Module,
-				Addr:         instAddr,
-				ActionConfig: actionNode,
-				Callers:      resourceCallers,
+				Target:          target,
+				ResourceTargets: t.ResourceTargets,
+				Module:          actionNode.Addr.Module,
+				Addr:            instAddr,
+				ActionConfig:    actionNode,
+				Callers:         resourceCallers,
 			})
 			targetSet.Remove(target)
 		}

--- a/internal/terraform/transform_targets.go
+++ b/internal/terraform/transform_targets.go
@@ -25,23 +25,16 @@ type GraphNodeTargetable interface {
 type TargetsTransformer struct {
 	// List of targeted resource names specified by the user.
 	Targets []addrs.Targetable
-
-	// List of targeted actions specified by the user.
-	ActionTargets []addrs.Targetable
 }
 
 func (t *TargetsTransformer) Transform(g *Graph) error {
-	if len(t.Targets) == 0 && len(t.ActionTargets) == 0 {
+	if len(t.Targets) == 0 {
 		return nil
 	}
 
-	// in practice, these are mutually exclusive so only one of these function
-	// calls will do any work
-
 	targetedNodes := t.selectTargetedNodes(g, t.Targets)
-	targetedActions := t.selectTargetedNodes(g, t.ActionTargets)
 	for _, v := range g.Vertices() {
-		if !targetedNodes.Include(v) && !targetedActions.Include(v) {
+		if !targetedNodes.Include(v) {
 			log.Printf("[DEBUG] Removing %q, filtered by targeting.", dag.VertexName(v))
 			g.Remove(v)
 		}


### PR DESCRIPTION
An action may be called via multiple resource instances, so allow the use of `-target` to more narrowly specify which actions are triggered via `-invoke`.

Additionally, we now validate all `-invoke` targets, returning an error if no actions are triggered by the `-invoke` plan.