### PR TITLE
chore: Remove change files that have since been backported to the v1.15 release branch to be part of v1.15.8

### DIFF
--- a/.changes/v1.16/NOTES-20260602-161506.yaml
+++ b/.changes/v1.16/NOTES-20260602-161506.yaml
@@ -1,5 +1,0 @@
-kind: NOTES
-body: 'command/init: Provider installation was changed to enable future enhancements in the area. This effectively reverses the log message changes from v1.15. `initializing_provider_plugin_message` is being re-introduced to replace the short-lived two message types `initializing_provider_plugin_from_config_message` & `initializing_provider_plugin_from_state_message`. The change should not have any significant end-user impact aside from the command output.'
-time: 2026-06-02T16:15:06.066251+01:00
-custom:
-    Issue: "38648"

--- a/.changes/v1.16/NOTES-20260609-133222.yaml
+++ b/.changes/v1.16/NOTES-20260609-133222.yaml
@@ -1,5 +1,0 @@
-kind: NOTES
-body: 'command/init: Provider installation was changed to enable future enhancements in the area. This partially reverses the init event order changes from v1.15; module installation will now occur after the backend is initialized. The change should not have any significant end-user impact aside from the command output.'
-time: 2026-06-09T13:32:22.033462+01:00
-custom:
-    Issue: "38699"


### PR DESCRIPTION
Acting on this https://github.com/hashicorp/terraform/pull/38838/changes#r3538125001 , from a backport that made these changes present in the v1.15.8 patch release. As these changes will be present in a prior version before we release v1.16 beta they shouldn't be in the v1.16 change logs.


Follows https://github.com/hashicorp/terraform/pull/38838 and https://github.com/hashicorp/terraform/pull/38830

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
