### PR TITLE
stacks: Introduce policy evaluation to `BuildProviderPluginCache` to prevent provider downloads

### DIFF
--- a/internal/rpcapi/convert.go
+++ b/internal/rpcapi/convert.go
@@ -12,10 +12,12 @@ import (
 	msgpack "github.com/zclconf/go-cty/cty/msgpack"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/rpcapi/terraform1"
+	"github.com/hashicorp/terraform/internal/rpcapi/terraform1/dependencies"
 	"github.com/hashicorp/terraform/internal/rpcapi/terraform1/stacks"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackruntime"
@@ -161,9 +163,9 @@ func externalInputValueFromProto(protoVal *stacks.DynamicValueWithSource) (stack
 }
 
 func componentInstancePolicyEvaluationProto(componentInstanceAddr stackaddrs.AbsComponentInstance, policyResults map[string]policy.EvaluationResponse) *stacks.ComponentInstancePolicyEvaluation {
-	results := make([]*stacks.PolicyResult, 0)
-	infos := make([]*stacks.PolicyInfo, 0)
-	policyDiags := make([]*stacks.PolicyDiagnostic, 0)
+	results := make([]*terraform1.PolicyResult, 0)
+	infos := make([]*terraform1.PolicyInfo, 0)
+	policyDiags := make([]*terraform1.PolicyDiagnostic, 0)
 
 	for addr, result := range policyResults {
 		results = append(results, policyResultsToProto(addr, result.Policies)...)
@@ -199,30 +201,48 @@ func providerInstancePolicyEvaluationProto(result *hooks.ProviderInstancePolicyR
 	}
 }
 
-func policyEvaluateResultToProto(result policy.EvaluateResult) stacks.EvaluateResult {
+func providerInstallPolicyEvaluationProto(provider addrs.Provider, result policy.EvaluationResponse) *dependencies.ProviderInstallPolicyEvaluation {
+	// The RPC which produces this policy evaluation event does not have access to the source bundle / configuration
+	// so we use a root module as a default.
+	addr := addrs.AbsProviderConfig{Provider: provider, Module: addrs.RootModule}
+	providerAddr := addr.String()
+
+	results := policyResultsToProto(providerAddr, result.Policies)
+	infos := policyInfosToProto(providerAddr, result.Enforcements)
+	policyDiags := policyDiagsToProto(providerAddr, result.Diagnostics)
+
+	return &dependencies.ProviderInstallPolicyEvaluation{
+		Addr:        addr.String(),
+		Results:     results,
+		Infos:       infos,
+		Diagnostics: policyDiags,
+	}
+}
+
+func policyEvaluateResultToProto(result policy.EvaluateResult) terraform1.EvaluateResult {
 	switch result {
 	case policy.InvalidResult:
-		return stacks.EvaluateResult_INVALID_EVALUATE_RESULT
+		return terraform1.EvaluateResult_INVALID_EVALUATE_RESULT
 	case policy.UnknownResult:
-		return stacks.EvaluateResult_UNKNOWN_EVALUATE_RESULT
+		return terraform1.EvaluateResult_UNKNOWN_EVALUATE_RESULT
 	case policy.PolicyErrorResult:
-		return stacks.EvaluateResult_ERROR_EVALUATE_RESULT
+		return terraform1.EvaluateResult_ERROR_EVALUATE_RESULT
 	case policy.AllowResult:
-		return stacks.EvaluateResult_ALLOW_EVALUATE_RESULT
+		return terraform1.EvaluateResult_ALLOW_EVALUATE_RESULT
 	case policy.DenyResult:
-		return stacks.EvaluateResult_DENY_EVALUATE_RESULT
+		return terraform1.EvaluateResult_DENY_EVALUATE_RESULT
 	case policy.SetupErrorResult:
-		return stacks.EvaluateResult_SETUP_ERROR_EVALUATE_RESULT
+		return terraform1.EvaluateResult_SETUP_ERROR_EVALUATE_RESULT
 	default:
 		// should be exhaustive
 		panic(fmt.Errorf("unhandled policy.EvaluateResult type: %T", result))
 	}
 }
 
-func policyResultsToProto(addr string, policies []*policy.Policy) []*stacks.PolicyResult {
-	protoPolicyResults := make([]*stacks.PolicyResult, len(policies))
+func policyResultsToProto(addr string, policies []*policy.Policy) []*terraform1.PolicyResult {
+	protoPolicyResults := make([]*terraform1.PolicyResult, len(policies))
 	for i, policy := range policies {
-		result := stacks.PolicyResult{
+		result := terraform1.PolicyResult{
 			TargetAddress:  addr,
 			PolicyMetadata: policyMetadataToProto(policy, nil),
 			Result:         policyEvaluateResultToProto(policy.Result),
@@ -232,11 +252,11 @@ func policyResultsToProto(addr string, policies []*policy.Policy) []*stacks.Poli
 	return protoPolicyResults
 }
 
-func policyMetadataToProto(policyObj *policy.Policy, enforceIndex *int32) *stacks.PolicyMetaData {
+func policyMetadataToProto(policyObj *policy.Policy, enforceIndex *int32) *terraform1.PolicyMetaData {
 	if policyObj == nil {
 		return nil
 	}
-	metadata := &stacks.PolicyMetaData{
+	metadata := &terraform1.PolicyMetaData{
 		PolicySetName:    policyObj.PolicySetName,
 		PolicyName:       policyObj.Address,
 		FileName:         policyObj.Filename,
@@ -250,8 +270,8 @@ func policyMetadataToProto(policyObj *policy.Policy, enforceIndex *int32) *stack
 	return metadata
 }
 
-func policyInfosToProto(addr string, enforcements []policy.EnforcementResult) []*stacks.PolicyInfo {
-	protoPolicyInfos := make([]*stacks.PolicyInfo, 0)
+func policyInfosToProto(addr string, enforcements []policy.EnforcementResult) []*terraform1.PolicyInfo {
+	protoPolicyInfos := make([]*terraform1.PolicyInfo, 0)
 
 	for _, enforcement := range enforcements {
 		if enforcement.Message == "" {
@@ -259,9 +279,9 @@ func policyInfosToProto(addr string, enforcements []policy.EnforcementResult) []
 		}
 		protoPolicyMetadata := policyMetadataToProto(enforcement.Policy, &enforcement.BlockIndex)
 
-		var protoPolicySnippet *stacks.PolicySnippet
+		var protoPolicySnippet *terraform1.PolicySnippet
 		if snippet := enforcement.Snippet; snippet != nil {
-			protoPolicySnippet = &stacks.PolicySnippet{
+			protoPolicySnippet = &terraform1.PolicySnippet{
 				Code:                 snippet.Code,
 				StartLine:            snippet.StartLine,
 				HighlightStartOffset: snippet.HighlightStartOffset,
@@ -282,7 +302,7 @@ func policyInfosToProto(addr string, enforcements []policy.EnforcementResult) []
 			}
 		}
 
-		protoPolicyInfos = append(protoPolicyInfos, &stacks.PolicyInfo{
+		protoPolicyInfos = append(protoPolicyInfos, &terraform1.PolicyInfo{
 			TargetAddress:  addr,
 			Result:         policyEvaluateResultToProto(enforcement.Result),
 			Message:        enforcement.Message,
@@ -295,14 +315,14 @@ func policyInfosToProto(addr string, enforcements []policy.EnforcementResult) []
 	return protoPolicyInfos
 }
 
-func policyDiagsToProto(addr string, policyDiags policy.Diagnostics) []*stacks.PolicyDiagnostic {
-	protoPolicyDiags := make([]*stacks.PolicyDiagnostic, len(policyDiags))
+func policyDiagsToProto(addr string, policyDiags policy.Diagnostics) []*terraform1.PolicyDiagnostic {
+	protoPolicyDiags := make([]*terraform1.PolicyDiagnostic, len(policyDiags))
 
 	for i, diag := range policyDiags {
 		desc := diag.Description()
 		extra := tfdiags.ExtraInfo[*policy.PolicyExtra](diag)
 
-		policyDiag := stacks.PolicyDiagnostic{
+		policyDiag := terraform1.PolicyDiagnostic{
 			TargetAddress: addr,
 			Diagnostic: &terraform1.Diagnostic{
 				Severity: terraform1.Diagnostic_ERROR,
@@ -320,7 +340,7 @@ func policyDiagsToProto(addr string, policyDiags policy.Diagnostics) []*stacks.P
 			policyDiag.PolicyMetadata = policyMetadataToProto(&extra.Policy, extra.EnforceIndex)
 
 			if snippet := extra.Snippet; snippet != nil {
-				policyDiag.PolicySnippet = &stacks.PolicySnippet{
+				policyDiag.PolicySnippet = &terraform1.PolicySnippet{
 					Code:                 snippet.Code,
 					StartLine:            snippet.StartLine,
 					HighlightStartOffset: snippet.HighlightStartOffset,
@@ -367,12 +387,12 @@ func policyDiagsToProto(addr string, policyDiags policy.Diagnostics) []*stacks.P
 	return protoPolicyDiags
 }
 
-func policyExpressionValuesToProto(policyExpressionValues []*proto.ExpressionValue) []*stacks.ExpressionValue {
+func policyExpressionValuesToProto(policyExpressionValues []*proto.ExpressionValue) []*terraform1.ExpressionValue {
 	if len(policyExpressionValues) == 0 {
 		return nil
 	}
 
-	expressionValues := make([]*stacks.ExpressionValue, 0, len(policyExpressionValues))
+	expressionValues := make([]*terraform1.ExpressionValue, 0, len(policyExpressionValues))
 	seen := make(map[string]struct{}, len(policyExpressionValues))
 
 	for _, val := range policyExpressionValues {
@@ -381,8 +401,8 @@ func policyExpressionValuesToProto(policyExpressionValues []*proto.ExpressionVal
 			continue // then we can't display this value
 		}
 
-		exprValue := &stacks.ExpressionValue{
-			Traversal: stacks.NewAttributePath(path),
+		exprValue := &terraform1.ExpressionValue{
+			Traversal: terraform1.NewAttributePath(path),
 		}
 
 		strPath := ctyPathStr(path)

--- a/internal/rpcapi/convert_test.go
+++ b/internal/rpcapi/convert_test.go
@@ -250,27 +250,27 @@ func TestComponentInstancePolicyEvaluationProto(t *testing.T) {
 				}
 			},
 			want: &stacks.ComponentInstancePolicyEvaluation{
-				Results: []*stacks.PolicyResult{
+				Results: []*terraform1.PolicyResult{
 					{
 						TargetAddress: "module.example",
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "module_policy.example",
 							FileName:         "policy_file.tfpolicy.hcl",
 							EnforcementLevel: "mandatory",
 						},
-						Result: stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Result: terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 					},
 				},
-				Diagnostics: []*stacks.PolicyDiagnostic{
+				Diagnostics: []*terraform1.PolicyDiagnostic{
 					{
 						TargetAddress: "module.example",
-						Result:        stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Result:        terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 						Diagnostic: &terraform1.Diagnostic{
 							Severity: terraform1.Diagnostic_ERROR,
 							Summary:  "module policy denied",
 							Detail:   "module policy blocked usage",
 						},
-						PolicyMetadata: &stacks.PolicyMetaData{},
+						PolicyMetadata: &terraform1.PolicyMetaData{},
 					},
 				},
 			},
@@ -311,31 +311,31 @@ func TestComponentInstancePolicyEvaluationProto(t *testing.T) {
 				}
 			},
 			want: &stacks.ComponentInstancePolicyEvaluation{
-				Results: []*stacks.PolicyResult{
+				Results: []*terraform1.PolicyResult{
 					{
 						TargetAddress: "module.example",
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "policy_name",
 							PolicySetName:    "some_policy_set",
 							FileName:         "policy_file.tfpolicy.hcl",
 							EnforcementLevel: "mandatory",
 						},
-						Result: stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+						Result: terraform1.EvaluateResult_ALLOW_EVALUATE_RESULT,
 					},
 				},
-				Infos: []*stacks.PolicyInfo{
+				Infos: []*terraform1.PolicyInfo{
 					{
 						TargetAddress: "module.example",
-						Result:        stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+						Result:        terraform1.EvaluateResult_ALLOW_EVALUATE_RESULT,
 						Message:       "module policy allowed usage",
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "policy_name",
 							PolicySetName:    "some_policy_set",
 							FileName:         "policy_file.tfpolicy.hcl",
 							EnforcementLevel: "mandatory",
 							EnforceIndex:     1,
 						},
-						PolicySnippet: &stacks.PolicySnippet{
+						PolicySnippet: &terraform1.PolicySnippet{
 							Code:                 `key = attr.value == "foo"`,
 							Context:              snippetContext,
 							StartLine:            3,
@@ -393,22 +393,22 @@ func TestComponentInstancePolicyEvaluationProto(t *testing.T) {
 				}
 			},
 			want: &stacks.ComponentInstancePolicyEvaluation{
-				Diagnostics: []*stacks.PolicyDiagnostic{
+				Diagnostics: []*terraform1.PolicyDiagnostic{
 					{
 						TargetAddress: "module.example",
-						Result:        stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Result:        terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 						Diagnostic: &terraform1.Diagnostic{
 							Severity: terraform1.Diagnostic_ERROR,
 							Summary:  "policy error",
 							Detail:   "the module is not allowed",
 						},
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "policy_name",
 							PolicySetName:    "some_policy_set",
 							FileName:         "policy_file.tfpolicy.hcl",
 							EnforcementLevel: "mandatory",
 						},
-						PolicySnippet: &stacks.PolicySnippet{
+						PolicySnippet: &terraform1.PolicySnippet{
 							Context:              snippetContext,
 							Code:                 `key = attr.value == "foo"`,
 							StartLine:            2,
@@ -420,9 +420,9 @@ func TestComponentInstancePolicyEvaluationProto(t *testing.T) {
 							Start:      &terraform1.SourcePos{Byte: 10, Line: 2, Column: 3},
 							End:        &terraform1.SourcePos{Byte: 20, Line: 2, Column: 13},
 						},
-						ExpressionValues: []*stacks.ExpressionValue{
+						ExpressionValues: []*terraform1.ExpressionValue{
 							{
-								Traversal: stacks.NewAttributePath(cty.GetAttrPath("value")),
+								Traversal: terraform1.NewAttributePath(cty.GetAttrPath("value")),
 								Value:     exprValueBytes,
 							},
 						},
@@ -464,28 +464,28 @@ func TestComponentInstancePolicyEvaluationProto(t *testing.T) {
 				}
 			},
 			want: &stacks.ComponentInstancePolicyEvaluation{
-				Results: []*stacks.PolicyResult{
+				Results: []*terraform1.PolicyResult{
 					{
 						TargetAddress: "module.example",
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "module_policy.example",
 							PolicySetName:    "some_policy_set",
 							FileName:         "policy_file.tfpolicy.hcl",
 							EnforcementLevel: "mandatory",
 						},
-						Result: stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Result: terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 					},
 				},
-				Diagnostics: []*stacks.PolicyDiagnostic{
+				Diagnostics: []*terraform1.PolicyDiagnostic{
 					{
 						TargetAddress: "module.example",
-						Result:        stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Result:        terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 						Diagnostic: &terraform1.Diagnostic{
 							Severity: terraform1.Diagnostic_ERROR,
 							Summary:  "enforce block denied module",
 							Detail:   "the enforce block condition failed",
 						},
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "module_policy.example",
 							PolicySetName:    "some_policy_set",
 							FileName:         "policy_file.tfpolicy.hcl",
@@ -524,10 +524,10 @@ func TestComponentInstancePolicyEvaluationProto(t *testing.T) {
 				}
 			},
 			want: &stacks.ComponentInstancePolicyEvaluation{
-				Diagnostics: []*stacks.PolicyDiagnostic{
+				Diagnostics: []*terraform1.PolicyDiagnostic{
 					{
 						TargetAddress: "test_instance.example",
-						Result:        stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+						Result:        terraform1.EvaluateResult_ALLOW_EVALUATE_RESULT,
 						Diagnostic: &terraform1.Diagnostic{
 							Severity: terraform1.Diagnostic_WARNING,
 							Summary:  "resource policy warning",
@@ -543,7 +543,7 @@ func TestComponentInstancePolicyEvaluationProto(t *testing.T) {
 								End:        &terraform1.SourcePos{Line: 5, Column: 20, Byte: 70},
 							},
 						},
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "policy_name",
 							PolicySetName:    "some_policy_set",
 							FileName:         "policy_file.tfpolicy.hcl",
@@ -583,24 +583,24 @@ func TestComponentInstancePolicyEvaluationProto(t *testing.T) {
 				}
 			},
 			want: &stacks.ComponentInstancePolicyEvaluation{
-				Diagnostics: []*stacks.PolicyDiagnostic{
+				Diagnostics: []*terraform1.PolicyDiagnostic{
 					{
 						TargetAddress: "test_instance.example",
-						Result:        stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Result:        terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 						Diagnostic: &terraform1.Diagnostic{
 							Severity: terraform1.Diagnostic_ERROR,
 							Summary:  "policy error",
 							Detail:   "the resource is not allowed",
 						},
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "policy_name",
 							PolicySetName:    "some_policy_set",
 							FileName:         "policy_file.tfpolicy.hcl",
 							EnforcementLevel: "mandatory",
 						},
-						ExpressionValues: []*stacks.ExpressionValue{
+						ExpressionValues: []*terraform1.ExpressionValue{
 							{
-								Traversal: stacks.NewAttributePath(cty.GetAttrPath("value")),
+								Traversal: terraform1.NewAttributePath(cty.GetAttrPath("value")),
 								Value:     exprValueBytes,
 							},
 						},
@@ -695,27 +695,27 @@ func TestProviderInstancePolicyEvaluationProto(t *testing.T) {
 				}
 			},
 			want: &stacks.ProviderInstancePolicyEvaluation{
-				Results: []*stacks.PolicyResult{
+				Results: []*terraform1.PolicyResult{
 					{
 						TargetAddress: `provider["registry.terraform.io/hashicorp/testing"]`,
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "provider_policy.example",
 							FileName:         "policy_file.tfpolicy.hcl",
 							EnforcementLevel: "mandatory",
 						},
-						Result: stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Result: terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 					},
 				},
-				Diagnostics: []*stacks.PolicyDiagnostic{
+				Diagnostics: []*terraform1.PolicyDiagnostic{
 					{
 						TargetAddress: `provider["registry.terraform.io/hashicorp/testing"]`,
-						Result:        stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Result:        terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 						Diagnostic: &terraform1.Diagnostic{
 							Severity: terraform1.Diagnostic_ERROR,
 							Summary:  "provider policy denied",
 							Detail:   "provider policy blocked usage",
 						},
-						PolicyMetadata: &stacks.PolicyMetaData{},
+						PolicyMetadata: &terraform1.PolicyMetaData{},
 					},
 				},
 			},
@@ -757,31 +757,31 @@ func TestProviderInstancePolicyEvaluationProto(t *testing.T) {
 				}
 			},
 			want: &stacks.ProviderInstancePolicyEvaluation{
-				Results: []*stacks.PolicyResult{
+				Results: []*terraform1.PolicyResult{
 					{
 						TargetAddress: `provider["registry.terraform.io/hashicorp/testing"]`,
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "policy_name",
 							PolicySetName:    "some_policy_set",
 							FileName:         "policy_file.tfpolicy.hcl",
 							EnforcementLevel: "mandatory",
 						},
-						Result: stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+						Result: terraform1.EvaluateResult_ALLOW_EVALUATE_RESULT,
 					},
 				},
-				Infos: []*stacks.PolicyInfo{
+				Infos: []*terraform1.PolicyInfo{
 					{
 						TargetAddress: `provider["registry.terraform.io/hashicorp/testing"]`,
-						Result:        stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+						Result:        terraform1.EvaluateResult_ALLOW_EVALUATE_RESULT,
 						Message:       "provider policy allowed usage",
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "policy_name",
 							PolicySetName:    "some_policy_set",
 							FileName:         "policy_file.tfpolicy.hcl",
 							EnforcementLevel: "mandatory",
 							EnforceIndex:     1,
 						},
-						PolicySnippet: &stacks.PolicySnippet{
+						PolicySnippet: &terraform1.PolicySnippet{
 							Code:                 `key = attr.value == "foo"`,
 							Context:              snippetContext,
 							StartLine:            3,
@@ -840,22 +840,22 @@ func TestProviderInstancePolicyEvaluationProto(t *testing.T) {
 				}
 			},
 			want: &stacks.ProviderInstancePolicyEvaluation{
-				Diagnostics: []*stacks.PolicyDiagnostic{
+				Diagnostics: []*terraform1.PolicyDiagnostic{
 					{
 						TargetAddress: `provider["registry.terraform.io/hashicorp/testing"]`,
-						Result:        stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Result:        terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 						Diagnostic: &terraform1.Diagnostic{
 							Severity: terraform1.Diagnostic_ERROR,
 							Summary:  "policy error",
 							Detail:   "the provider is not allowed",
 						},
-						PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyMetadata: &terraform1.PolicyMetaData{
 							PolicyName:       "policy_name",
 							PolicySetName:    "some_policy_set",
 							FileName:         "policy_file.tfpolicy.hcl",
 							EnforcementLevel: "mandatory",
 						},
-						PolicySnippet: &stacks.PolicySnippet{
+						PolicySnippet: &terraform1.PolicySnippet{
 							Context:              snippetContext,
 							Code:                 `key = attr.value == "foo"`,
 							StartLine:            2,
@@ -867,9 +867,9 @@ func TestProviderInstancePolicyEvaluationProto(t *testing.T) {
 							Start:      &terraform1.SourcePos{Byte: 10, Line: 2, Column: 3},
 							End:        &terraform1.SourcePos{Byte: 20, Line: 2, Column: 13},
 						},
-						ExpressionValues: []*stacks.ExpressionValue{
+						ExpressionValues: []*terraform1.ExpressionValue{
 							{
-								Traversal: stacks.NewAttributePath(cty.GetAttrPath("value")),
+								Traversal: terraform1.NewAttributePath(cty.GetAttrPath("value")),
 								Value:     exprValueBytes,
 							},
 						},

--- a/internal/rpcapi/dependencies.go
+++ b/internal/rpcapi/dependencies.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/go-slug/sourceaddrs"
 	"github.com/hashicorp/go-slug/sourcebundle"
 	"github.com/hashicorp/terraform-svchost/disco"
+	"github.com/zclconf/go-cty/cty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -27,6 +29,8 @@ import (
 	"github.com/hashicorp/terraform/internal/logging"
 	tfplugin "github.com/hashicorp/terraform/internal/plugin"
 	tfplugin6 "github.com/hashicorp/terraform/internal/plugin6"
+	"github.com/hashicorp/terraform/internal/policy"
+	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/providercache"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/rpcapi/terraform1"
@@ -40,6 +44,9 @@ type dependenciesServer struct {
 
 	handles  *handleTable
 	services *disco.Disco
+
+	// policyClientOverride is an in-memory override of the policy client used for testing.
+	policyClientOverride policy.Client
 }
 
 func newDependenciesServer(handles *handleTable, services *disco.Disco) *dependenciesServer {
@@ -196,6 +203,33 @@ func (s *dependenciesServer) BuildProviderPluginCache(req *dependencies.BuildPro
 	locks := s.handles.DependencyLocks(hnd)
 	if locks == nil {
 		return status.Error(codes.InvalidArgument, "invalid dependency locks handle")
+	}
+
+	// Setup the policy client if the caller provides a plugin path and policies
+	var policyClient policy.Client
+	if req.TfpolicyPluginPath != nil && len(req.PolicyPaths) > 0 {
+		if s.policyClientOverride != nil {
+			// Tests use a mock policy client
+			policyClient = s.policyClientOverride
+		} else {
+			var entitlement *policy.Entitlement
+			if req.PolicyEntitlement != nil {
+				entitlement = &policy.Entitlement{
+					Host:  req.PolicyEntitlement.Host,
+					Token: req.PolicyEntitlement.Token,
+					Org:   req.PolicyEntitlement.Org,
+				}
+			}
+			// Normal code path for connecting to a policy client
+			var diags policy.Diagnostics
+			policyClient, diags = policy.NewPolicyClient(ctx, *req.TfpolicyPluginPath, req.PolicyPaths, entitlement)
+			if diags.HasErrors() {
+				return status.Errorf(codes.FailedPrecondition, "failed to connect to policy client: %s", diags.AsTerraformDiags().Err())
+			}
+		}
+
+		log.Printf("[DEBUG] rpcapi: Policy engine initialized with paths: %v", req.PolicyPaths)
+		defer policyClient.Stop()
 	}
 
 	selectors := make([]getproviders.MultiSourceSelector, 0, len(req.InstallationMethods))
@@ -422,7 +456,40 @@ func (s *dependenciesServer) BuildProviderPluginCache(req *dependencies.BuildPro
 	}
 	ctx = instEvts.OnContext(ctx)
 
-	_, err := inst.EnsureProviderVersions(ctx, locks, reqd, providercache.InstallNewProvidersOnly)
+	providerPolicyInstallHook := &providerPolicyHook{
+		client: policyClient,
+		sendEventCb: func(provider addrs.Provider, result policy.EvaluationResponse) error {
+			// Send the policy result back to the client
+			evts.Send(&dependencies.BuildProviderPluginCache_Event{
+				Event: &dependencies.BuildProviderPluginCache_Event_ProviderInstallPolicyEvaluation{
+					ProviderInstallPolicyEvaluation: providerInstallPolicyEvaluationProto(provider, result),
+				},
+			})
+
+			if result.Diagnostics.HasErrors() {
+				evts.Send(&dependencies.BuildProviderPluginCache_Event{
+					Event: &dependencies.BuildProviderPluginCache_Event_Diagnostic{
+						Diagnostic: diagnosticToProto(tfdiags.Sourceless(
+							tfdiags.Error,
+							"Provider download blocked due to policy violations",
+							fmt.Sprintf(
+								"Download blocked due to policy violations for provider %s v%s. Please review the policy results for details.",
+								provider.ForDisplay(), version.String(),
+							),
+						)),
+					},
+				})
+
+				// We still return an error here to prevent the installation
+				sentErrorDiags = true
+				return fmt.Errorf("Provider download blocked due to policy violations. Please review the policy results for details")
+			}
+
+			return nil
+		},
+	}
+
+	_, err := inst.EnsureProviderVersions(ctx, locks, reqd, providercache.InstallNewProvidersOnly, providerPolicyInstallHook)
 	if err != nil {
 		// If we already emitted errors in the form of diagnostics then
 		// err will typically just duplicate them, so we'll skip emitting
@@ -449,6 +516,46 @@ func (s *dependenciesServer) BuildProviderPluginCache(req *dependencies.BuildPro
 	// bugs in the calling program, rather than problems with the installation
 	// process.
 	return nil
+}
+
+var _ providercache.InstallerHook = &providerPolicyHook{}
+
+// providerPolicyHook enables policy evaluation during provider installation.
+type providerPolicyHook struct {
+	client      policy.Client
+	sendEventCb func(provider addrs.Provider, result policy.EvaluationResponse) error
+}
+
+// ProviderVersionSelected satisfies the [providers.InstallerHook] interface.
+// When a provider version is selected, this method performs policy evaluation for the provider,
+// and aborts the installation if the policy evaluation fails.
+func (p *providerPolicyHook) ProviderVersionSelected(ctx context.Context, provider addrs.Provider, version string) error {
+	// If the client is nil, then policy evaluation is disabled, so we can skip.
+	if p.client == nil {
+		return nil
+	}
+	log.Println("[DEBUG] rpcapi: evaluating policy for provider", provider.String(), version)
+	result := p.client.EvaluateProvider(ctx, policy.EvaluationRequest[*proto.PolicyEvaluateProviderRequest_ProviderMetadata]{
+		Target: provider.Type,
+
+		// Configuration attributes are not available when building the provider cache, so we will send an unknown
+		// dynamic value to the policy client.
+		Attrs: policy.CtyToPolicyValue(cty.DynamicVal),
+		Meta: &proto.PolicyEvaluateProviderRequest_ProviderMetadata{
+			Name:      provider.Type,
+			Namespace: provider.Namespace,
+			Source:    provider.String(),
+			Version:   version,
+		},
+	})
+
+	// If there were no policy evaluations reported then return with no error
+	if result.Empty() {
+		return nil
+	}
+
+	log.Println("[DEBUG] rpcapi: policy result for provider", provider.String(), version, "overall", result.Overall)
+	return p.sendEventCb(provider, result)
 }
 
 func (s *dependenciesServer) OpenProviderPluginCache(ctx context.Context, req *dependencies.OpenProviderPluginCache_Request) (*dependencies.OpenProviderPluginCache_Response, error) {

--- a/internal/rpcapi/dependencies_test.go
+++ b/internal/rpcapi/dependencies_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/hashicorp/terraform/internal/policy"
+	policyproto "github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/rpcapi/terraform1"
 	"github.com/hashicorp/terraform/internal/rpcapi/terraform1/dependencies"
 
@@ -492,4 +494,308 @@ func TestDependenciesProviderSchema(t *testing.T) {
 		}
 	}
 
+}
+
+func TestDependenciesProviderCache_policy(t *testing.T) {
+	policyObj := func(result policy.EvaluateResult) *policy.Policy {
+		return &policy.Policy{
+			Result:           result,
+			PolicySetName:    "some_policy_set",
+			Address:          "policy_name",
+			Directory:        "some/path/to",
+			Filename:         "policy_file.tfpolicy.hcl",
+			EnforcementLevel: "mandatory",
+		}
+	}
+
+	testCases := map[string]struct {
+		policyResponse            policy.EvaluationResponse
+		expectedDiags             []*terraform1.Diagnostic
+		expectedPolicyEvaluations []*dependencies.ProviderInstallPolicyEvaluation
+		expectedProviderPackages  []*terraform1.ProviderPackage
+	}{
+		"policy allow - no enforcements": {
+			policyResponse: policy.EvaluationResponse{
+				Overall:  policy.AllowResult,
+				Policies: []*policy.Policy{policyObj(policy.AllowResult)},
+			},
+			expectedDiags: []*terraform1.Diagnostic{},
+			// No enforcements in the response so no policy evaluation events
+			expectedPolicyEvaluations: []*dependencies.ProviderInstallPolicyEvaluation{},
+			expectedProviderPackages: []*terraform1.ProviderPackage{
+				{
+					SourceAddr: "example.com/foo/bar",
+					Version:    "1.2.3",
+					Hashes: []string{
+						// This hash is of the fake package directory we installed
+						// from, under testdata/provider-fs-mirror .
+						"h1:cAp58lPuOAaPN9ZDdFHx9FxVK2NU0UeObQs2/zld9Lc=",
+					},
+				},
+			},
+		},
+		"policy allow - advisory": {
+			policyResponse: policy.EvaluationResponse{
+				Overall:  policy.AllowResult,
+				Policies: []*policy.Policy{policyObj(policy.AllowResult)},
+				Enforcements: []policy.EnforcementResult{
+					{
+						Result:     policy.AllowResult,
+						Message:    "just an advisory message",
+						BlockIndex: 1,
+						Policy:     policyObj(policy.AllowResult),
+					},
+				},
+			},
+			expectedDiags: []*terraform1.Diagnostic{},
+			expectedPolicyEvaluations: []*dependencies.ProviderInstallPolicyEvaluation{
+				{
+					Addr: `provider["example.com/foo/bar"]`,
+					Results: []*terraform1.PolicyResult{
+						{
+							TargetAddress: `provider["example.com/foo/bar"]`,
+							PolicyMetadata: &terraform1.PolicyMetaData{
+								PolicyName:       "policy_name",
+								PolicySetName:    "some_policy_set",
+								EnforcementLevel: "mandatory",
+								FileName:         "policy_file.tfpolicy.hcl",
+							},
+							Result: terraform1.EvaluateResult_ALLOW_EVALUATE_RESULT,
+						},
+					},
+					Infos: []*terraform1.PolicyInfo{
+						{
+							TargetAddress: `provider["example.com/foo/bar"]`,
+							PolicyMetadata: &terraform1.PolicyMetaData{
+								PolicyName:       "policy_name",
+								PolicySetName:    "some_policy_set",
+								EnforcementLevel: "mandatory",
+								FileName:         "policy_file.tfpolicy.hcl",
+								EnforceIndex:     1,
+							},
+							Message: "just an advisory message",
+							Result:  terraform1.EvaluateResult_ALLOW_EVALUATE_RESULT,
+						},
+					},
+				},
+			},
+			// Providers are still installed successfully
+			expectedProviderPackages: []*terraform1.ProviderPackage{
+				{
+					SourceAddr: "example.com/foo/bar",
+					Version:    "1.2.3",
+					Hashes: []string{
+						// This hash is of the fake package directory we installed
+						// from, under testdata/provider-fs-mirror .
+						"h1:cAp58lPuOAaPN9ZDdFHx9FxVK2NU0UeObQs2/zld9Lc=",
+					},
+				},
+			},
+		},
+		"policy deny": {
+			policyResponse: policy.EvaluationResponse{
+				Overall:  policy.DenyResult,
+				Policies: []*policy.Policy{policyObj(policy.DenyResult)},
+				Diagnostics: policy.DiagsFromProto([]*policyproto.Diagnostic{
+					{
+						Severity: policyproto.Severity_ERROR,
+						Summary:  "Provider policy violation",
+						Detail:   "testing provider violates policy",
+						Result: &policyproto.DiagnosticResult{
+							Result: policyproto.EvaluateResult_DENY_EVALUATE_RESULT,
+						},
+					},
+				}, nil),
+			},
+			expectedDiags: []*terraform1.Diagnostic{
+				{
+					Severity: terraform1.Diagnostic_ERROR,
+					Summary:  "Provider download blocked due to policy violations",
+					Detail:   "Download blocked due to policy violations for provider example.com/foo/bar v1.16.0-dev. Please review the policy results for details.",
+				},
+			},
+			expectedPolicyEvaluations: []*dependencies.ProviderInstallPolicyEvaluation{
+				{
+					Addr: `provider["example.com/foo/bar"]`,
+					Results: []*terraform1.PolicyResult{
+						{
+							TargetAddress: `provider["example.com/foo/bar"]`,
+							PolicyMetadata: &terraform1.PolicyMetaData{
+								PolicyName:       "policy_name",
+								PolicySetName:    "some_policy_set",
+								EnforcementLevel: "mandatory",
+								FileName:         "policy_file.tfpolicy.hcl",
+							},
+							Result: terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
+						},
+					},
+					Infos: []*terraform1.PolicyInfo{},
+					Diagnostics: []*terraform1.PolicyDiagnostic{
+						{
+							TargetAddress:  `provider["example.com/foo/bar"]`,
+							PolicyMetadata: &terraform1.PolicyMetaData{},
+							Result:         terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
+							Diagnostic: &terraform1.Diagnostic{
+								Severity: terraform1.Diagnostic_ERROR,
+								Summary:  "Provider policy violation",
+								Detail:   "testing provider violates policy",
+							},
+						},
+					},
+				},
+			},
+			// Providers are not installed
+			expectedProviderPackages: nil,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+
+			ctx := context.Background()
+
+			handles := newHandleTable()
+			depsServer := newDependenciesServer(handles, disco.New())
+
+			mockPolicyClient := policy.NewTestMockClient(t)
+
+			mockPolicyClient.EvaluateFn = func(_ context.Context, req policy.EvaluationRequest[*policyproto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				t.Errorf("unexpected call to evaluate resource %q during provider install", req.Target)
+				return policy.EvaluationResponse{}
+			}
+
+			mockPolicyClient.EvaluateModuleFn = func(ctx context.Context, req policy.EvaluationRequest[*policyproto.PolicyEvaluateModuleRequest_ModuleMetadata]) policy.EvaluationResponse {
+				t.Errorf("unexpected call to evaluate module %q during provider install", req.Target)
+				return policy.EvaluationResponse{}
+			}
+
+			mockPolicyClient.EvaluateProviderFn = func(ctx context.Context, req policy.EvaluationRequest[*policyproto.PolicyEvaluateProviderRequest_ProviderMetadata]) policy.EvaluationResponse {
+				// Assert provider data as defined in the lock file at: internal/rpcapi/testdata/sourcebundle/foo/.terraform.lock.hcl
+				expectedMeta := &policyproto.PolicyEvaluateProviderRequest_ProviderMetadata{
+					Name:      "bar",
+					Namespace: "foo",
+					Source:    "example.com/foo/bar",
+					Version:   "1.2.3",
+				}
+				if diff := cmp.Diff(req.Meta, expectedMeta, protocmp.Transform()); diff != "" {
+					t.Errorf("unexpected provider metadata\n%s", diff)
+					return policy.EvaluationResponse{}
+				}
+
+				return tc.policyResponse
+			}
+
+			depsServer.policyClientOverride = mockPolicyClient
+
+			grpcClient, close := grpcClientForTesting(ctx, t, func(srv *grpc.Server) {
+				dependencies.RegisterDependenciesServer(srv, depsServer)
+			})
+			defer close()
+			depsClient := dependencies.NewDependenciesClient(grpcClient)
+
+			openSourcesResp, err := depsClient.OpenSourceBundle(ctx, &dependencies.OpenSourceBundle_Request{
+				LocalPath: "testdata/sourcebundle",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				_, err := depsClient.CloseSourceBundle(ctx, &dependencies.CloseSourceBundle_Request{
+					SourceBundleHandle: openSourcesResp.SourceBundleHandle,
+				})
+				if err != nil {
+					t.Error(err)
+				}
+			}()
+
+			openLocksResp, err := depsClient.OpenDependencyLockFile(ctx, &dependencies.OpenDependencyLockFile_Request{
+				SourceBundleHandle: openSourcesResp.SourceBundleHandle,
+				SourceAddress: &terraform1.SourceAddress{
+					Source: "git::https://example.com/foo.git//.terraform.lock.hcl",
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(openLocksResp.Diagnostics) != 0 {
+				t.Error("OpenDependencyLockFile returned unexpected diagnostics")
+			}
+
+			tmpDir := t.TempDir()
+			cacheDir := filepath.Join(tmpDir, "pc")
+
+			fakePolicyPluginPath := "/not/a/real/plugin"
+			evts, err := depsClient.BuildProviderPluginCache(ctx, &dependencies.BuildProviderPluginCache_Request{
+				DependencyLocksHandle: openLocksResp.DependencyLocksHandle,
+				CacheDir:              cacheDir,
+				TfpolicyPluginPath:    &fakePolicyPluginPath,
+				PolicyPaths: []string{
+					"/fake/policy-set/",
+				},
+				InstallationMethods: []*dependencies.BuildProviderPluginCache_Request_InstallMethod{
+					{
+						Source: &dependencies.BuildProviderPluginCache_Request_InstallMethod_LocalMirrorDir{
+							LocalMirrorDir: "testdata/provider-fs-mirror",
+						},
+					},
+				},
+				OverridePlatform: "os_arch",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gotDiagnostics := make([]*terraform1.Diagnostic, 0)
+			gotPolicyEvaluationEvents := make([]*dependencies.ProviderInstallPolicyEvaluation, 0)
+			for {
+				msg, err := evts.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatal(err) // not expecting any errors
+				}
+
+				switch evt := msg.Event.(type) {
+				case *dependencies.BuildProviderPluginCache_Event_Diagnostic:
+					gotDiagnostics = append(gotDiagnostics, evt.Diagnostic)
+				case *dependencies.BuildProviderPluginCache_Event_ProviderInstallPolicyEvaluation:
+					gotPolicyEvaluationEvents = append(gotPolicyEvaluationEvents, evt.ProviderInstallPolicyEvaluation)
+				}
+			}
+
+			if diff := cmp.Diff(tc.expectedDiags, gotDiagnostics, protocmp.Transform()); diff != "" {
+				t.Fatalf("unexpected BuildProviderPluginCache diags\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedPolicyEvaluations, gotPolicyEvaluationEvents, protocmp.Transform()); diff != "" {
+				t.Fatalf("unexpected BuildProviderPluginCache policy events\n%s", diff)
+			}
+
+			openCacheResp, err := depsClient.OpenProviderPluginCache(ctx, &dependencies.OpenProviderPluginCache_Request{
+				CacheDir:         cacheDir,
+				OverridePlatform: "os_arch",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				_, err := depsClient.CloseProviderPluginCache(ctx, &dependencies.CloseProviderPluginCache_Request{
+					ProviderCacheHandle: openCacheResp.ProviderCacheHandle,
+				})
+				if err != nil {
+					t.Error(err)
+				}
+			}()
+			pkgsResp, err := depsClient.GetCachedProviders(ctx, &dependencies.GetCachedProviders_Request{
+				ProviderCacheHandle: openCacheResp.ProviderCacheHandle,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedProviderPackages, pkgsResp.AvailableProviders, protocmp.Transform()); diff != "" {
+				t.Errorf("wrong providers in cache reported after building\n%s", diff)
+			}
+		})
+	}
 }

--- a/internal/rpcapi/stacks_test.go
+++ b/internal/rpcapi/stacks_test.go
@@ -2641,7 +2641,7 @@ func policyEvaluationTestClient(t *testing.T) policy.Client {
 }
 
 func createExpectedComponentInstancePolicyEvaluation(componentInstanceAddr string) aggregatedPolicyEvent {
-	expectedPolicyMetadata := &stacks.PolicyMetaData{
+	expectedPolicyMetadata := &terraform1.PolicyMetaData{
 		PolicyName:       "policy_name",
 		PolicySetName:    "some_policy_set",
 		EnforcementLevel: "mandatory",
@@ -2655,27 +2655,27 @@ func createExpectedComponentInstancePolicyEvaluation(componentInstanceAddr strin
 				ComponentAddr:         "component.simple_component",
 				ComponentInstanceAddr: componentInstanceAddr,
 			},
-			Results: []*stacks.PolicyResult{
+			Results: []*terraform1.PolicyResult{
 				{
 					TargetAddress:  "module.child.testing_resource.child_resource",
 					PolicyMetadata: expectedPolicyMetadata,
-					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+					Result:         terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 				},
 				{
 					TargetAddress:  "testing_resource.parent_resource",
 					PolicyMetadata: expectedPolicyMetadata,
-					Result:         stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+					Result:         terraform1.EvaluateResult_ALLOW_EVALUATE_RESULT,
 				},
 				{
 					TargetAddress:  "module.child",
 					PolicyMetadata: expectedPolicyMetadata,
-					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+					Result:         terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 				},
 			},
-			Infos: []*stacks.PolicyInfo{
+			Infos: []*terraform1.PolicyInfo{
 				{
 					TargetAddress: "testing_resource.parent_resource",
-					PolicyMetadata: &stacks.PolicyMetaData{
+					PolicyMetadata: &terraform1.PolicyMetaData{
 						PolicyName:       "policy_name",
 						PolicySetName:    "some_policy_set",
 						EnforcementLevel: "mandatory",
@@ -2683,14 +2683,14 @@ func createExpectedComponentInstancePolicyEvaluation(componentInstanceAddr strin
 						EnforceIndex:     1,
 					},
 					Message: "just an advisory message",
-					Result:  stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+					Result:  terraform1.EvaluateResult_ALLOW_EVALUATE_RESULT,
 				},
 			},
-			Diagnostics: []*stacks.PolicyDiagnostic{
+			Diagnostics: []*terraform1.PolicyDiagnostic{
 				{
 					TargetAddress:  "module.child.testing_resource.child_resource",
-					PolicyMetadata: &stacks.PolicyMetaData{},
-					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+					PolicyMetadata: &terraform1.PolicyMetaData{},
+					Result:         terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 					Diagnostic: &terraform1.Diagnostic{
 						Severity: terraform1.Diagnostic_ERROR,
 						Summary:  "Child module resource violation",
@@ -2709,8 +2709,8 @@ func createExpectedComponentInstancePolicyEvaluation(componentInstanceAddr strin
 				},
 				{
 					TargetAddress:  "module.child",
-					PolicyMetadata: &stacks.PolicyMetaData{},
-					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+					PolicyMetadata: &terraform1.PolicyMetaData{},
+					Result:         terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 					Diagnostic: &terraform1.Diagnostic{
 						Severity: terraform1.Diagnostic_ERROR,
 						Summary:  "Child module policy violation",
@@ -2733,7 +2733,7 @@ func createExpectedComponentInstancePolicyEvaluation(componentInstanceAddr strin
 }
 
 func createExpectedProviderInstancePolicyEvaluation(providerInstanceAddr string) aggregatedPolicyEvent {
-	expectedPolicyMetadata := &stacks.PolicyMetaData{
+	expectedPolicyMetadata := &terraform1.PolicyMetaData{
 		PolicyName:       "policy_name",
 		PolicySetName:    "some_policy_set",
 		EnforcementLevel: "mandatory",
@@ -2748,19 +2748,19 @@ func createExpectedProviderInstancePolicyEvaluation(providerInstanceAddr string)
 				ProviderAddr:         providerAddr,
 				ProviderInstanceAddr: providerInstanceAddr,
 			},
-			Results: []*stacks.PolicyResult{
+			Results: []*terraform1.PolicyResult{
 				{
 					TargetAddress:  providerAddr,
 					PolicyMetadata: expectedPolicyMetadata,
-					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+					Result:         terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 				},
 			},
-			Infos: []*stacks.PolicyInfo{},
-			Diagnostics: []*stacks.PolicyDiagnostic{
+			Infos: []*terraform1.PolicyInfo{},
+			Diagnostics: []*terraform1.PolicyDiagnostic{
 				{
 					TargetAddress:  providerAddr,
-					PolicyMetadata: &stacks.PolicyMetaData{},
-					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+					PolicyMetadata: &terraform1.PolicyMetaData{},
+					Result:         terraform1.EvaluateResult_DENY_EVALUATE_RESULT,
 					Diagnostic: &terraform1.Diagnostic{
 						Severity: terraform1.Diagnostic_ERROR,
 						Summary:  "Provider policy violation",

--- a/internal/rpcapi/terraform1/conversion.go
+++ b/internal/rpcapi/terraform1/conversion.go
@@ -1,0 +1,78 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform1
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// NewAttributePath constructs an [AttributePath] message object from
+// a [cty.Path] value.
+func NewAttributePath(from cty.Path) *AttributePath {
+	ret := &AttributePath{}
+	if len(from) == 0 {
+		return ret
+	}
+	ret.Steps = make([]*AttributePath_Step, len(from))
+	for i, step := range from {
+		switch step := step.(type) {
+		case cty.GetAttrStep:
+			ret.Steps[i] = &AttributePath_Step{
+				Selector: &AttributePath_Step_AttributeName{
+					AttributeName: step.Name,
+				},
+			}
+		case cty.IndexStep:
+			k := step.Key
+			// Although the key is cty.Value, in practice it should typically
+			// be constrained only to known and non-null strings and numbers.
+			// If we encounter anything else then we'll just abort and return
+			// a truncated path, since the only way other values should be
+			// able to appear is if we're traversing through a set, and we
+			// typically avoid doing that in callers by truncating the path
+			// at the same point anyway. (Note that marked values -- one of
+			// our main uses for AttributePath -- cannot exist inside
+			// sets anyway, so that case can't arise there.)
+			if k.IsNull() || !k.IsKnown() {
+				k = cty.DynamicVal // to force falling into the default case for the switch below
+			}
+
+			switch k.Type() {
+			case cty.String:
+				ret.Steps[i] = &AttributePath_Step{
+					Selector: &AttributePath_Step_ElementKeyString{
+						ElementKeyString: k.AsString(),
+					},
+				}
+			case cty.Number:
+				// We require an integer in int64 range. We might not get that
+				// in the unlikely event that this is a traversal through a
+				// cty.Set(cty.Number), since any number would be valid in
+				// principle for that case.
+				bf := k.AsBigFloat()
+				idx, acc := bf.Int64()
+				if acc != big.Exact {
+					ret.Steps = ret.Steps[:i]
+					return ret
+				}
+				ret.Steps[i] = &AttributePath_Step{
+					Selector: &AttributePath_Step_ElementKeyInt{
+						ElementKeyInt: idx,
+					},
+				}
+			default:
+				ret.Steps = ret.Steps[:i]
+				return ret
+			}
+		default:
+			// Should not get here because the above should be exhaustive for
+			// all cty.PathStep implementations.
+			panic(fmt.Sprintf("path has unsupported step type %T", step))
+		}
+	}
+	return ret
+}

--- a/internal/rpcapi/terraform1/dependencies/dependencies.pb.go
+++ b/internal/rpcapi/terraform1/dependencies/dependencies.pb.go
@@ -833,6 +833,74 @@ func (x *Schema) GetBlock() *Schema_Block {
 	return nil
 }
 
+type ProviderInstallPolicyEvaluation struct {
+	state         protoimpl.MessageState         `protogen:"open.v1"`
+	Addr          string                         `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	Results       []*terraform1.PolicyResult     `protobuf:"bytes,2,rep,name=results,proto3" json:"results,omitempty"`
+	Infos         []*terraform1.PolicyInfo       `protobuf:"bytes,3,rep,name=infos,proto3" json:"infos,omitempty"`
+	Diagnostics   []*terraform1.PolicyDiagnostic `protobuf:"bytes,4,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProviderInstallPolicyEvaluation) Reset() {
+	*x = ProviderInstallPolicyEvaluation{}
+	mi := &file_dependencies_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProviderInstallPolicyEvaluation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProviderInstallPolicyEvaluation) ProtoMessage() {}
+
+func (x *ProviderInstallPolicyEvaluation) ProtoReflect() protoreflect.Message {
+	mi := &file_dependencies_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProviderInstallPolicyEvaluation.ProtoReflect.Descriptor instead.
+func (*ProviderInstallPolicyEvaluation) Descriptor() ([]byte, []int) {
+	return file_dependencies_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ProviderInstallPolicyEvaluation) GetAddr() string {
+	if x != nil {
+		return x.Addr
+	}
+	return ""
+}
+
+func (x *ProviderInstallPolicyEvaluation) GetResults() []*terraform1.PolicyResult {
+	if x != nil {
+		return x.Results
+	}
+	return nil
+}
+
+func (x *ProviderInstallPolicyEvaluation) GetInfos() []*terraform1.PolicyInfo {
+	if x != nil {
+		return x.Infos
+	}
+	return nil
+}
+
+func (x *ProviderInstallPolicyEvaluation) GetDiagnostics() []*terraform1.PolicyDiagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
 type OpenSourceBundle_Request struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LocalPath     string                 `protobuf:"bytes,1,opt,name=local_path,json=localPath,proto3" json:"local_path,omitempty"`
@@ -842,7 +910,7 @@ type OpenSourceBundle_Request struct {
 
 func (x *OpenSourceBundle_Request) Reset() {
 	*x = OpenSourceBundle_Request{}
-	mi := &file_dependencies_proto_msgTypes[15]
+	mi := &file_dependencies_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -854,7 +922,7 @@ func (x *OpenSourceBundle_Request) String() string {
 func (*OpenSourceBundle_Request) ProtoMessage() {}
 
 func (x *OpenSourceBundle_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[15]
+	mi := &file_dependencies_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -886,7 +954,7 @@ type OpenSourceBundle_Response struct {
 
 func (x *OpenSourceBundle_Response) Reset() {
 	*x = OpenSourceBundle_Response{}
-	mi := &file_dependencies_proto_msgTypes[16]
+	mi := &file_dependencies_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -898,7 +966,7 @@ func (x *OpenSourceBundle_Response) String() string {
 func (*OpenSourceBundle_Response) ProtoMessage() {}
 
 func (x *OpenSourceBundle_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[16]
+	mi := &file_dependencies_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -930,7 +998,7 @@ type CloseSourceBundle_Request struct {
 
 func (x *CloseSourceBundle_Request) Reset() {
 	*x = CloseSourceBundle_Request{}
-	mi := &file_dependencies_proto_msgTypes[17]
+	mi := &file_dependencies_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -942,7 +1010,7 @@ func (x *CloseSourceBundle_Request) String() string {
 func (*CloseSourceBundle_Request) ProtoMessage() {}
 
 func (x *CloseSourceBundle_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[17]
+	mi := &file_dependencies_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -973,7 +1041,7 @@ type CloseSourceBundle_Response struct {
 
 func (x *CloseSourceBundle_Response) Reset() {
 	*x = CloseSourceBundle_Response{}
-	mi := &file_dependencies_proto_msgTypes[18]
+	mi := &file_dependencies_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -985,7 +1053,7 @@ func (x *CloseSourceBundle_Response) String() string {
 func (*CloseSourceBundle_Response) ProtoMessage() {}
 
 func (x *CloseSourceBundle_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[18]
+	mi := &file_dependencies_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1011,7 +1079,7 @@ type OpenDependencyLockFile_Request struct {
 
 func (x *OpenDependencyLockFile_Request) Reset() {
 	*x = OpenDependencyLockFile_Request{}
-	mi := &file_dependencies_proto_msgTypes[19]
+	mi := &file_dependencies_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1023,7 +1091,7 @@ func (x *OpenDependencyLockFile_Request) String() string {
 func (*OpenDependencyLockFile_Request) ProtoMessage() {}
 
 func (x *OpenDependencyLockFile_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[19]
+	mi := &file_dependencies_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1063,7 +1131,7 @@ type OpenDependencyLockFile_Response struct {
 
 func (x *OpenDependencyLockFile_Response) Reset() {
 	*x = OpenDependencyLockFile_Response{}
-	mi := &file_dependencies_proto_msgTypes[20]
+	mi := &file_dependencies_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1075,7 +1143,7 @@ func (x *OpenDependencyLockFile_Response) String() string {
 func (*OpenDependencyLockFile_Response) ProtoMessage() {}
 
 func (x *OpenDependencyLockFile_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[20]
+	mi := &file_dependencies_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1120,7 +1188,7 @@ type CreateDependencyLocks_Request struct {
 
 func (x *CreateDependencyLocks_Request) Reset() {
 	*x = CreateDependencyLocks_Request{}
-	mi := &file_dependencies_proto_msgTypes[21]
+	mi := &file_dependencies_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1132,7 +1200,7 @@ func (x *CreateDependencyLocks_Request) String() string {
 func (*CreateDependencyLocks_Request) ProtoMessage() {}
 
 func (x *CreateDependencyLocks_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[21]
+	mi := &file_dependencies_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1164,7 +1232,7 @@ type CreateDependencyLocks_Response struct {
 
 func (x *CreateDependencyLocks_Response) Reset() {
 	*x = CreateDependencyLocks_Response{}
-	mi := &file_dependencies_proto_msgTypes[22]
+	mi := &file_dependencies_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1176,7 +1244,7 @@ func (x *CreateDependencyLocks_Response) String() string {
 func (*CreateDependencyLocks_Response) ProtoMessage() {}
 
 func (x *CreateDependencyLocks_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[22]
+	mi := &file_dependencies_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1208,7 +1276,7 @@ type CloseDependencyLocks_Request struct {
 
 func (x *CloseDependencyLocks_Request) Reset() {
 	*x = CloseDependencyLocks_Request{}
-	mi := &file_dependencies_proto_msgTypes[23]
+	mi := &file_dependencies_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1220,7 +1288,7 @@ func (x *CloseDependencyLocks_Request) String() string {
 func (*CloseDependencyLocks_Request) ProtoMessage() {}
 
 func (x *CloseDependencyLocks_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[23]
+	mi := &file_dependencies_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1251,7 +1319,7 @@ type CloseDependencyLocks_Response struct {
 
 func (x *CloseDependencyLocks_Response) Reset() {
 	*x = CloseDependencyLocks_Response{}
-	mi := &file_dependencies_proto_msgTypes[24]
+	mi := &file_dependencies_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1263,7 +1331,7 @@ func (x *CloseDependencyLocks_Response) String() string {
 func (*CloseDependencyLocks_Response) ProtoMessage() {}
 
 func (x *CloseDependencyLocks_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[24]
+	mi := &file_dependencies_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1288,7 +1356,7 @@ type GetLockedProviderDependencies_Request struct {
 
 func (x *GetLockedProviderDependencies_Request) Reset() {
 	*x = GetLockedProviderDependencies_Request{}
-	mi := &file_dependencies_proto_msgTypes[25]
+	mi := &file_dependencies_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1300,7 +1368,7 @@ func (x *GetLockedProviderDependencies_Request) String() string {
 func (*GetLockedProviderDependencies_Request) ProtoMessage() {}
 
 func (x *GetLockedProviderDependencies_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[25]
+	mi := &file_dependencies_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1332,7 +1400,7 @@ type GetLockedProviderDependencies_Response struct {
 
 func (x *GetLockedProviderDependencies_Response) Reset() {
 	*x = GetLockedProviderDependencies_Response{}
-	mi := &file_dependencies_proto_msgTypes[26]
+	mi := &file_dependencies_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1344,7 +1412,7 @@ func (x *GetLockedProviderDependencies_Response) String() string {
 func (*GetLockedProviderDependencies_Response) ProtoMessage() {}
 
 func (x *GetLockedProviderDependencies_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[26]
+	mi := &file_dependencies_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1381,13 +1449,18 @@ type BuildProviderPluginCache_Request struct {
 	// server's then the generated cache directory will appear empty to
 	// other operations on this server.
 	OverridePlatform string `protobuf:"bytes,4,opt,name=override_platform,json=overridePlatform,proto3" json:"override_platform,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// The path to the tfpolicy-plugin to use for evaluating policies. If omitted will skip policy evaluation.
+	TfpolicyPluginPath *string `protobuf:"bytes,5,opt,name=tfpolicy_plugin_path,json=tfpolicyPluginPath,proto3,oneof" json:"tfpolicy_plugin_path,omitempty"`
+	// Paths to the policies to evaluate. If no policies are provided, will skip policy evaluation.
+	PolicyPaths       []string                      `protobuf:"bytes,6,rep,name=policy_paths,json=policyPaths,proto3" json:"policy_paths,omitempty"`
+	PolicyEntitlement *terraform1.PolicyEntitlement `protobuf:"bytes,7,opt,name=policy_entitlement,json=policyEntitlement,proto3" json:"policy_entitlement,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *BuildProviderPluginCache_Request) Reset() {
 	*x = BuildProviderPluginCache_Request{}
-	mi := &file_dependencies_proto_msgTypes[27]
+	mi := &file_dependencies_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1399,7 +1472,7 @@ func (x *BuildProviderPluginCache_Request) String() string {
 func (*BuildProviderPluginCache_Request) ProtoMessage() {}
 
 func (x *BuildProviderPluginCache_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[27]
+	mi := &file_dependencies_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1443,6 +1516,27 @@ func (x *BuildProviderPluginCache_Request) GetOverridePlatform() string {
 	return ""
 }
 
+func (x *BuildProviderPluginCache_Request) GetTfpolicyPluginPath() string {
+	if x != nil && x.TfpolicyPluginPath != nil {
+		return *x.TfpolicyPluginPath
+	}
+	return ""
+}
+
+func (x *BuildProviderPluginCache_Request) GetPolicyPaths() []string {
+	if x != nil {
+		return x.PolicyPaths
+	}
+	return nil
+}
+
+func (x *BuildProviderPluginCache_Request) GetPolicyEntitlement() *terraform1.PolicyEntitlement {
+	if x != nil {
+		return x.PolicyEntitlement
+	}
+	return nil
+}
+
 type BuildProviderPluginCache_Event struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Event:
@@ -1456,6 +1550,7 @@ type BuildProviderPluginCache_Event struct {
 	//	*BuildProviderPluginCache_Event_FetchBegin_
 	//	*BuildProviderPluginCache_Event_FetchComplete_
 	//	*BuildProviderPluginCache_Event_Diagnostic
+	//	*BuildProviderPluginCache_Event_ProviderInstallPolicyEvaluation
 	Event         isBuildProviderPluginCache_Event_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1463,7 +1558,7 @@ type BuildProviderPluginCache_Event struct {
 
 func (x *BuildProviderPluginCache_Event) Reset() {
 	*x = BuildProviderPluginCache_Event{}
-	mi := &file_dependencies_proto_msgTypes[28]
+	mi := &file_dependencies_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1475,7 +1570,7 @@ func (x *BuildProviderPluginCache_Event) String() string {
 func (*BuildProviderPluginCache_Event) ProtoMessage() {}
 
 func (x *BuildProviderPluginCache_Event) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[28]
+	mi := &file_dependencies_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1579,6 +1674,15 @@ func (x *BuildProviderPluginCache_Event) GetDiagnostic() *terraform1.Diagnostic 
 	return nil
 }
 
+func (x *BuildProviderPluginCache_Event) GetProviderInstallPolicyEvaluation() *ProviderInstallPolicyEvaluation {
+	if x != nil {
+		if x, ok := x.Event.(*BuildProviderPluginCache_Event_ProviderInstallPolicyEvaluation); ok {
+			return x.ProviderInstallPolicyEvaluation
+		}
+	}
+	return nil
+}
+
 type isBuildProviderPluginCache_Event_Event interface {
 	isBuildProviderPluginCache_Event_Event()
 }
@@ -1619,6 +1723,10 @@ type BuildProviderPluginCache_Event_Diagnostic struct {
 	Diagnostic *terraform1.Diagnostic `protobuf:"bytes,9,opt,name=diagnostic,proto3,oneof"`
 }
 
+type BuildProviderPluginCache_Event_ProviderInstallPolicyEvaluation struct {
+	ProviderInstallPolicyEvaluation *ProviderInstallPolicyEvaluation `protobuf:"bytes,10,opt,name=provider_install_policy_evaluation,json=providerInstallPolicyEvaluation,proto3,oneof"`
+}
+
 func (*BuildProviderPluginCache_Event_Pending_) isBuildProviderPluginCache_Event_Event() {}
 
 func (*BuildProviderPluginCache_Event_AlreadyInstalled) isBuildProviderPluginCache_Event_Event() {}
@@ -1637,6 +1745,9 @@ func (*BuildProviderPluginCache_Event_FetchComplete_) isBuildProviderPluginCache
 
 func (*BuildProviderPluginCache_Event_Diagnostic) isBuildProviderPluginCache_Event_Event() {}
 
+func (*BuildProviderPluginCache_Event_ProviderInstallPolicyEvaluation) isBuildProviderPluginCache_Event_Event() {
+}
+
 type BuildProviderPluginCache_Request_InstallMethod struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Source:
@@ -1653,7 +1764,7 @@ type BuildProviderPluginCache_Request_InstallMethod struct {
 
 func (x *BuildProviderPluginCache_Request_InstallMethod) Reset() {
 	*x = BuildProviderPluginCache_Request_InstallMethod{}
-	mi := &file_dependencies_proto_msgTypes[29]
+	mi := &file_dependencies_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1665,7 +1776,7 @@ func (x *BuildProviderPluginCache_Request_InstallMethod) String() string {
 func (*BuildProviderPluginCache_Request_InstallMethod) ProtoMessage() {}
 
 func (x *BuildProviderPluginCache_Request_InstallMethod) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[29]
+	mi := &file_dependencies_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1763,7 +1874,7 @@ type BuildProviderPluginCache_Event_Pending struct {
 
 func (x *BuildProviderPluginCache_Event_Pending) Reset() {
 	*x = BuildProviderPluginCache_Event_Pending{}
-	mi := &file_dependencies_proto_msgTypes[30]
+	mi := &file_dependencies_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1775,7 +1886,7 @@ func (x *BuildProviderPluginCache_Event_Pending) String() string {
 func (*BuildProviderPluginCache_Event_Pending) ProtoMessage() {}
 
 func (x *BuildProviderPluginCache_Event_Pending) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[30]
+	mi := &file_dependencies_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1808,7 +1919,7 @@ type BuildProviderPluginCache_Event_ProviderConstraints struct {
 
 func (x *BuildProviderPluginCache_Event_ProviderConstraints) Reset() {
 	*x = BuildProviderPluginCache_Event_ProviderConstraints{}
-	mi := &file_dependencies_proto_msgTypes[31]
+	mi := &file_dependencies_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1820,7 +1931,7 @@ func (x *BuildProviderPluginCache_Event_ProviderConstraints) String() string {
 func (*BuildProviderPluginCache_Event_ProviderConstraints) ProtoMessage() {}
 
 func (x *BuildProviderPluginCache_Event_ProviderConstraints) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[31]
+	mi := &file_dependencies_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1860,7 +1971,7 @@ type BuildProviderPluginCache_Event_ProviderVersion struct {
 
 func (x *BuildProviderPluginCache_Event_ProviderVersion) Reset() {
 	*x = BuildProviderPluginCache_Event_ProviderVersion{}
-	mi := &file_dependencies_proto_msgTypes[32]
+	mi := &file_dependencies_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1872,7 +1983,7 @@ func (x *BuildProviderPluginCache_Event_ProviderVersion) String() string {
 func (*BuildProviderPluginCache_Event_ProviderVersion) ProtoMessage() {}
 
 func (x *BuildProviderPluginCache_Event_ProviderVersion) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[32]
+	mi := &file_dependencies_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1912,7 +2023,7 @@ type BuildProviderPluginCache_Event_ProviderWarnings struct {
 
 func (x *BuildProviderPluginCache_Event_ProviderWarnings) Reset() {
 	*x = BuildProviderPluginCache_Event_ProviderWarnings{}
-	mi := &file_dependencies_proto_msgTypes[33]
+	mi := &file_dependencies_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1924,7 +2035,7 @@ func (x *BuildProviderPluginCache_Event_ProviderWarnings) String() string {
 func (*BuildProviderPluginCache_Event_ProviderWarnings) ProtoMessage() {}
 
 func (x *BuildProviderPluginCache_Event_ProviderWarnings) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[33]
+	mi := &file_dependencies_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1964,7 +2075,7 @@ type BuildProviderPluginCache_Event_FetchBegin struct {
 
 func (x *BuildProviderPluginCache_Event_FetchBegin) Reset() {
 	*x = BuildProviderPluginCache_Event_FetchBegin{}
-	mi := &file_dependencies_proto_msgTypes[34]
+	mi := &file_dependencies_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1976,7 +2087,7 @@ func (x *BuildProviderPluginCache_Event_FetchBegin) String() string {
 func (*BuildProviderPluginCache_Event_FetchBegin) ProtoMessage() {}
 
 func (x *BuildProviderPluginCache_Event_FetchBegin) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[34]
+	mi := &file_dependencies_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2022,7 +2133,7 @@ type BuildProviderPluginCache_Event_FetchComplete struct {
 
 func (x *BuildProviderPluginCache_Event_FetchComplete) Reset() {
 	*x = BuildProviderPluginCache_Event_FetchComplete{}
-	mi := &file_dependencies_proto_msgTypes[35]
+	mi := &file_dependencies_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2034,7 +2145,7 @@ func (x *BuildProviderPluginCache_Event_FetchComplete) String() string {
 func (*BuildProviderPluginCache_Event_FetchComplete) ProtoMessage() {}
 
 func (x *BuildProviderPluginCache_Event_FetchComplete) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[35]
+	mi := &file_dependencies_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2089,7 +2200,7 @@ type OpenProviderPluginCache_Request struct {
 
 func (x *OpenProviderPluginCache_Request) Reset() {
 	*x = OpenProviderPluginCache_Request{}
-	mi := &file_dependencies_proto_msgTypes[36]
+	mi := &file_dependencies_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2101,7 +2212,7 @@ func (x *OpenProviderPluginCache_Request) String() string {
 func (*OpenProviderPluginCache_Request) ProtoMessage() {}
 
 func (x *OpenProviderPluginCache_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[36]
+	mi := &file_dependencies_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2140,7 +2251,7 @@ type OpenProviderPluginCache_Response struct {
 
 func (x *OpenProviderPluginCache_Response) Reset() {
 	*x = OpenProviderPluginCache_Response{}
-	mi := &file_dependencies_proto_msgTypes[37]
+	mi := &file_dependencies_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2152,7 +2263,7 @@ func (x *OpenProviderPluginCache_Response) String() string {
 func (*OpenProviderPluginCache_Response) ProtoMessage() {}
 
 func (x *OpenProviderPluginCache_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[37]
+	mi := &file_dependencies_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2184,7 +2295,7 @@ type CloseProviderPluginCache_Request struct {
 
 func (x *CloseProviderPluginCache_Request) Reset() {
 	*x = CloseProviderPluginCache_Request{}
-	mi := &file_dependencies_proto_msgTypes[38]
+	mi := &file_dependencies_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2196,7 +2307,7 @@ func (x *CloseProviderPluginCache_Request) String() string {
 func (*CloseProviderPluginCache_Request) ProtoMessage() {}
 
 func (x *CloseProviderPluginCache_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[38]
+	mi := &file_dependencies_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2227,7 +2338,7 @@ type CloseProviderPluginCache_Response struct {
 
 func (x *CloseProviderPluginCache_Response) Reset() {
 	*x = CloseProviderPluginCache_Response{}
-	mi := &file_dependencies_proto_msgTypes[39]
+	mi := &file_dependencies_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2239,7 +2350,7 @@ func (x *CloseProviderPluginCache_Response) String() string {
 func (*CloseProviderPluginCache_Response) ProtoMessage() {}
 
 func (x *CloseProviderPluginCache_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[39]
+	mi := &file_dependencies_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2264,7 +2375,7 @@ type GetCachedProviders_Request struct {
 
 func (x *GetCachedProviders_Request) Reset() {
 	*x = GetCachedProviders_Request{}
-	mi := &file_dependencies_proto_msgTypes[40]
+	mi := &file_dependencies_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2276,7 +2387,7 @@ func (x *GetCachedProviders_Request) String() string {
 func (*GetCachedProviders_Request) ProtoMessage() {}
 
 func (x *GetCachedProviders_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[40]
+	mi := &file_dependencies_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2308,7 +2419,7 @@ type GetCachedProviders_Response struct {
 
 func (x *GetCachedProviders_Response) Reset() {
 	*x = GetCachedProviders_Response{}
-	mi := &file_dependencies_proto_msgTypes[41]
+	mi := &file_dependencies_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2320,7 +2431,7 @@ func (x *GetCachedProviders_Response) String() string {
 func (*GetCachedProviders_Response) ProtoMessage() {}
 
 func (x *GetCachedProviders_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[41]
+	mi := &file_dependencies_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2351,7 +2462,7 @@ type GetBuiltInProviders_Request struct {
 
 func (x *GetBuiltInProviders_Request) Reset() {
 	*x = GetBuiltInProviders_Request{}
-	mi := &file_dependencies_proto_msgTypes[42]
+	mi := &file_dependencies_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2363,7 +2474,7 @@ func (x *GetBuiltInProviders_Request) String() string {
 func (*GetBuiltInProviders_Request) ProtoMessage() {}
 
 func (x *GetBuiltInProviders_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[42]
+	mi := &file_dependencies_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2395,7 +2506,7 @@ type GetBuiltInProviders_Response struct {
 
 func (x *GetBuiltInProviders_Response) Reset() {
 	*x = GetBuiltInProviders_Response{}
-	mi := &file_dependencies_proto_msgTypes[43]
+	mi := &file_dependencies_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2407,7 +2518,7 @@ func (x *GetBuiltInProviders_Response) String() string {
 func (*GetBuiltInProviders_Response) ProtoMessage() {}
 
 func (x *GetBuiltInProviders_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[43]
+	mi := &file_dependencies_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2462,7 +2573,7 @@ type GetProviderSchema_Request struct {
 
 func (x *GetProviderSchema_Request) Reset() {
 	*x = GetProviderSchema_Request{}
-	mi := &file_dependencies_proto_msgTypes[44]
+	mi := &file_dependencies_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2474,7 +2585,7 @@ func (x *GetProviderSchema_Request) String() string {
 func (*GetProviderSchema_Request) ProtoMessage() {}
 
 func (x *GetProviderSchema_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[44]
+	mi := &file_dependencies_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2520,7 +2631,7 @@ type GetProviderSchema_Response struct {
 
 func (x *GetProviderSchema_Response) Reset() {
 	*x = GetProviderSchema_Response{}
-	mi := &file_dependencies_proto_msgTypes[45]
+	mi := &file_dependencies_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2532,7 +2643,7 @@ func (x *GetProviderSchema_Response) String() string {
 func (*GetProviderSchema_Response) ProtoMessage() {}
 
 func (x *GetProviderSchema_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[45]
+	mi := &file_dependencies_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2567,7 +2678,7 @@ type Schema_Block struct {
 
 func (x *Schema_Block) Reset() {
 	*x = Schema_Block{}
-	mi := &file_dependencies_proto_msgTypes[49]
+	mi := &file_dependencies_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2579,7 +2690,7 @@ func (x *Schema_Block) String() string {
 func (*Schema_Block) ProtoMessage() {}
 
 func (x *Schema_Block) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[49]
+	mi := &file_dependencies_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2640,7 +2751,7 @@ type Schema_Attribute struct {
 
 func (x *Schema_Attribute) Reset() {
 	*x = Schema_Attribute{}
-	mi := &file_dependencies_proto_msgTypes[50]
+	mi := &file_dependencies_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2652,7 +2763,7 @@ func (x *Schema_Attribute) String() string {
 func (*Schema_Attribute) ProtoMessage() {}
 
 func (x *Schema_Attribute) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[50]
+	mi := &file_dependencies_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2742,7 +2853,7 @@ type Schema_NestedBlock struct {
 
 func (x *Schema_NestedBlock) Reset() {
 	*x = Schema_NestedBlock{}
-	mi := &file_dependencies_proto_msgTypes[51]
+	mi := &file_dependencies_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2754,7 +2865,7 @@ func (x *Schema_NestedBlock) String() string {
 func (*Schema_NestedBlock) ProtoMessage() {}
 
 func (x *Schema_NestedBlock) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[51]
+	mi := &file_dependencies_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2801,7 +2912,7 @@ type Schema_Object struct {
 
 func (x *Schema_Object) Reset() {
 	*x = Schema_Object{}
-	mi := &file_dependencies_proto_msgTypes[52]
+	mi := &file_dependencies_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2813,7 +2924,7 @@ func (x *Schema_Object) String() string {
 func (*Schema_Object) ProtoMessage() {}
 
 func (x *Schema_Object) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[52]
+	mi := &file_dependencies_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2853,7 +2964,7 @@ type Schema_DocString struct {
 
 func (x *Schema_DocString) Reset() {
 	*x = Schema_DocString{}
-	mi := &file_dependencies_proto_msgTypes[53]
+	mi := &file_dependencies_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2865,7 +2976,7 @@ func (x *Schema_DocString) String() string {
 func (*Schema_DocString) ProtoMessage() {}
 
 func (x *Schema_DocString) ProtoReflect() protoreflect.Message {
-	mi := &file_dependencies_proto_msgTypes[53]
+	mi := &file_dependencies_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2932,20 +3043,24 @@ const file_dependencies_proto_rawDesc = "" +
 	"\aRequest\x126\n" +
 	"\x17dependency_locks_handle\x18\x01 \x01(\x03R\x15dependencyLocksHandle\x1aV\n" +
 	"\bResponse\x12J\n" +
-	"\x12selected_providers\x18\x01 \x03(\v2\x1b.terraform1.ProviderPackageR\x11selectedProviders\"\xb4\x12\n" +
-	"\x18BuildProviderPluginCache\x1a\xcd\x03\n" +
+	"\x12selected_providers\x18\x01 \x03(\v2\x1b.terraform1.ProviderPackageR\x11selectedProviders\"\xff\x14\n" +
+	"\x18BuildProviderPluginCache\x1a\x8e\x05\n" +
 	"\aRequest\x12\x1b\n" +
 	"\tcache_dir\x18\x01 \x01(\tR\bcacheDir\x126\n" +
 	"\x17dependency_locks_handle\x18\x02 \x01(\x03R\x15dependencyLocksHandle\x12z\n" +
 	"\x14installation_methods\x18\x03 \x03(\v2G.terraform1.dependencies.BuildProviderPluginCache.Request.InstallMethodR\x13installationMethods\x12+\n" +
-	"\x11override_platform\x18\x04 \x01(\tR\x10overridePlatform\x1a\xc3\x01\n" +
+	"\x11override_platform\x18\x04 \x01(\tR\x10overridePlatform\x125\n" +
+	"\x14tfpolicy_plugin_path\x18\x05 \x01(\tH\x00R\x12tfpolicyPluginPath\x88\x01\x01\x12!\n" +
+	"\fpolicy_paths\x18\x06 \x03(\tR\vpolicyPaths\x12L\n" +
+	"\x12policy_entitlement\x18\a \x01(\v2\x1d.terraform1.PolicyEntitlementR\x11policyEntitlement\x1a\xc3\x01\n" +
 	"\rInstallMethod\x12\x18\n" +
 	"\x06direct\x18\x01 \x01(\bH\x00R\x06direct\x12*\n" +
 	"\x10local_mirror_dir\x18\x02 \x01(\tH\x00R\x0elocalMirrorDir\x12.\n" +
 	"\x12network_mirror_url\x18\x03 \x01(\tH\x00R\x10networkMirrorUrl\x12\x18\n" +
 	"\ainclude\x18\x04 \x03(\tR\ainclude\x12\x18\n" +
 	"\aexclude\x18\x05 \x03(\tR\aexcludeB\b\n" +
-	"\x06source\x1a\xc7\x0e\n" +
+	"\x06sourceB\x17\n" +
+	"\x15_tfpolicy_plugin_path\x1a\xd1\x0f\n" +
 	"\x05Event\x12[\n" +
 	"\apending\x18\x01 \x01(\v2?.terraform1.dependencies.BuildProviderPluginCache.Event.PendingH\x00R\apending\x12v\n" +
 	"\x11already_installed\x18\x02 \x01(\v2G.terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersionH\x00R\x10alreadyInstalled\x12d\n" +
@@ -2959,7 +3074,9 @@ const file_dependencies_proto_rawDesc = "" +
 	"\x0efetch_complete\x18\b \x01(\v2E.terraform1.dependencies.BuildProviderPluginCache.Event.FetchCompleteH\x00R\rfetchComplete\x128\n" +
 	"\n" +
 	"diagnostic\x18\t \x01(\v2\x16.terraform1.DiagnosticH\x00R\n" +
-	"diagnostic\x1ar\n" +
+	"diagnostic\x12\x87\x01\n" +
+	"\"provider_install_policy_evaluation\x18\n" +
+	" \x01(\v28.terraform1.dependencies.ProviderInstallPolicyEvaluationH\x00R\x1fproviderInstallPolicyEvaluation\x1ar\n" +
 	"\aPending\x12g\n" +
 	"\bexpected\x18\x01 \x03(\v2K.terraform1.dependencies.BuildProviderPluginCache.Event.ProviderConstraintsR\bexpected\x1aR\n" +
 	"\x13ProviderConstraints\x12\x1f\n" +
@@ -3090,7 +3207,12 @@ const file_dependencies_proto_rawDesc = "" +
 	"\x06format\x18\x02 \x01(\x0e20.terraform1.dependencies.Schema.DocString.FormatR\x06format\"!\n" +
 	"\x06Format\x12\t\n" +
 	"\x05PLAIN\x10\x00\x12\f\n" +
-	"\bMARKDOWN\x10\x012\x87\r\n" +
+	"\bMARKDOWN\x10\x01\"\xd7\x01\n" +
+	"\x1fProviderInstallPolicyEvaluation\x12\x12\n" +
+	"\x04addr\x18\x01 \x01(\tR\x04addr\x122\n" +
+	"\aresults\x18\x02 \x03(\v2\x18.terraform1.PolicyResultR\aresults\x12,\n" +
+	"\x05infos\x18\x03 \x03(\v2\x16.terraform1.PolicyInfoR\x05infos\x12>\n" +
+	"\vdiagnostics\x18\x04 \x03(\v2\x1c.terraform1.PolicyDiagnosticR\vdiagnostics2\x87\r\n" +
 	"\fDependencies\x12y\n" +
 	"\x10OpenSourceBundle\x121.terraform1.dependencies.OpenSourceBundle.Request\x1a2.terraform1.dependencies.OpenSourceBundle.Response\x12|\n" +
 	"\x11CloseSourceBundle\x122.terraform1.dependencies.CloseSourceBundle.Request\x1a3.terraform1.dependencies.CloseSourceBundle.Response\x12\x8b\x01\n" +
@@ -3118,7 +3240,7 @@ func file_dependencies_proto_rawDescGZIP() []byte {
 }
 
 var file_dependencies_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_dependencies_proto_msgTypes = make([]protoimpl.MessageInfo, 54)
+var file_dependencies_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
 var file_dependencies_proto_goTypes = []any{
 	(BuildProviderPluginCache_Event_FetchComplete_AuthResult)(0), // 0: terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete.AuthResult
 	(Schema_NestedBlock_NestingMode)(0),                          // 1: terraform1.dependencies.Schema.NestedBlock.NestingMode
@@ -3139,119 +3261,129 @@ var file_dependencies_proto_goTypes = []any{
 	(*ProviderSchema)(nil),                                       // 16: terraform1.dependencies.ProviderSchema
 	(*ActionSchema)(nil),                                         // 17: terraform1.dependencies.ActionSchema
 	(*Schema)(nil),                                               // 18: terraform1.dependencies.Schema
-	(*OpenSourceBundle_Request)(nil),                             // 19: terraform1.dependencies.OpenSourceBundle.Request
-	(*OpenSourceBundle_Response)(nil),                            // 20: terraform1.dependencies.OpenSourceBundle.Response
-	(*CloseSourceBundle_Request)(nil),                            // 21: terraform1.dependencies.CloseSourceBundle.Request
-	(*CloseSourceBundle_Response)(nil),                           // 22: terraform1.dependencies.CloseSourceBundle.Response
-	(*OpenDependencyLockFile_Request)(nil),                       // 23: terraform1.dependencies.OpenDependencyLockFile.Request
-	(*OpenDependencyLockFile_Response)(nil),                      // 24: terraform1.dependencies.OpenDependencyLockFile.Response
-	(*CreateDependencyLocks_Request)(nil),                        // 25: terraform1.dependencies.CreateDependencyLocks.Request
-	(*CreateDependencyLocks_Response)(nil),                       // 26: terraform1.dependencies.CreateDependencyLocks.Response
-	(*CloseDependencyLocks_Request)(nil),                         // 27: terraform1.dependencies.CloseDependencyLocks.Request
-	(*CloseDependencyLocks_Response)(nil),                        // 28: terraform1.dependencies.CloseDependencyLocks.Response
-	(*GetLockedProviderDependencies_Request)(nil),                // 29: terraform1.dependencies.GetLockedProviderDependencies.Request
-	(*GetLockedProviderDependencies_Response)(nil),               // 30: terraform1.dependencies.GetLockedProviderDependencies.Response
-	(*BuildProviderPluginCache_Request)(nil),                     // 31: terraform1.dependencies.BuildProviderPluginCache.Request
-	(*BuildProviderPluginCache_Event)(nil),                       // 32: terraform1.dependencies.BuildProviderPluginCache.Event
-	(*BuildProviderPluginCache_Request_InstallMethod)(nil),       // 33: terraform1.dependencies.BuildProviderPluginCache.Request.InstallMethod
-	(*BuildProviderPluginCache_Event_Pending)(nil),               // 34: terraform1.dependencies.BuildProviderPluginCache.Event.Pending
-	(*BuildProviderPluginCache_Event_ProviderConstraints)(nil),   // 35: terraform1.dependencies.BuildProviderPluginCache.Event.ProviderConstraints
-	(*BuildProviderPluginCache_Event_ProviderVersion)(nil),       // 36: terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
-	(*BuildProviderPluginCache_Event_ProviderWarnings)(nil),      // 37: terraform1.dependencies.BuildProviderPluginCache.Event.ProviderWarnings
-	(*BuildProviderPluginCache_Event_FetchBegin)(nil),            // 38: terraform1.dependencies.BuildProviderPluginCache.Event.FetchBegin
-	(*BuildProviderPluginCache_Event_FetchComplete)(nil),         // 39: terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete
-	(*OpenProviderPluginCache_Request)(nil),                      // 40: terraform1.dependencies.OpenProviderPluginCache.Request
-	(*OpenProviderPluginCache_Response)(nil),                     // 41: terraform1.dependencies.OpenProviderPluginCache.Response
-	(*CloseProviderPluginCache_Request)(nil),                     // 42: terraform1.dependencies.CloseProviderPluginCache.Request
-	(*CloseProviderPluginCache_Response)(nil),                    // 43: terraform1.dependencies.CloseProviderPluginCache.Response
-	(*GetCachedProviders_Request)(nil),                           // 44: terraform1.dependencies.GetCachedProviders.Request
-	(*GetCachedProviders_Response)(nil),                          // 45: terraform1.dependencies.GetCachedProviders.Response
-	(*GetBuiltInProviders_Request)(nil),                          // 46: terraform1.dependencies.GetBuiltInProviders.Request
-	(*GetBuiltInProviders_Response)(nil),                         // 47: terraform1.dependencies.GetBuiltInProviders.Response
-	(*GetProviderSchema_Request)(nil),                            // 48: terraform1.dependencies.GetProviderSchema.Request
-	(*GetProviderSchema_Response)(nil),                           // 49: terraform1.dependencies.GetProviderSchema.Response
-	nil,                                                          // 50: terraform1.dependencies.ProviderSchema.ManagedResourceTypesEntry
-	nil,                                                          // 51: terraform1.dependencies.ProviderSchema.DataResourceTypesEntry
-	nil,                                                          // 52: terraform1.dependencies.ProviderSchema.ActionTypesEntry
-	(*Schema_Block)(nil),                                         // 53: terraform1.dependencies.Schema.Block
-	(*Schema_Attribute)(nil),                                     // 54: terraform1.dependencies.Schema.Attribute
-	(*Schema_NestedBlock)(nil),                                   // 55: terraform1.dependencies.Schema.NestedBlock
-	(*Schema_Object)(nil),                                        // 56: terraform1.dependencies.Schema.Object
-	(*Schema_DocString)(nil),                                     // 57: terraform1.dependencies.Schema.DocString
-	(*terraform1.SourceAddress)(nil),                             // 58: terraform1.SourceAddress
-	(*terraform1.Diagnostic)(nil),                                // 59: terraform1.Diagnostic
-	(*terraform1.ProviderPackage)(nil),                           // 60: terraform1.ProviderPackage
+	(*ProviderInstallPolicyEvaluation)(nil),                      // 19: terraform1.dependencies.ProviderInstallPolicyEvaluation
+	(*OpenSourceBundle_Request)(nil),                             // 20: terraform1.dependencies.OpenSourceBundle.Request
+	(*OpenSourceBundle_Response)(nil),                            // 21: terraform1.dependencies.OpenSourceBundle.Response
+	(*CloseSourceBundle_Request)(nil),                            // 22: terraform1.dependencies.CloseSourceBundle.Request
+	(*CloseSourceBundle_Response)(nil),                           // 23: terraform1.dependencies.CloseSourceBundle.Response
+	(*OpenDependencyLockFile_Request)(nil),                       // 24: terraform1.dependencies.OpenDependencyLockFile.Request
+	(*OpenDependencyLockFile_Response)(nil),                      // 25: terraform1.dependencies.OpenDependencyLockFile.Response
+	(*CreateDependencyLocks_Request)(nil),                        // 26: terraform1.dependencies.CreateDependencyLocks.Request
+	(*CreateDependencyLocks_Response)(nil),                       // 27: terraform1.dependencies.CreateDependencyLocks.Response
+	(*CloseDependencyLocks_Request)(nil),                         // 28: terraform1.dependencies.CloseDependencyLocks.Request
+	(*CloseDependencyLocks_Response)(nil),                        // 29: terraform1.dependencies.CloseDependencyLocks.Response
+	(*GetLockedProviderDependencies_Request)(nil),                // 30: terraform1.dependencies.GetLockedProviderDependencies.Request
+	(*GetLockedProviderDependencies_Response)(nil),               // 31: terraform1.dependencies.GetLockedProviderDependencies.Response
+	(*BuildProviderPluginCache_Request)(nil),                     // 32: terraform1.dependencies.BuildProviderPluginCache.Request
+	(*BuildProviderPluginCache_Event)(nil),                       // 33: terraform1.dependencies.BuildProviderPluginCache.Event
+	(*BuildProviderPluginCache_Request_InstallMethod)(nil),       // 34: terraform1.dependencies.BuildProviderPluginCache.Request.InstallMethod
+	(*BuildProviderPluginCache_Event_Pending)(nil),               // 35: terraform1.dependencies.BuildProviderPluginCache.Event.Pending
+	(*BuildProviderPluginCache_Event_ProviderConstraints)(nil),   // 36: terraform1.dependencies.BuildProviderPluginCache.Event.ProviderConstraints
+	(*BuildProviderPluginCache_Event_ProviderVersion)(nil),       // 37: terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
+	(*BuildProviderPluginCache_Event_ProviderWarnings)(nil),      // 38: terraform1.dependencies.BuildProviderPluginCache.Event.ProviderWarnings
+	(*BuildProviderPluginCache_Event_FetchBegin)(nil),            // 39: terraform1.dependencies.BuildProviderPluginCache.Event.FetchBegin
+	(*BuildProviderPluginCache_Event_FetchComplete)(nil),         // 40: terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete
+	(*OpenProviderPluginCache_Request)(nil),                      // 41: terraform1.dependencies.OpenProviderPluginCache.Request
+	(*OpenProviderPluginCache_Response)(nil),                     // 42: terraform1.dependencies.OpenProviderPluginCache.Response
+	(*CloseProviderPluginCache_Request)(nil),                     // 43: terraform1.dependencies.CloseProviderPluginCache.Request
+	(*CloseProviderPluginCache_Response)(nil),                    // 44: terraform1.dependencies.CloseProviderPluginCache.Response
+	(*GetCachedProviders_Request)(nil),                           // 45: terraform1.dependencies.GetCachedProviders.Request
+	(*GetCachedProviders_Response)(nil),                          // 46: terraform1.dependencies.GetCachedProviders.Response
+	(*GetBuiltInProviders_Request)(nil),                          // 47: terraform1.dependencies.GetBuiltInProviders.Request
+	(*GetBuiltInProviders_Response)(nil),                         // 48: terraform1.dependencies.GetBuiltInProviders.Response
+	(*GetProviderSchema_Request)(nil),                            // 49: terraform1.dependencies.GetProviderSchema.Request
+	(*GetProviderSchema_Response)(nil),                           // 50: terraform1.dependencies.GetProviderSchema.Response
+	nil,                                                          // 51: terraform1.dependencies.ProviderSchema.ManagedResourceTypesEntry
+	nil,                                                          // 52: terraform1.dependencies.ProviderSchema.DataResourceTypesEntry
+	nil,                                                          // 53: terraform1.dependencies.ProviderSchema.ActionTypesEntry
+	(*Schema_Block)(nil),                                         // 54: terraform1.dependencies.Schema.Block
+	(*Schema_Attribute)(nil),                                     // 55: terraform1.dependencies.Schema.Attribute
+	(*Schema_NestedBlock)(nil),                                   // 56: terraform1.dependencies.Schema.NestedBlock
+	(*Schema_Object)(nil),                                        // 57: terraform1.dependencies.Schema.Object
+	(*Schema_DocString)(nil),                                     // 58: terraform1.dependencies.Schema.DocString
+	(*terraform1.PolicyResult)(nil),                              // 59: terraform1.PolicyResult
+	(*terraform1.PolicyInfo)(nil),                                // 60: terraform1.PolicyInfo
+	(*terraform1.PolicyDiagnostic)(nil),                          // 61: terraform1.PolicyDiagnostic
+	(*terraform1.SourceAddress)(nil),                             // 62: terraform1.SourceAddress
+	(*terraform1.Diagnostic)(nil),                                // 63: terraform1.Diagnostic
+	(*terraform1.ProviderPackage)(nil),                           // 64: terraform1.ProviderPackage
+	(*terraform1.PolicyEntitlement)(nil),                         // 65: terraform1.PolicyEntitlement
 }
 var file_dependencies_proto_depIdxs = []int32{
 	18, // 0: terraform1.dependencies.ProviderSchema.provider_config:type_name -> terraform1.dependencies.Schema
-	50, // 1: terraform1.dependencies.ProviderSchema.managed_resource_types:type_name -> terraform1.dependencies.ProviderSchema.ManagedResourceTypesEntry
-	51, // 2: terraform1.dependencies.ProviderSchema.data_resource_types:type_name -> terraform1.dependencies.ProviderSchema.DataResourceTypesEntry
-	52, // 3: terraform1.dependencies.ProviderSchema.action_types:type_name -> terraform1.dependencies.ProviderSchema.ActionTypesEntry
+	51, // 1: terraform1.dependencies.ProviderSchema.managed_resource_types:type_name -> terraform1.dependencies.ProviderSchema.ManagedResourceTypesEntry
+	52, // 2: terraform1.dependencies.ProviderSchema.data_resource_types:type_name -> terraform1.dependencies.ProviderSchema.DataResourceTypesEntry
+	53, // 3: terraform1.dependencies.ProviderSchema.action_types:type_name -> terraform1.dependencies.ProviderSchema.ActionTypesEntry
 	18, // 4: terraform1.dependencies.ActionSchema.schema:type_name -> terraform1.dependencies.Schema
-	53, // 5: terraform1.dependencies.Schema.block:type_name -> terraform1.dependencies.Schema.Block
-	58, // 6: terraform1.dependencies.OpenDependencyLockFile.Request.source_address:type_name -> terraform1.SourceAddress
-	59, // 7: terraform1.dependencies.OpenDependencyLockFile.Response.diagnostics:type_name -> terraform1.Diagnostic
-	60, // 8: terraform1.dependencies.CreateDependencyLocks.Request.provider_selections:type_name -> terraform1.ProviderPackage
-	60, // 9: terraform1.dependencies.GetLockedProviderDependencies.Response.selected_providers:type_name -> terraform1.ProviderPackage
-	33, // 10: terraform1.dependencies.BuildProviderPluginCache.Request.installation_methods:type_name -> terraform1.dependencies.BuildProviderPluginCache.Request.InstallMethod
-	34, // 11: terraform1.dependencies.BuildProviderPluginCache.Event.pending:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.Pending
-	36, // 12: terraform1.dependencies.BuildProviderPluginCache.Event.already_installed:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
-	36, // 13: terraform1.dependencies.BuildProviderPluginCache.Event.built_in:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
-	35, // 14: terraform1.dependencies.BuildProviderPluginCache.Event.query_begin:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderConstraints
-	36, // 15: terraform1.dependencies.BuildProviderPluginCache.Event.query_success:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
-	37, // 16: terraform1.dependencies.BuildProviderPluginCache.Event.query_warnings:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderWarnings
-	38, // 17: terraform1.dependencies.BuildProviderPluginCache.Event.fetch_begin:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.FetchBegin
-	39, // 18: terraform1.dependencies.BuildProviderPluginCache.Event.fetch_complete:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete
-	59, // 19: terraform1.dependencies.BuildProviderPluginCache.Event.diagnostic:type_name -> terraform1.Diagnostic
-	35, // 20: terraform1.dependencies.BuildProviderPluginCache.Event.Pending.expected:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderConstraints
-	36, // 21: terraform1.dependencies.BuildProviderPluginCache.Event.FetchBegin.provider_version:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
-	36, // 22: terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete.provider_version:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
-	0,  // 23: terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete.auth_result:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete.AuthResult
-	60, // 24: terraform1.dependencies.GetCachedProviders.Response.available_providers:type_name -> terraform1.ProviderPackage
-	60, // 25: terraform1.dependencies.GetBuiltInProviders.Response.available_providers:type_name -> terraform1.ProviderPackage
-	16, // 26: terraform1.dependencies.GetProviderSchema.Response.schema:type_name -> terraform1.dependencies.ProviderSchema
-	18, // 27: terraform1.dependencies.ProviderSchema.ManagedResourceTypesEntry.value:type_name -> terraform1.dependencies.Schema
-	18, // 28: terraform1.dependencies.ProviderSchema.DataResourceTypesEntry.value:type_name -> terraform1.dependencies.Schema
-	17, // 29: terraform1.dependencies.ProviderSchema.ActionTypesEntry.value:type_name -> terraform1.dependencies.ActionSchema
-	54, // 30: terraform1.dependencies.Schema.Block.attributes:type_name -> terraform1.dependencies.Schema.Attribute
-	55, // 31: terraform1.dependencies.Schema.Block.block_types:type_name -> terraform1.dependencies.Schema.NestedBlock
-	57, // 32: terraform1.dependencies.Schema.Block.description:type_name -> terraform1.dependencies.Schema.DocString
-	56, // 33: terraform1.dependencies.Schema.Attribute.nested_type:type_name -> terraform1.dependencies.Schema.Object
-	57, // 34: terraform1.dependencies.Schema.Attribute.description:type_name -> terraform1.dependencies.Schema.DocString
-	53, // 35: terraform1.dependencies.Schema.NestedBlock.block:type_name -> terraform1.dependencies.Schema.Block
-	1,  // 36: terraform1.dependencies.Schema.NestedBlock.nesting:type_name -> terraform1.dependencies.Schema.NestedBlock.NestingMode
-	54, // 37: terraform1.dependencies.Schema.Object.attributes:type_name -> terraform1.dependencies.Schema.Attribute
-	2,  // 38: terraform1.dependencies.Schema.Object.nesting:type_name -> terraform1.dependencies.Schema.Object.NestingMode
-	3,  // 39: terraform1.dependencies.Schema.DocString.format:type_name -> terraform1.dependencies.Schema.DocString.Format
-	19, // 40: terraform1.dependencies.Dependencies.OpenSourceBundle:input_type -> terraform1.dependencies.OpenSourceBundle.Request
-	21, // 41: terraform1.dependencies.Dependencies.CloseSourceBundle:input_type -> terraform1.dependencies.CloseSourceBundle.Request
-	23, // 42: terraform1.dependencies.Dependencies.OpenDependencyLockFile:input_type -> terraform1.dependencies.OpenDependencyLockFile.Request
-	25, // 43: terraform1.dependencies.Dependencies.CreateDependencyLocks:input_type -> terraform1.dependencies.CreateDependencyLocks.Request
-	27, // 44: terraform1.dependencies.Dependencies.CloseDependencyLocks:input_type -> terraform1.dependencies.CloseDependencyLocks.Request
-	29, // 45: terraform1.dependencies.Dependencies.GetLockedProviderDependencies:input_type -> terraform1.dependencies.GetLockedProviderDependencies.Request
-	31, // 46: terraform1.dependencies.Dependencies.BuildProviderPluginCache:input_type -> terraform1.dependencies.BuildProviderPluginCache.Request
-	40, // 47: terraform1.dependencies.Dependencies.OpenProviderPluginCache:input_type -> terraform1.dependencies.OpenProviderPluginCache.Request
-	42, // 48: terraform1.dependencies.Dependencies.CloseProviderPluginCache:input_type -> terraform1.dependencies.CloseProviderPluginCache.Request
-	44, // 49: terraform1.dependencies.Dependencies.GetCachedProviders:input_type -> terraform1.dependencies.GetCachedProviders.Request
-	46, // 50: terraform1.dependencies.Dependencies.GetBuiltInProviders:input_type -> terraform1.dependencies.GetBuiltInProviders.Request
-	48, // 51: terraform1.dependencies.Dependencies.GetProviderSchema:input_type -> terraform1.dependencies.GetProviderSchema.Request
-	20, // 52: terraform1.dependencies.Dependencies.OpenSourceBundle:output_type -> terraform1.dependencies.OpenSourceBundle.Response
-	22, // 53: terraform1.dependencies.Dependencies.CloseSourceBundle:output_type -> terraform1.dependencies.CloseSourceBundle.Response
-	24, // 54: terraform1.dependencies.Dependencies.OpenDependencyLockFile:output_type -> terraform1.dependencies.OpenDependencyLockFile.Response
-	26, // 55: terraform1.dependencies.Dependencies.CreateDependencyLocks:output_type -> terraform1.dependencies.CreateDependencyLocks.Response
-	28, // 56: terraform1.dependencies.Dependencies.CloseDependencyLocks:output_type -> terraform1.dependencies.CloseDependencyLocks.Response
-	30, // 57: terraform1.dependencies.Dependencies.GetLockedProviderDependencies:output_type -> terraform1.dependencies.GetLockedProviderDependencies.Response
-	32, // 58: terraform1.dependencies.Dependencies.BuildProviderPluginCache:output_type -> terraform1.dependencies.BuildProviderPluginCache.Event
-	41, // 59: terraform1.dependencies.Dependencies.OpenProviderPluginCache:output_type -> terraform1.dependencies.OpenProviderPluginCache.Response
-	43, // 60: terraform1.dependencies.Dependencies.CloseProviderPluginCache:output_type -> terraform1.dependencies.CloseProviderPluginCache.Response
-	45, // 61: terraform1.dependencies.Dependencies.GetCachedProviders:output_type -> terraform1.dependencies.GetCachedProviders.Response
-	47, // 62: terraform1.dependencies.Dependencies.GetBuiltInProviders:output_type -> terraform1.dependencies.GetBuiltInProviders.Response
-	49, // 63: terraform1.dependencies.Dependencies.GetProviderSchema:output_type -> terraform1.dependencies.GetProviderSchema.Response
-	52, // [52:64] is the sub-list for method output_type
-	40, // [40:52] is the sub-list for method input_type
-	40, // [40:40] is the sub-list for extension type_name
-	40, // [40:40] is the sub-list for extension extendee
-	0,  // [0:40] is the sub-list for field type_name
+	54, // 5: terraform1.dependencies.Schema.block:type_name -> terraform1.dependencies.Schema.Block
+	59, // 6: terraform1.dependencies.ProviderInstallPolicyEvaluation.results:type_name -> terraform1.PolicyResult
+	60, // 7: terraform1.dependencies.ProviderInstallPolicyEvaluation.infos:type_name -> terraform1.PolicyInfo
+	61, // 8: terraform1.dependencies.ProviderInstallPolicyEvaluation.diagnostics:type_name -> terraform1.PolicyDiagnostic
+	62, // 9: terraform1.dependencies.OpenDependencyLockFile.Request.source_address:type_name -> terraform1.SourceAddress
+	63, // 10: terraform1.dependencies.OpenDependencyLockFile.Response.diagnostics:type_name -> terraform1.Diagnostic
+	64, // 11: terraform1.dependencies.CreateDependencyLocks.Request.provider_selections:type_name -> terraform1.ProviderPackage
+	64, // 12: terraform1.dependencies.GetLockedProviderDependencies.Response.selected_providers:type_name -> terraform1.ProviderPackage
+	34, // 13: terraform1.dependencies.BuildProviderPluginCache.Request.installation_methods:type_name -> terraform1.dependencies.BuildProviderPluginCache.Request.InstallMethod
+	65, // 14: terraform1.dependencies.BuildProviderPluginCache.Request.policy_entitlement:type_name -> terraform1.PolicyEntitlement
+	35, // 15: terraform1.dependencies.BuildProviderPluginCache.Event.pending:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.Pending
+	37, // 16: terraform1.dependencies.BuildProviderPluginCache.Event.already_installed:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
+	37, // 17: terraform1.dependencies.BuildProviderPluginCache.Event.built_in:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
+	36, // 18: terraform1.dependencies.BuildProviderPluginCache.Event.query_begin:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderConstraints
+	37, // 19: terraform1.dependencies.BuildProviderPluginCache.Event.query_success:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
+	38, // 20: terraform1.dependencies.BuildProviderPluginCache.Event.query_warnings:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderWarnings
+	39, // 21: terraform1.dependencies.BuildProviderPluginCache.Event.fetch_begin:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.FetchBegin
+	40, // 22: terraform1.dependencies.BuildProviderPluginCache.Event.fetch_complete:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete
+	63, // 23: terraform1.dependencies.BuildProviderPluginCache.Event.diagnostic:type_name -> terraform1.Diagnostic
+	19, // 24: terraform1.dependencies.BuildProviderPluginCache.Event.provider_install_policy_evaluation:type_name -> terraform1.dependencies.ProviderInstallPolicyEvaluation
+	36, // 25: terraform1.dependencies.BuildProviderPluginCache.Event.Pending.expected:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderConstraints
+	37, // 26: terraform1.dependencies.BuildProviderPluginCache.Event.FetchBegin.provider_version:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
+	37, // 27: terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete.provider_version:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.ProviderVersion
+	0,  // 28: terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete.auth_result:type_name -> terraform1.dependencies.BuildProviderPluginCache.Event.FetchComplete.AuthResult
+	64, // 29: terraform1.dependencies.GetCachedProviders.Response.available_providers:type_name -> terraform1.ProviderPackage
+	64, // 30: terraform1.dependencies.GetBuiltInProviders.Response.available_providers:type_name -> terraform1.ProviderPackage
+	16, // 31: terraform1.dependencies.GetProviderSchema.Response.schema:type_name -> terraform1.dependencies.ProviderSchema
+	18, // 32: terraform1.dependencies.ProviderSchema.ManagedResourceTypesEntry.value:type_name -> terraform1.dependencies.Schema
+	18, // 33: terraform1.dependencies.ProviderSchema.DataResourceTypesEntry.value:type_name -> terraform1.dependencies.Schema
+	17, // 34: terraform1.dependencies.ProviderSchema.ActionTypesEntry.value:type_name -> terraform1.dependencies.ActionSchema
+	55, // 35: terraform1.dependencies.Schema.Block.attributes:type_name -> terraform1.dependencies.Schema.Attribute
+	56, // 36: terraform1.dependencies.Schema.Block.block_types:type_name -> terraform1.dependencies.Schema.NestedBlock
+	58, // 37: terraform1.dependencies.Schema.Block.description:type_name -> terraform1.dependencies.Schema.DocString
+	57, // 38: terraform1.dependencies.Schema.Attribute.nested_type:type_name -> terraform1.dependencies.Schema.Object
+	58, // 39: terraform1.dependencies.Schema.Attribute.description:type_name -> terraform1.dependencies.Schema.DocString
+	54, // 40: terraform1.dependencies.Schema.NestedBlock.block:type_name -> terraform1.dependencies.Schema.Block
+	1,  // 41: terraform1.dependencies.Schema.NestedBlock.nesting:type_name -> terraform1.dependencies.Schema.NestedBlock.NestingMode
+	55, // 42: terraform1.dependencies.Schema.Object.attributes:type_name -> terraform1.dependencies.Schema.Attribute
+	2,  // 43: terraform1.dependencies.Schema.Object.nesting:type_name -> terraform1.dependencies.Schema.Object.NestingMode
+	3,  // 44: terraform1.dependencies.Schema.DocString.format:type_name -> terraform1.dependencies.Schema.DocString.Format
+	20, // 45: terraform1.dependencies.Dependencies.OpenSourceBundle:input_type -> terraform1.dependencies.OpenSourceBundle.Request
+	22, // 46: terraform1.dependencies.Dependencies.CloseSourceBundle:input_type -> terraform1.dependencies.CloseSourceBundle.Request
+	24, // 47: terraform1.dependencies.Dependencies.OpenDependencyLockFile:input_type -> terraform1.dependencies.OpenDependencyLockFile.Request
+	26, // 48: terraform1.dependencies.Dependencies.CreateDependencyLocks:input_type -> terraform1.dependencies.CreateDependencyLocks.Request
+	28, // 49: terraform1.dependencies.Dependencies.CloseDependencyLocks:input_type -> terraform1.dependencies.CloseDependencyLocks.Request
+	30, // 50: terraform1.dependencies.Dependencies.GetLockedProviderDependencies:input_type -> terraform1.dependencies.GetLockedProviderDependencies.Request
+	32, // 51: terraform1.dependencies.Dependencies.BuildProviderPluginCache:input_type -> terraform1.dependencies.BuildProviderPluginCache.Request
+	41, // 52: terraform1.dependencies.Dependencies.OpenProviderPluginCache:input_type -> terraform1.dependencies.OpenProviderPluginCache.Request
+	43, // 53: terraform1.dependencies.Dependencies.CloseProviderPluginCache:input_type -> terraform1.dependencies.CloseProviderPluginCache.Request
+	45, // 54: terraform1.dependencies.Dependencies.GetCachedProviders:input_type -> terraform1.dependencies.GetCachedProviders.Request
+	47, // 55: terraform1.dependencies.Dependencies.GetBuiltInProviders:input_type -> terraform1.dependencies.GetBuiltInProviders.Request
+	49, // 56: terraform1.dependencies.Dependencies.GetProviderSchema:input_type -> terraform1.dependencies.GetProviderSchema.Request
+	21, // 57: terraform1.dependencies.Dependencies.OpenSourceBundle:output_type -> terraform1.dependencies.OpenSourceBundle.Response
+	23, // 58: terraform1.dependencies.Dependencies.CloseSourceBundle:output_type -> terraform1.dependencies.CloseSourceBundle.Response
+	25, // 59: terraform1.dependencies.Dependencies.OpenDependencyLockFile:output_type -> terraform1.dependencies.OpenDependencyLockFile.Response
+	27, // 60: terraform1.dependencies.Dependencies.CreateDependencyLocks:output_type -> terraform1.dependencies.CreateDependencyLocks.Response
+	29, // 61: terraform1.dependencies.Dependencies.CloseDependencyLocks:output_type -> terraform1.dependencies.CloseDependencyLocks.Response
+	31, // 62: terraform1.dependencies.Dependencies.GetLockedProviderDependencies:output_type -> terraform1.dependencies.GetLockedProviderDependencies.Response
+	33, // 63: terraform1.dependencies.Dependencies.BuildProviderPluginCache:output_type -> terraform1.dependencies.BuildProviderPluginCache.Event
+	42, // 64: terraform1.dependencies.Dependencies.OpenProviderPluginCache:output_type -> terraform1.dependencies.OpenProviderPluginCache.Response
+	44, // 65: terraform1.dependencies.Dependencies.CloseProviderPluginCache:output_type -> terraform1.dependencies.CloseProviderPluginCache.Response
+	46, // 66: terraform1.dependencies.Dependencies.GetCachedProviders:output_type -> terraform1.dependencies.GetCachedProviders.Response
+	48, // 67: terraform1.dependencies.Dependencies.GetBuiltInProviders:output_type -> terraform1.dependencies.GetBuiltInProviders.Response
+	50, // 68: terraform1.dependencies.Dependencies.GetProviderSchema:output_type -> terraform1.dependencies.GetProviderSchema.Response
+	57, // [57:69] is the sub-list for method output_type
+	45, // [45:57] is the sub-list for method input_type
+	45, // [45:45] is the sub-list for extension type_name
+	45, // [45:45] is the sub-list for extension extendee
+	0,  // [0:45] is the sub-list for field type_name
 }
 
 func init() { file_dependencies_proto_init() }
@@ -3259,7 +3391,8 @@ func file_dependencies_proto_init() {
 	if File_dependencies_proto != nil {
 		return
 	}
-	file_dependencies_proto_msgTypes[28].OneofWrappers = []any{
+	file_dependencies_proto_msgTypes[28].OneofWrappers = []any{}
+	file_dependencies_proto_msgTypes[29].OneofWrappers = []any{
 		(*BuildProviderPluginCache_Event_Pending_)(nil),
 		(*BuildProviderPluginCache_Event_AlreadyInstalled)(nil),
 		(*BuildProviderPluginCache_Event_BuiltIn)(nil),
@@ -3269,8 +3402,9 @@ func file_dependencies_proto_init() {
 		(*BuildProviderPluginCache_Event_FetchBegin_)(nil),
 		(*BuildProviderPluginCache_Event_FetchComplete_)(nil),
 		(*BuildProviderPluginCache_Event_Diagnostic)(nil),
+		(*BuildProviderPluginCache_Event_ProviderInstallPolicyEvaluation)(nil),
 	}
-	file_dependencies_proto_msgTypes[29].OneofWrappers = []any{
+	file_dependencies_proto_msgTypes[30].OneofWrappers = []any{
 		(*BuildProviderPluginCache_Request_InstallMethod_Direct)(nil),
 		(*BuildProviderPluginCache_Request_InstallMethod_LocalMirrorDir)(nil),
 		(*BuildProviderPluginCache_Request_InstallMethod_NetworkMirrorUrl)(nil),
@@ -3281,7 +3415,7 @@ func file_dependencies_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_dependencies_proto_rawDesc), len(file_dependencies_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   54,
+			NumMessages:   55,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/rpcapi/terraform1/dependencies/dependencies.proto
+++ b/internal/rpcapi/terraform1/dependencies/dependencies.proto
@@ -156,6 +156,13 @@ message BuildProviderPluginCache {
     // other operations on this server.
     string override_platform = 4;
 
+
+    // The path to the tfpolicy-plugin to use for evaluating policies. If omitted will skip policy evaluation.
+    optional string tfpolicy_plugin_path = 5;
+    // Paths to the policies to evaluate. If no policies are provided, will skip policy evaluation.
+    repeated string policy_paths = 6; 
+    terraform1.PolicyEntitlement policy_entitlement = 7;
+
     message InstallMethod {
       oneof source {
         bool direct = 1;
@@ -180,6 +187,7 @@ message BuildProviderPluginCache {
       FetchComplete fetch_complete = 8;
 
       terraform1.Diagnostic diagnostic = 9;
+      ProviderInstallPolicyEvaluation provider_install_policy_evaluation = 10;
     }
 
     message Pending {
@@ -383,4 +391,12 @@ message Schema {
       MARKDOWN = 1;
     }
   }
+}
+
+
+message ProviderInstallPolicyEvaluation {
+  string addr = 1;
+  repeated terraform1.PolicyResult results = 2;
+  repeated terraform1.PolicyInfo infos = 3;
+  repeated terraform1.PolicyDiagnostic diagnostics = 4;
 }

--- a/internal/rpcapi/terraform1/stacks/stacks.pb.go
+++ b/internal/rpcapi/terraform1/stacks/stacks.pb.go
@@ -182,65 +182,6 @@ func (ChangeType) EnumDescriptor() ([]byte, []int) {
 	return file_stacks_proto_rawDescGZIP(), []int{2}
 }
 
-// Sourced from: /terraform/internal/policy/proto/types.proto#EvaluateResult
-type EvaluateResult int32
-
-const (
-	EvaluateResult_INVALID_EVALUATE_RESULT     EvaluateResult = 0
-	EvaluateResult_UNKNOWN_EVALUATE_RESULT     EvaluateResult = 1
-	EvaluateResult_ERROR_EVALUATE_RESULT       EvaluateResult = 2
-	EvaluateResult_ALLOW_EVALUATE_RESULT       EvaluateResult = 3
-	EvaluateResult_DENY_EVALUATE_RESULT        EvaluateResult = 4
-	EvaluateResult_SETUP_ERROR_EVALUATE_RESULT EvaluateResult = 5
-)
-
-// Enum value maps for EvaluateResult.
-var (
-	EvaluateResult_name = map[int32]string{
-		0: "INVALID_EVALUATE_RESULT",
-		1: "UNKNOWN_EVALUATE_RESULT",
-		2: "ERROR_EVALUATE_RESULT",
-		3: "ALLOW_EVALUATE_RESULT",
-		4: "DENY_EVALUATE_RESULT",
-		5: "SETUP_ERROR_EVALUATE_RESULT",
-	}
-	EvaluateResult_value = map[string]int32{
-		"INVALID_EVALUATE_RESULT":     0,
-		"UNKNOWN_EVALUATE_RESULT":     1,
-		"ERROR_EVALUATE_RESULT":       2,
-		"ALLOW_EVALUATE_RESULT":       3,
-		"DENY_EVALUATE_RESULT":        4,
-		"SETUP_ERROR_EVALUATE_RESULT": 5,
-	}
-)
-
-func (x EvaluateResult) Enum() *EvaluateResult {
-	p := new(EvaluateResult)
-	*p = x
-	return p
-}
-
-func (x EvaluateResult) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (EvaluateResult) Descriptor() protoreflect.EnumDescriptor {
-	return file_stacks_proto_enumTypes[3].Descriptor()
-}
-
-func (EvaluateResult) Type() protoreflect.EnumType {
-	return &file_stacks_proto_enumTypes[3]
-}
-
-func (x EvaluateResult) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use EvaluateResult.Descriptor instead.
-func (EvaluateResult) EnumDescriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{3}
-}
-
 type FindStackConfigurationComponents_Instances int32
 
 const (
@@ -274,11 +215,11 @@ func (x FindStackConfigurationComponents_Instances) String() string {
 }
 
 func (FindStackConfigurationComponents_Instances) Descriptor() protoreflect.EnumDescriptor {
-	return file_stacks_proto_enumTypes[4].Descriptor()
+	return file_stacks_proto_enumTypes[3].Descriptor()
 }
 
 func (FindStackConfigurationComponents_Instances) Type() protoreflect.EnumType {
-	return &file_stacks_proto_enumTypes[4]
+	return &file_stacks_proto_enumTypes[3]
 }
 
 func (x FindStackConfigurationComponents_Instances) Number() protoreflect.EnumNumber {
@@ -339,11 +280,11 @@ func (x PlannedChange_ActionTriggerEvent) String() string {
 }
 
 func (PlannedChange_ActionTriggerEvent) Descriptor() protoreflect.EnumDescriptor {
-	return file_stacks_proto_enumTypes[5].Descriptor()
+	return file_stacks_proto_enumTypes[4].Descriptor()
 }
 
 func (PlannedChange_ActionTriggerEvent) Type() protoreflect.EnumType {
-	return &file_stacks_proto_enumTypes[5]
+	return &file_stacks_proto_enumTypes[4]
 }
 
 func (x PlannedChange_ActionTriggerEvent) Number() protoreflect.EnumNumber {
@@ -399,11 +340,11 @@ func (x Deferred_Reason) String() string {
 }
 
 func (Deferred_Reason) Descriptor() protoreflect.EnumDescriptor {
-	return file_stacks_proto_enumTypes[6].Descriptor()
+	return file_stacks_proto_enumTypes[5].Descriptor()
 }
 
 func (Deferred_Reason) Type() protoreflect.EnumType {
-	return &file_stacks_proto_enumTypes[6]
+	return &file_stacks_proto_enumTypes[5]
 }
 
 func (x Deferred_Reason) Number() protoreflect.EnumNumber {
@@ -464,11 +405,11 @@ func (x StackChangeProgress_ActionTriggerEvent) String() string {
 }
 
 func (StackChangeProgress_ActionTriggerEvent) Descriptor() protoreflect.EnumDescriptor {
-	return file_stacks_proto_enumTypes[7].Descriptor()
+	return file_stacks_proto_enumTypes[6].Descriptor()
 }
 
 func (StackChangeProgress_ActionTriggerEvent) Type() protoreflect.EnumType {
-	return &file_stacks_proto_enumTypes[7]
+	return &file_stacks_proto_enumTypes[6]
 }
 
 func (x StackChangeProgress_ActionTriggerEvent) Number() protoreflect.EnumNumber {
@@ -528,11 +469,11 @@ func (x StackChangeProgress_ComponentInstanceStatus_Status) String() string {
 }
 
 func (StackChangeProgress_ComponentInstanceStatus_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_stacks_proto_enumTypes[8].Descriptor()
+	return file_stacks_proto_enumTypes[7].Descriptor()
 }
 
 func (StackChangeProgress_ComponentInstanceStatus_Status) Type() protoreflect.EnumType {
-	return &file_stacks_proto_enumTypes[8]
+	return &file_stacks_proto_enumTypes[7]
 }
 
 func (x StackChangeProgress_ComponentInstanceStatus_Status) Number() protoreflect.EnumNumber {
@@ -595,11 +536,11 @@ func (x StackChangeProgress_ResourceInstanceStatus_Status) String() string {
 }
 
 func (StackChangeProgress_ResourceInstanceStatus_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_stacks_proto_enumTypes[9].Descriptor()
+	return file_stacks_proto_enumTypes[8].Descriptor()
 }
 
 func (StackChangeProgress_ResourceInstanceStatus_Status) Type() protoreflect.EnumType {
-	return &file_stacks_proto_enumTypes[9]
+	return &file_stacks_proto_enumTypes[8]
 }
 
 func (x StackChangeProgress_ResourceInstanceStatus_Status) Number() protoreflect.EnumNumber {
@@ -650,11 +591,11 @@ func (x StackChangeProgress_ActionInvocationStatus_Status) String() string {
 }
 
 func (StackChangeProgress_ActionInvocationStatus_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_stacks_proto_enumTypes[10].Descriptor()
+	return file_stacks_proto_enumTypes[9].Descriptor()
 }
 
 func (StackChangeProgress_ActionInvocationStatus_Status) Type() protoreflect.EnumType {
-	return &file_stacks_proto_enumTypes[10]
+	return &file_stacks_proto_enumTypes[9]
 }
 
 func (x StackChangeProgress_ActionInvocationStatus_Status) Number() protoreflect.EnumNumber {
@@ -702,11 +643,11 @@ func (x StackChangeProgress_ProvisionerStatus_Status) String() string {
 }
 
 func (StackChangeProgress_ProvisionerStatus_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_stacks_proto_enumTypes[11].Descriptor()
+	return file_stacks_proto_enumTypes[10].Descriptor()
 }
 
 func (StackChangeProgress_ProvisionerStatus_Status) Type() protoreflect.EnumType {
-	return &file_stacks_proto_enumTypes[11]
+	return &file_stacks_proto_enumTypes[10]
 }
 
 func (x StackChangeProgress_ProvisionerStatus_Status) Number() protoreflect.EnumNumber {
@@ -2298,11 +2239,11 @@ func (*ListResourceIdentities) Descriptor() ([]byte, []int) {
 }
 
 type ComponentInstancePolicyEvaluation struct {
-	state         protoimpl.MessageState        `protogen:"open.v1"`
-	Addr          *ComponentInstanceInStackAddr `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
-	Results       []*PolicyResult               `protobuf:"bytes,2,rep,name=results,proto3" json:"results,omitempty"`
-	Infos         []*PolicyInfo                 `protobuf:"bytes,3,rep,name=infos,proto3" json:"infos,omitempty"`
-	Diagnostics   []*PolicyDiagnostic           `protobuf:"bytes,4,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	state         protoimpl.MessageState         `protogen:"open.v1"`
+	Addr          *ComponentInstanceInStackAddr  `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	Results       []*terraform1.PolicyResult     `protobuf:"bytes,2,rep,name=results,proto3" json:"results,omitempty"`
+	Infos         []*terraform1.PolicyInfo       `protobuf:"bytes,3,rep,name=infos,proto3" json:"infos,omitempty"`
+	Diagnostics   []*terraform1.PolicyDiagnostic `protobuf:"bytes,4,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2344,21 +2285,21 @@ func (x *ComponentInstancePolicyEvaluation) GetAddr() *ComponentInstanceInStackA
 	return nil
 }
 
-func (x *ComponentInstancePolicyEvaluation) GetResults() []*PolicyResult {
+func (x *ComponentInstancePolicyEvaluation) GetResults() []*terraform1.PolicyResult {
 	if x != nil {
 		return x.Results
 	}
 	return nil
 }
 
-func (x *ComponentInstancePolicyEvaluation) GetInfos() []*PolicyInfo {
+func (x *ComponentInstancePolicyEvaluation) GetInfos() []*terraform1.PolicyInfo {
 	if x != nil {
 		return x.Infos
 	}
 	return nil
 }
 
-func (x *ComponentInstancePolicyEvaluation) GetDiagnostics() []*PolicyDiagnostic {
+func (x *ComponentInstancePolicyEvaluation) GetDiagnostics() []*terraform1.PolicyDiagnostic {
 	if x != nil {
 		return x.Diagnostics
 	}
@@ -2366,11 +2307,11 @@ func (x *ComponentInstancePolicyEvaluation) GetDiagnostics() []*PolicyDiagnostic
 }
 
 type ProviderInstancePolicyEvaluation struct {
-	state         protoimpl.MessageState       `protogen:"open.v1"`
-	Addr          *ProviderInstanceInStackAddr `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
-	Results       []*PolicyResult              `protobuf:"bytes,2,rep,name=results,proto3" json:"results,omitempty"`
-	Infos         []*PolicyInfo                `protobuf:"bytes,3,rep,name=infos,proto3" json:"infos,omitempty"`
-	Diagnostics   []*PolicyDiagnostic          `protobuf:"bytes,4,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	state         protoimpl.MessageState         `protogen:"open.v1"`
+	Addr          *ProviderInstanceInStackAddr   `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	Results       []*terraform1.PolicyResult     `protobuf:"bytes,2,rep,name=results,proto3" json:"results,omitempty"`
+	Infos         []*terraform1.PolicyInfo       `protobuf:"bytes,3,rep,name=infos,proto3" json:"infos,omitempty"`
+	Diagnostics   []*terraform1.PolicyDiagnostic `protobuf:"bytes,4,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2412,464 +2353,23 @@ func (x *ProviderInstancePolicyEvaluation) GetAddr() *ProviderInstanceInStackAdd
 	return nil
 }
 
-func (x *ProviderInstancePolicyEvaluation) GetResults() []*PolicyResult {
+func (x *ProviderInstancePolicyEvaluation) GetResults() []*terraform1.PolicyResult {
 	if x != nil {
 		return x.Results
 	}
 	return nil
 }
 
-func (x *ProviderInstancePolicyEvaluation) GetInfos() []*PolicyInfo {
+func (x *ProviderInstancePolicyEvaluation) GetInfos() []*terraform1.PolicyInfo {
 	if x != nil {
 		return x.Infos
 	}
 	return nil
 }
 
-func (x *ProviderInstancePolicyEvaluation) GetDiagnostics() []*PolicyDiagnostic {
+func (x *ProviderInstancePolicyEvaluation) GetDiagnostics() []*terraform1.PolicyDiagnostic {
 	if x != nil {
 		return x.Diagnostics
-	}
-	return nil
-}
-
-type PolicyMetaData struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	PolicyName       string                 `protobuf:"bytes,1,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
-	PolicySetName    string                 `protobuf:"bytes,2,opt,name=policy_set_name,json=policySetName,proto3" json:"policy_set_name,omitempty"`
-	EnforcementLevel string                 `protobuf:"bytes,3,opt,name=enforcement_level,json=enforcementLevel,proto3" json:"enforcement_level,omitempty"`
-	FileName         string                 `protobuf:"bytes,4,opt,name=file_name,json=fileName,proto3" json:"file_name,omitempty"`
-	EnforceIndex     int32                  `protobuf:"varint,5,opt,name=enforce_index,json=enforceIndex,proto3" json:"enforce_index,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
-}
-
-func (x *PolicyMetaData) Reset() {
-	*x = PolicyMetaData{}
-	mi := &file_stacks_proto_msgTypes[31]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PolicyMetaData) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PolicyMetaData) ProtoMessage() {}
-
-func (x *PolicyMetaData) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[31]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PolicyMetaData.ProtoReflect.Descriptor instead.
-func (*PolicyMetaData) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{31}
-}
-
-func (x *PolicyMetaData) GetPolicyName() string {
-	if x != nil {
-		return x.PolicyName
-	}
-	return ""
-}
-
-func (x *PolicyMetaData) GetPolicySetName() string {
-	if x != nil {
-		return x.PolicySetName
-	}
-	return ""
-}
-
-func (x *PolicyMetaData) GetEnforcementLevel() string {
-	if x != nil {
-		return x.EnforcementLevel
-	}
-	return ""
-}
-
-func (x *PolicyMetaData) GetFileName() string {
-	if x != nil {
-		return x.FileName
-	}
-	return ""
-}
-
-func (x *PolicyMetaData) GetEnforceIndex() int32 {
-	if x != nil {
-		return x.EnforceIndex
-	}
-	return 0
-}
-
-type PolicyResult struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	TargetAddress  string                 `protobuf:"bytes,1,opt,name=target_address,json=targetAddress,proto3" json:"target_address,omitempty"`
-	PolicyMetadata *PolicyMetaData        `protobuf:"bytes,2,opt,name=policy_metadata,json=policyMetadata,proto3" json:"policy_metadata,omitempty"`
-	Result         EvaluateResult         `protobuf:"varint,3,opt,name=result,proto3,enum=terraform1.stacks.EvaluateResult" json:"result,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
-}
-
-func (x *PolicyResult) Reset() {
-	*x = PolicyResult{}
-	mi := &file_stacks_proto_msgTypes[32]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PolicyResult) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PolicyResult) ProtoMessage() {}
-
-func (x *PolicyResult) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[32]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PolicyResult.ProtoReflect.Descriptor instead.
-func (*PolicyResult) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{32}
-}
-
-func (x *PolicyResult) GetTargetAddress() string {
-	if x != nil {
-		return x.TargetAddress
-	}
-	return ""
-}
-
-func (x *PolicyResult) GetPolicyMetadata() *PolicyMetaData {
-	if x != nil {
-		return x.PolicyMetadata
-	}
-	return nil
-}
-
-func (x *PolicyResult) GetResult() EvaluateResult {
-	if x != nil {
-		return x.Result
-	}
-	return EvaluateResult_INVALID_EVALUATE_RESULT
-}
-
-type PolicyInfo struct {
-	state          protoimpl.MessageState  `protogen:"open.v1"`
-	TargetAddress  string                  `protobuf:"bytes,1,opt,name=target_address,json=targetAddress,proto3" json:"target_address,omitempty"`
-	PolicyMetadata *PolicyMetaData         `protobuf:"bytes,2,opt,name=policy_metadata,json=policyMetadata,proto3" json:"policy_metadata,omitempty"`
-	Message        string                  `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
-	PolicyRange    *terraform1.SourceRange `protobuf:"bytes,4,opt,name=policy_range,json=policyRange,proto3" json:"policy_range,omitempty"`
-	PolicySnippet  *PolicySnippet          `protobuf:"bytes,5,opt,name=policy_snippet,json=policySnippet,proto3" json:"policy_snippet,omitempty"`
-	Result         EvaluateResult          `protobuf:"varint,6,opt,name=result,proto3,enum=terraform1.stacks.EvaluateResult" json:"result,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
-}
-
-func (x *PolicyInfo) Reset() {
-	*x = PolicyInfo{}
-	mi := &file_stacks_proto_msgTypes[33]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PolicyInfo) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PolicyInfo) ProtoMessage() {}
-
-func (x *PolicyInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[33]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PolicyInfo.ProtoReflect.Descriptor instead.
-func (*PolicyInfo) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{33}
-}
-
-func (x *PolicyInfo) GetTargetAddress() string {
-	if x != nil {
-		return x.TargetAddress
-	}
-	return ""
-}
-
-func (x *PolicyInfo) GetPolicyMetadata() *PolicyMetaData {
-	if x != nil {
-		return x.PolicyMetadata
-	}
-	return nil
-}
-
-func (x *PolicyInfo) GetMessage() string {
-	if x != nil {
-		return x.Message
-	}
-	return ""
-}
-
-func (x *PolicyInfo) GetPolicyRange() *terraform1.SourceRange {
-	if x != nil {
-		return x.PolicyRange
-	}
-	return nil
-}
-
-func (x *PolicyInfo) GetPolicySnippet() *PolicySnippet {
-	if x != nil {
-		return x.PolicySnippet
-	}
-	return nil
-}
-
-func (x *PolicyInfo) GetResult() EvaluateResult {
-	if x != nil {
-		return x.Result
-	}
-	return EvaluateResult_INVALID_EVALUATE_RESULT
-}
-
-type PolicySnippet struct {
-	state                protoimpl.MessageState `protogen:"open.v1"`
-	Context              string                 `protobuf:"bytes,1,opt,name=context,proto3" json:"context,omitempty"`
-	Code                 string                 `protobuf:"bytes,2,opt,name=code,proto3" json:"code,omitempty"`
-	StartLine            int64                  `protobuf:"varint,3,opt,name=start_line,json=startLine,proto3" json:"start_line,omitempty"`
-	HighlightStartOffset int64                  `protobuf:"varint,4,opt,name=highlight_start_offset,json=highlightStartOffset,proto3" json:"highlight_start_offset,omitempty"`
-	HighlightEndOffset   int64                  `protobuf:"varint,5,opt,name=highlight_end_offset,json=highlightEndOffset,proto3" json:"highlight_end_offset,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
-}
-
-func (x *PolicySnippet) Reset() {
-	*x = PolicySnippet{}
-	mi := &file_stacks_proto_msgTypes[34]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PolicySnippet) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PolicySnippet) ProtoMessage() {}
-
-func (x *PolicySnippet) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[34]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PolicySnippet.ProtoReflect.Descriptor instead.
-func (*PolicySnippet) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{34}
-}
-
-func (x *PolicySnippet) GetContext() string {
-	if x != nil {
-		return x.Context
-	}
-	return ""
-}
-
-func (x *PolicySnippet) GetCode() string {
-	if x != nil {
-		return x.Code
-	}
-	return ""
-}
-
-func (x *PolicySnippet) GetStartLine() int64 {
-	if x != nil {
-		return x.StartLine
-	}
-	return 0
-}
-
-func (x *PolicySnippet) GetHighlightStartOffset() int64 {
-	if x != nil {
-		return x.HighlightStartOffset
-	}
-	return 0
-}
-
-func (x *PolicySnippet) GetHighlightEndOffset() int64 {
-	if x != nil {
-		return x.HighlightEndOffset
-	}
-	return 0
-}
-
-type PolicyDiagnostic struct {
-	state            protoimpl.MessageState  `protogen:"open.v1"`
-	TargetAddress    string                  `protobuf:"bytes,1,opt,name=target_address,json=targetAddress,proto3" json:"target_address,omitempty"`
-	PolicyMetadata   *PolicyMetaData         `protobuf:"bytes,2,opt,name=policy_metadata,json=policyMetadata,proto3" json:"policy_metadata,omitempty"`
-	Result           EvaluateResult          `protobuf:"varint,3,opt,name=result,proto3,enum=terraform1.stacks.EvaluateResult" json:"result,omitempty"`
-	Diagnostic       *terraform1.Diagnostic  `protobuf:"bytes,4,opt,name=diagnostic,proto3" json:"diagnostic,omitempty"`
-	PolicySnippet    *PolicySnippet          `protobuf:"bytes,5,opt,name=policy_snippet,json=policySnippet,proto3" json:"policy_snippet,omitempty"`
-	PolicyRange      *terraform1.SourceRange `protobuf:"bytes,6,opt,name=policy_range,json=policyRange,proto3" json:"policy_range,omitempty"`
-	ExpressionValues []*ExpressionValue      `protobuf:"bytes,7,rep,name=expression_values,json=expressionValues,proto3" json:"expression_values,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
-}
-
-func (x *PolicyDiagnostic) Reset() {
-	*x = PolicyDiagnostic{}
-	mi := &file_stacks_proto_msgTypes[35]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PolicyDiagnostic) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PolicyDiagnostic) ProtoMessage() {}
-
-func (x *PolicyDiagnostic) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[35]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PolicyDiagnostic.ProtoReflect.Descriptor instead.
-func (*PolicyDiagnostic) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{35}
-}
-
-func (x *PolicyDiagnostic) GetTargetAddress() string {
-	if x != nil {
-		return x.TargetAddress
-	}
-	return ""
-}
-
-func (x *PolicyDiagnostic) GetPolicyMetadata() *PolicyMetaData {
-	if x != nil {
-		return x.PolicyMetadata
-	}
-	return nil
-}
-
-func (x *PolicyDiagnostic) GetResult() EvaluateResult {
-	if x != nil {
-		return x.Result
-	}
-	return EvaluateResult_INVALID_EVALUATE_RESULT
-}
-
-func (x *PolicyDiagnostic) GetDiagnostic() *terraform1.Diagnostic {
-	if x != nil {
-		return x.Diagnostic
-	}
-	return nil
-}
-
-func (x *PolicyDiagnostic) GetPolicySnippet() *PolicySnippet {
-	if x != nil {
-		return x.PolicySnippet
-	}
-	return nil
-}
-
-func (x *PolicyDiagnostic) GetPolicyRange() *terraform1.SourceRange {
-	if x != nil {
-		return x.PolicyRange
-	}
-	return nil
-}
-
-func (x *PolicyDiagnostic) GetExpressionValues() []*ExpressionValue {
-	if x != nil {
-		return x.ExpressionValues
-	}
-	return nil
-}
-
-// Sourced from: /terraform/internal/policy/proto/diagnostics.proto#ExpressionValue
-type ExpressionValue struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Traversal     *AttributePath         `protobuf:"bytes,1,opt,name=traversal,proto3" json:"traversal,omitempty"`
-	Value         []byte                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *ExpressionValue) Reset() {
-	*x = ExpressionValue{}
-	mi := &file_stacks_proto_msgTypes[36]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ExpressionValue) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ExpressionValue) ProtoMessage() {}
-
-func (x *ExpressionValue) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[36]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use ExpressionValue.ProtoReflect.Descriptor instead.
-func (*ExpressionValue) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{36}
-}
-
-func (x *ExpressionValue) GetTraversal() *AttributePath {
-	if x != nil {
-		return x.Traversal
-	}
-	return nil
-}
-
-func (x *ExpressionValue) GetValue() []byte {
-	if x != nil {
-		return x.Value
 	}
 	return nil
 }
@@ -2887,7 +2387,7 @@ type OpenTerraformState_Request struct {
 
 func (x *OpenTerraformState_Request) Reset() {
 	*x = OpenTerraformState_Request{}
-	mi := &file_stacks_proto_msgTypes[37]
+	mi := &file_stacks_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2899,7 +2399,7 @@ func (x *OpenTerraformState_Request) String() string {
 func (*OpenTerraformState_Request) ProtoMessage() {}
 
 func (x *OpenTerraformState_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[37]
+	mi := &file_stacks_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2968,7 +2468,7 @@ type OpenTerraformState_Response struct {
 
 func (x *OpenTerraformState_Response) Reset() {
 	*x = OpenTerraformState_Response{}
-	mi := &file_stacks_proto_msgTypes[38]
+	mi := &file_stacks_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2980,7 +2480,7 @@ func (x *OpenTerraformState_Response) String() string {
 func (*OpenTerraformState_Response) ProtoMessage() {}
 
 func (x *OpenTerraformState_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[38]
+	mi := &file_stacks_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3019,7 +2519,7 @@ type CloseTerraformState_Request struct {
 
 func (x *CloseTerraformState_Request) Reset() {
 	*x = CloseTerraformState_Request{}
-	mi := &file_stacks_proto_msgTypes[39]
+	mi := &file_stacks_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3031,7 +2531,7 @@ func (x *CloseTerraformState_Request) String() string {
 func (*CloseTerraformState_Request) ProtoMessage() {}
 
 func (x *CloseTerraformState_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[39]
+	mi := &file_stacks_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3062,7 +2562,7 @@ type CloseTerraformState_Response struct {
 
 func (x *CloseTerraformState_Response) Reset() {
 	*x = CloseTerraformState_Response{}
-	mi := &file_stacks_proto_msgTypes[40]
+	mi := &file_stacks_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3074,7 +2574,7 @@ func (x *CloseTerraformState_Response) String() string {
 func (*CloseTerraformState_Response) ProtoMessage() {}
 
 func (x *CloseTerraformState_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[40]
+	mi := &file_stacks_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3106,7 +2606,7 @@ type MigrateTerraformState_Request struct {
 
 func (x *MigrateTerraformState_Request) Reset() {
 	*x = MigrateTerraformState_Request{}
-	mi := &file_stacks_proto_msgTypes[41]
+	mi := &file_stacks_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3118,7 +2618,7 @@ func (x *MigrateTerraformState_Request) String() string {
 func (*MigrateTerraformState_Request) ProtoMessage() {}
 
 func (x *MigrateTerraformState_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[41]
+	mi := &file_stacks_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3202,7 +2702,7 @@ type MigrateTerraformState_Event struct {
 
 func (x *MigrateTerraformState_Event) Reset() {
 	*x = MigrateTerraformState_Event{}
-	mi := &file_stacks_proto_msgTypes[42]
+	mi := &file_stacks_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3214,7 +2714,7 @@ func (x *MigrateTerraformState_Event) String() string {
 func (*MigrateTerraformState_Event) ProtoMessage() {}
 
 func (x *MigrateTerraformState_Event) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[42]
+	mi := &file_stacks_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3302,7 +2802,7 @@ type MigrateTerraformState_Request_Mapping struct {
 
 func (x *MigrateTerraformState_Request_Mapping) Reset() {
 	*x = MigrateTerraformState_Request_Mapping{}
-	mi := &file_stacks_proto_msgTypes[43]
+	mi := &file_stacks_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3314,7 +2814,7 @@ func (x *MigrateTerraformState_Request_Mapping) String() string {
 func (*MigrateTerraformState_Request_Mapping) ProtoMessage() {}
 
 func (x *MigrateTerraformState_Request_Mapping) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[43]
+	mi := &file_stacks_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3354,7 +2854,7 @@ type OpenStackConfiguration_Request struct {
 
 func (x *OpenStackConfiguration_Request) Reset() {
 	*x = OpenStackConfiguration_Request{}
-	mi := &file_stacks_proto_msgTypes[46]
+	mi := &file_stacks_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3366,7 +2866,7 @@ func (x *OpenStackConfiguration_Request) String() string {
 func (*OpenStackConfiguration_Request) ProtoMessage() {}
 
 func (x *OpenStackConfiguration_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[46]
+	mi := &file_stacks_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3406,7 +2906,7 @@ type OpenStackConfiguration_Response struct {
 
 func (x *OpenStackConfiguration_Response) Reset() {
 	*x = OpenStackConfiguration_Response{}
-	mi := &file_stacks_proto_msgTypes[47]
+	mi := &file_stacks_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3418,7 +2918,7 @@ func (x *OpenStackConfiguration_Response) String() string {
 func (*OpenStackConfiguration_Response) ProtoMessage() {}
 
 func (x *OpenStackConfiguration_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[47]
+	mi := &file_stacks_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3457,7 +2957,7 @@ type CloseStackConfiguration_Request struct {
 
 func (x *CloseStackConfiguration_Request) Reset() {
 	*x = CloseStackConfiguration_Request{}
-	mi := &file_stacks_proto_msgTypes[48]
+	mi := &file_stacks_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3469,7 +2969,7 @@ func (x *CloseStackConfiguration_Request) String() string {
 func (*CloseStackConfiguration_Request) ProtoMessage() {}
 
 func (x *CloseStackConfiguration_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[48]
+	mi := &file_stacks_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3500,7 +3000,7 @@ type CloseStackConfiguration_Response struct {
 
 func (x *CloseStackConfiguration_Response) Reset() {
 	*x = CloseStackConfiguration_Response{}
-	mi := &file_stacks_proto_msgTypes[49]
+	mi := &file_stacks_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3512,7 +3012,7 @@ func (x *CloseStackConfiguration_Response) String() string {
 func (*CloseStackConfiguration_Response) ProtoMessage() {}
 
 func (x *CloseStackConfiguration_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[49]
+	mi := &file_stacks_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3539,7 +3039,7 @@ type ValidateStackConfiguration_Request struct {
 
 func (x *ValidateStackConfiguration_Request) Reset() {
 	*x = ValidateStackConfiguration_Request{}
-	mi := &file_stacks_proto_msgTypes[50]
+	mi := &file_stacks_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3551,7 +3051,7 @@ func (x *ValidateStackConfiguration_Request) String() string {
 func (*ValidateStackConfiguration_Request) ProtoMessage() {}
 
 func (x *ValidateStackConfiguration_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[50]
+	mi := &file_stacks_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3597,7 +3097,7 @@ type ValidateStackConfiguration_Response struct {
 
 func (x *ValidateStackConfiguration_Response) Reset() {
 	*x = ValidateStackConfiguration_Response{}
-	mi := &file_stacks_proto_msgTypes[51]
+	mi := &file_stacks_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3609,7 +3109,7 @@ func (x *ValidateStackConfiguration_Response) String() string {
 func (*ValidateStackConfiguration_Response) ProtoMessage() {}
 
 func (x *ValidateStackConfiguration_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[51]
+	mi := &file_stacks_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3641,7 +3141,7 @@ type FindStackConfigurationComponents_Request struct {
 
 func (x *FindStackConfigurationComponents_Request) Reset() {
 	*x = FindStackConfigurationComponents_Request{}
-	mi := &file_stacks_proto_msgTypes[52]
+	mi := &file_stacks_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3653,7 +3153,7 @@ func (x *FindStackConfigurationComponents_Request) String() string {
 func (*FindStackConfigurationComponents_Request) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[52]
+	mi := &file_stacks_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3685,7 +3185,7 @@ type FindStackConfigurationComponents_Response struct {
 
 func (x *FindStackConfigurationComponents_Response) Reset() {
 	*x = FindStackConfigurationComponents_Response{}
-	mi := &file_stacks_proto_msgTypes[53]
+	mi := &file_stacks_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3697,7 +3197,7 @@ func (x *FindStackConfigurationComponents_Response) String() string {
 func (*FindStackConfigurationComponents_Response) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[53]
+	mi := &file_stacks_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3733,7 +3233,7 @@ type FindStackConfigurationComponents_StackConfig struct {
 
 func (x *FindStackConfigurationComponents_StackConfig) Reset() {
 	*x = FindStackConfigurationComponents_StackConfig{}
-	mi := &file_stacks_proto_msgTypes[54]
+	mi := &file_stacks_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3745,7 +3245,7 @@ func (x *FindStackConfigurationComponents_StackConfig) String() string {
 func (*FindStackConfigurationComponents_StackConfig) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_StackConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[54]
+	mi := &file_stacks_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3807,7 +3307,7 @@ type FindStackConfigurationComponents_EmbeddedStack struct {
 
 func (x *FindStackConfigurationComponents_EmbeddedStack) Reset() {
 	*x = FindStackConfigurationComponents_EmbeddedStack{}
-	mi := &file_stacks_proto_msgTypes[55]
+	mi := &file_stacks_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3819,7 +3319,7 @@ func (x *FindStackConfigurationComponents_EmbeddedStack) String() string {
 func (*FindStackConfigurationComponents_EmbeddedStack) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_EmbeddedStack) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[55]
+	mi := &file_stacks_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3867,7 +3367,7 @@ type FindStackConfigurationComponents_Component struct {
 
 func (x *FindStackConfigurationComponents_Component) Reset() {
 	*x = FindStackConfigurationComponents_Component{}
-	mi := &file_stacks_proto_msgTypes[56]
+	mi := &file_stacks_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3879,7 +3379,7 @@ func (x *FindStackConfigurationComponents_Component) String() string {
 func (*FindStackConfigurationComponents_Component) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_Component) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[56]
+	mi := &file_stacks_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3933,7 +3433,7 @@ type FindStackConfigurationComponents_Removed struct {
 
 func (x *FindStackConfigurationComponents_Removed) Reset() {
 	*x = FindStackConfigurationComponents_Removed{}
-	mi := &file_stacks_proto_msgTypes[57]
+	mi := &file_stacks_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3945,7 +3445,7 @@ func (x *FindStackConfigurationComponents_Removed) String() string {
 func (*FindStackConfigurationComponents_Removed) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_Removed) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[57]
+	mi := &file_stacks_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4011,7 +3511,7 @@ type FindStackConfigurationComponents_InputVariable struct {
 
 func (x *FindStackConfigurationComponents_InputVariable) Reset() {
 	*x = FindStackConfigurationComponents_InputVariable{}
-	mi := &file_stacks_proto_msgTypes[58]
+	mi := &file_stacks_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4023,7 +3523,7 @@ func (x *FindStackConfigurationComponents_InputVariable) String() string {
 func (*FindStackConfigurationComponents_InputVariable) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_InputVariable) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[58]
+	mi := &file_stacks_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4070,7 +3570,7 @@ type FindStackConfigurationComponents_OutputValue struct {
 
 func (x *FindStackConfigurationComponents_OutputValue) Reset() {
 	*x = FindStackConfigurationComponents_OutputValue{}
-	mi := &file_stacks_proto_msgTypes[59]
+	mi := &file_stacks_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4082,7 +3582,7 @@ func (x *FindStackConfigurationComponents_OutputValue) String() string {
 func (*FindStackConfigurationComponents_OutputValue) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_OutputValue) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[59]
+	mi := &file_stacks_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4124,7 +3624,7 @@ type FindStackConfigurationComponents_Removed_Block struct {
 
 func (x *FindStackConfigurationComponents_Removed_Block) Reset() {
 	*x = FindStackConfigurationComponents_Removed_Block{}
-	mi := &file_stacks_proto_msgTypes[65]
+	mi := &file_stacks_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4136,7 +3636,7 @@ func (x *FindStackConfigurationComponents_Removed_Block) String() string {
 func (*FindStackConfigurationComponents_Removed_Block) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_Removed_Block) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[65]
+	mi := &file_stacks_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4189,7 +3689,7 @@ type OpenStackState_RequestItem struct {
 
 func (x *OpenStackState_RequestItem) Reset() {
 	*x = OpenStackState_RequestItem{}
-	mi := &file_stacks_proto_msgTypes[66]
+	mi := &file_stacks_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4201,7 +3701,7 @@ func (x *OpenStackState_RequestItem) String() string {
 func (*OpenStackState_RequestItem) ProtoMessage() {}
 
 func (x *OpenStackState_RequestItem) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[66]
+	mi := &file_stacks_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4233,7 +3733,7 @@ type OpenStackState_Response struct {
 
 func (x *OpenStackState_Response) Reset() {
 	*x = OpenStackState_Response{}
-	mi := &file_stacks_proto_msgTypes[67]
+	mi := &file_stacks_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4245,7 +3745,7 @@ func (x *OpenStackState_Response) String() string {
 func (*OpenStackState_Response) ProtoMessage() {}
 
 func (x *OpenStackState_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[67]
+	mi := &file_stacks_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4277,7 +3777,7 @@ type CloseStackState_Request struct {
 
 func (x *CloseStackState_Request) Reset() {
 	*x = CloseStackState_Request{}
-	mi := &file_stacks_proto_msgTypes[68]
+	mi := &file_stacks_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4289,7 +3789,7 @@ func (x *CloseStackState_Request) String() string {
 func (*CloseStackState_Request) ProtoMessage() {}
 
 func (x *CloseStackState_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[68]
+	mi := &file_stacks_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4320,7 +3820,7 @@ type CloseStackState_Response struct {
 
 func (x *CloseStackState_Response) Reset() {
 	*x = CloseStackState_Response{}
-	mi := &file_stacks_proto_msgTypes[69]
+	mi := &file_stacks_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4332,7 +3832,7 @@ func (x *CloseStackState_Response) String() string {
 func (*CloseStackState_Response) ProtoMessage() {}
 
 func (x *CloseStackState_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[69]
+	mi := &file_stacks_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4368,7 +3868,7 @@ type PlanStackChanges_Request struct {
 
 func (x *PlanStackChanges_Request) Reset() {
 	*x = PlanStackChanges_Request{}
-	mi := &file_stacks_proto_msgTypes[70]
+	mi := &file_stacks_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4380,7 +3880,7 @@ func (x *PlanStackChanges_Request) String() string {
 func (*PlanStackChanges_Request) ProtoMessage() {}
 
 func (x *PlanStackChanges_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[70]
+	mi := &file_stacks_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4476,7 +3976,7 @@ type PlanStackChanges_Event struct {
 
 func (x *PlanStackChanges_Event) Reset() {
 	*x = PlanStackChanges_Event{}
-	mi := &file_stacks_proto_msgTypes[71]
+	mi := &file_stacks_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4488,7 +3988,7 @@ func (x *PlanStackChanges_Event) String() string {
 func (*PlanStackChanges_Event) ProtoMessage() {}
 
 func (x *PlanStackChanges_Event) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[71]
+	mi := &file_stacks_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4601,7 +4101,7 @@ type OpenStackPlan_RequestItem struct {
 
 func (x *OpenStackPlan_RequestItem) Reset() {
 	*x = OpenStackPlan_RequestItem{}
-	mi := &file_stacks_proto_msgTypes[74]
+	mi := &file_stacks_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4613,7 +4113,7 @@ func (x *OpenStackPlan_RequestItem) String() string {
 func (*OpenStackPlan_RequestItem) ProtoMessage() {}
 
 func (x *OpenStackPlan_RequestItem) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[74]
+	mi := &file_stacks_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4645,7 +4145,7 @@ type OpenStackPlan_Response struct {
 
 func (x *OpenStackPlan_Response) Reset() {
 	*x = OpenStackPlan_Response{}
-	mi := &file_stacks_proto_msgTypes[75]
+	mi := &file_stacks_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4657,7 +4157,7 @@ func (x *OpenStackPlan_Response) String() string {
 func (*OpenStackPlan_Response) ProtoMessage() {}
 
 func (x *OpenStackPlan_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[75]
+	mi := &file_stacks_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4689,7 +4189,7 @@ type CloseStackPlan_Request struct {
 
 func (x *CloseStackPlan_Request) Reset() {
 	*x = CloseStackPlan_Request{}
-	mi := &file_stacks_proto_msgTypes[76]
+	mi := &file_stacks_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4701,7 +4201,7 @@ func (x *CloseStackPlan_Request) String() string {
 func (*CloseStackPlan_Request) ProtoMessage() {}
 
 func (x *CloseStackPlan_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[76]
+	mi := &file_stacks_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4732,7 +4232,7 @@ type CloseStackPlan_Response struct {
 
 func (x *CloseStackPlan_Response) Reset() {
 	*x = CloseStackPlan_Response{}
-	mi := &file_stacks_proto_msgTypes[77]
+	mi := &file_stacks_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4744,7 +4244,7 @@ func (x *CloseStackPlan_Response) String() string {
 func (*CloseStackPlan_Response) ProtoMessage() {}
 
 func (x *CloseStackPlan_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[77]
+	mi := &file_stacks_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4809,7 +4309,7 @@ type ApplyStackChanges_Request struct {
 
 func (x *ApplyStackChanges_Request) Reset() {
 	*x = ApplyStackChanges_Request{}
-	mi := &file_stacks_proto_msgTypes[78]
+	mi := &file_stacks_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4821,7 +4321,7 @@ func (x *ApplyStackChanges_Request) String() string {
 func (*ApplyStackChanges_Request) ProtoMessage() {}
 
 func (x *ApplyStackChanges_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[78]
+	mi := &file_stacks_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4917,7 +4417,7 @@ type ApplyStackChanges_Event struct {
 
 func (x *ApplyStackChanges_Event) Reset() {
 	*x = ApplyStackChanges_Event{}
-	mi := &file_stacks_proto_msgTypes[79]
+	mi := &file_stacks_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4929,7 +4429,7 @@ func (x *ApplyStackChanges_Event) String() string {
 func (*ApplyStackChanges_Event) ProtoMessage() {}
 
 func (x *ApplyStackChanges_Event) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[79]
+	mi := &file_stacks_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5046,7 +4546,7 @@ type OpenStackInspector_Request struct {
 
 func (x *OpenStackInspector_Request) Reset() {
 	*x = OpenStackInspector_Request{}
-	mi := &file_stacks_proto_msgTypes[81]
+	mi := &file_stacks_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5058,7 +4558,7 @@ func (x *OpenStackInspector_Request) String() string {
 func (*OpenStackInspector_Request) ProtoMessage() {}
 
 func (x *OpenStackInspector_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[81]
+	mi := &file_stacks_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5119,7 +4619,7 @@ type OpenStackInspector_Response struct {
 
 func (x *OpenStackInspector_Response) Reset() {
 	*x = OpenStackInspector_Response{}
-	mi := &file_stacks_proto_msgTypes[82]
+	mi := &file_stacks_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5131,7 +4631,7 @@ func (x *OpenStackInspector_Response) String() string {
 func (*OpenStackInspector_Response) ProtoMessage() {}
 
 func (x *OpenStackInspector_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[82]
+	mi := &file_stacks_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5172,7 +4672,7 @@ type InspectExpressionResult_Request struct {
 
 func (x *InspectExpressionResult_Request) Reset() {
 	*x = InspectExpressionResult_Request{}
-	mi := &file_stacks_proto_msgTypes[85]
+	mi := &file_stacks_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5184,7 +4684,7 @@ func (x *InspectExpressionResult_Request) String() string {
 func (*InspectExpressionResult_Request) ProtoMessage() {}
 
 func (x *InspectExpressionResult_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[85]
+	mi := &file_stacks_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5237,7 +4737,7 @@ type InspectExpressionResult_Response struct {
 
 func (x *InspectExpressionResult_Response) Reset() {
 	*x = InspectExpressionResult_Response{}
-	mi := &file_stacks_proto_msgTypes[86]
+	mi := &file_stacks_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5249,7 +4749,7 @@ func (x *InspectExpressionResult_Response) String() string {
 func (*InspectExpressionResult_Response) ProtoMessage() {}
 
 func (x *InspectExpressionResult_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[86]
+	mi := &file_stacks_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5293,7 +4793,7 @@ type AttributePath_Step struct {
 
 func (x *AttributePath_Step) Reset() {
 	*x = AttributePath_Step{}
-	mi := &file_stacks_proto_msgTypes[87]
+	mi := &file_stacks_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5305,7 +4805,7 @@ func (x *AttributePath_Step) String() string {
 func (*AttributePath_Step) ProtoMessage() {}
 
 func (x *AttributePath_Step) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[87]
+	mi := &file_stacks_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5408,7 +4908,7 @@ type PlannedChange_ChangeDescription struct {
 
 func (x *PlannedChange_ChangeDescription) Reset() {
 	*x = PlannedChange_ChangeDescription{}
-	mi := &file_stacks_proto_msgTypes[88]
+	mi := &file_stacks_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5420,7 +4920,7 @@ func (x *PlannedChange_ChangeDescription) String() string {
 func (*PlannedChange_ChangeDescription) ProtoMessage() {}
 
 func (x *PlannedChange_ChangeDescription) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[88]
+	mi := &file_stacks_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5605,7 +5105,7 @@ type PlannedChange_ComponentInstance struct {
 
 func (x *PlannedChange_ComponentInstance) Reset() {
 	*x = PlannedChange_ComponentInstance{}
-	mi := &file_stacks_proto_msgTypes[89]
+	mi := &file_stacks_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5617,7 +5117,7 @@ func (x *PlannedChange_ComponentInstance) String() string {
 func (*PlannedChange_ComponentInstance) ProtoMessage() {}
 
 func (x *PlannedChange_ComponentInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[89]
+	mi := &file_stacks_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5702,7 +5202,7 @@ type PlannedChange_ResourceInstance struct {
 
 func (x *PlannedChange_ResourceInstance) Reset() {
 	*x = PlannedChange_ResourceInstance{}
-	mi := &file_stacks_proto_msgTypes[90]
+	mi := &file_stacks_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5714,7 +5214,7 @@ func (x *PlannedChange_ResourceInstance) String() string {
 func (*PlannedChange_ResourceInstance) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[90]
+	mi := &file_stacks_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5849,7 +5349,7 @@ type PlannedChange_OutputValue struct {
 
 func (x *PlannedChange_OutputValue) Reset() {
 	*x = PlannedChange_OutputValue{}
-	mi := &file_stacks_proto_msgTypes[91]
+	mi := &file_stacks_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5861,7 +5361,7 @@ func (x *PlannedChange_OutputValue) String() string {
 func (*PlannedChange_OutputValue) ProtoMessage() {}
 
 func (x *PlannedChange_OutputValue) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[91]
+	mi := &file_stacks_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5908,7 +5408,7 @@ type PlannedChange_ResourceInstanceDeferred struct {
 
 func (x *PlannedChange_ResourceInstanceDeferred) Reset() {
 	*x = PlannedChange_ResourceInstanceDeferred{}
-	mi := &file_stacks_proto_msgTypes[92]
+	mi := &file_stacks_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5920,7 +5420,7 @@ func (x *PlannedChange_ResourceInstanceDeferred) String() string {
 func (*PlannedChange_ResourceInstanceDeferred) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceInstanceDeferred) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[92]
+	mi := &file_stacks_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5965,7 +5465,7 @@ type PlannedChange_InputVariable struct {
 
 func (x *PlannedChange_InputVariable) Reset() {
 	*x = PlannedChange_InputVariable{}
-	mi := &file_stacks_proto_msgTypes[93]
+	mi := &file_stacks_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5977,7 +5477,7 @@ func (x *PlannedChange_InputVariable) String() string {
 func (*PlannedChange_InputVariable) ProtoMessage() {}
 
 func (x *PlannedChange_InputVariable) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[93]
+	mi := &file_stacks_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6043,7 +5543,7 @@ type PlannedChange_ActionInvocationInstance struct {
 
 func (x *PlannedChange_ActionInvocationInstance) Reset() {
 	*x = PlannedChange_ActionInvocationInstance{}
-	mi := &file_stacks_proto_msgTypes[94]
+	mi := &file_stacks_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6055,7 +5555,7 @@ func (x *PlannedChange_ActionInvocationInstance) String() string {
 func (*PlannedChange_ActionInvocationInstance) ProtoMessage() {}
 
 func (x *PlannedChange_ActionInvocationInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[94]
+	mi := &file_stacks_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6158,7 +5658,7 @@ type PlannedChange_ActionInvocationDeferred struct {
 
 func (x *PlannedChange_ActionInvocationDeferred) Reset() {
 	*x = PlannedChange_ActionInvocationDeferred{}
-	mi := &file_stacks_proto_msgTypes[95]
+	mi := &file_stacks_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6170,7 +5670,7 @@ func (x *PlannedChange_ActionInvocationDeferred) String() string {
 func (*PlannedChange_ActionInvocationDeferred) ProtoMessage() {}
 
 func (x *PlannedChange_ActionInvocationDeferred) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[95]
+	mi := &file_stacks_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6214,7 +5714,7 @@ type PlannedChange_ResourceActionTrigger struct {
 
 func (x *PlannedChange_ResourceActionTrigger) Reset() {
 	*x = PlannedChange_ResourceActionTrigger{}
-	mi := &file_stacks_proto_msgTypes[96]
+	mi := &file_stacks_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6226,7 +5726,7 @@ func (x *PlannedChange_ResourceActionTrigger) String() string {
 func (*PlannedChange_ResourceActionTrigger) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceActionTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[96]
+	mi := &file_stacks_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6280,7 +5780,7 @@ type PlannedChange_InvokeActionTrigger struct {
 
 func (x *PlannedChange_InvokeActionTrigger) Reset() {
 	*x = PlannedChange_InvokeActionTrigger{}
-	mi := &file_stacks_proto_msgTypes[97]
+	mi := &file_stacks_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6292,7 +5792,7 @@ func (x *PlannedChange_InvokeActionTrigger) String() string {
 func (*PlannedChange_InvokeActionTrigger) ProtoMessage() {}
 
 func (x *PlannedChange_InvokeActionTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[97]
+	mi := &file_stacks_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6318,7 +5818,7 @@ type PlannedChange_ResourceInstance_Index struct {
 
 func (x *PlannedChange_ResourceInstance_Index) Reset() {
 	*x = PlannedChange_ResourceInstance_Index{}
-	mi := &file_stacks_proto_msgTypes[99]
+	mi := &file_stacks_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6330,7 +5830,7 @@ func (x *PlannedChange_ResourceInstance_Index) String() string {
 func (*PlannedChange_ResourceInstance_Index) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceInstance_Index) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[99]
+	mi := &file_stacks_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6369,7 +5869,7 @@ type PlannedChange_ResourceInstance_Moved struct {
 
 func (x *PlannedChange_ResourceInstance_Moved) Reset() {
 	*x = PlannedChange_ResourceInstance_Moved{}
-	mi := &file_stacks_proto_msgTypes[100]
+	mi := &file_stacks_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6381,7 +5881,7 @@ func (x *PlannedChange_ResourceInstance_Moved) String() string {
 func (*PlannedChange_ResourceInstance_Moved) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceInstance_Moved) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[100]
+	mi := &file_stacks_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6415,7 +5915,7 @@ type PlannedChange_ResourceInstance_Imported struct {
 
 func (x *PlannedChange_ResourceInstance_Imported) Reset() {
 	*x = PlannedChange_ResourceInstance_Imported{}
-	mi := &file_stacks_proto_msgTypes[101]
+	mi := &file_stacks_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6427,7 +5927,7 @@ func (x *PlannedChange_ResourceInstance_Imported) String() string {
 func (*PlannedChange_ResourceInstance_Imported) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceInstance_Imported) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[101]
+	mi := &file_stacks_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6474,7 +5974,7 @@ type AppliedChange_RawChange struct {
 
 func (x *AppliedChange_RawChange) Reset() {
 	*x = AppliedChange_RawChange{}
-	mi := &file_stacks_proto_msgTypes[102]
+	mi := &file_stacks_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6486,7 +5986,7 @@ func (x *AppliedChange_RawChange) String() string {
 func (*AppliedChange_RawChange) ProtoMessage() {}
 
 func (x *AppliedChange_RawChange) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[102]
+	mi := &file_stacks_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6534,7 +6034,7 @@ type AppliedChange_ChangeDescription struct {
 
 func (x *AppliedChange_ChangeDescription) Reset() {
 	*x = AppliedChange_ChangeDescription{}
-	mi := &file_stacks_proto_msgTypes[103]
+	mi := &file_stacks_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6546,7 +6046,7 @@ func (x *AppliedChange_ChangeDescription) String() string {
 func (*AppliedChange_ChangeDescription) ProtoMessage() {}
 
 func (x *AppliedChange_ChangeDescription) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[103]
+	mi := &file_stacks_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6708,7 +6208,7 @@ type AppliedChange_ResourceInstance struct {
 
 func (x *AppliedChange_ResourceInstance) Reset() {
 	*x = AppliedChange_ResourceInstance{}
-	mi := &file_stacks_proto_msgTypes[104]
+	mi := &file_stacks_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6720,7 +6220,7 @@ func (x *AppliedChange_ResourceInstance) String() string {
 func (*AppliedChange_ResourceInstance) ProtoMessage() {}
 
 func (x *AppliedChange_ResourceInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[104]
+	mi := &file_stacks_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6789,7 +6289,7 @@ type AppliedChange_ComponentInstance struct {
 
 func (x *AppliedChange_ComponentInstance) Reset() {
 	*x = AppliedChange_ComponentInstance{}
-	mi := &file_stacks_proto_msgTypes[105]
+	mi := &file_stacks_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6801,7 +6301,7 @@ func (x *AppliedChange_ComponentInstance) String() string {
 func (*AppliedChange_ComponentInstance) ProtoMessage() {}
 
 func (x *AppliedChange_ComponentInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[105]
+	mi := &file_stacks_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6848,7 +6348,7 @@ type AppliedChange_OutputValue struct {
 
 func (x *AppliedChange_OutputValue) Reset() {
 	*x = AppliedChange_OutputValue{}
-	mi := &file_stacks_proto_msgTypes[106]
+	mi := &file_stacks_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6860,7 +6360,7 @@ func (x *AppliedChange_OutputValue) String() string {
 func (*AppliedChange_OutputValue) ProtoMessage() {}
 
 func (x *AppliedChange_OutputValue) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[106]
+	mi := &file_stacks_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6900,7 +6400,7 @@ type AppliedChange_InputVariable struct {
 
 func (x *AppliedChange_InputVariable) Reset() {
 	*x = AppliedChange_InputVariable{}
-	mi := &file_stacks_proto_msgTypes[107]
+	mi := &file_stacks_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6912,7 +6412,7 @@ func (x *AppliedChange_InputVariable) String() string {
 func (*AppliedChange_InputVariable) ProtoMessage() {}
 
 func (x *AppliedChange_InputVariable) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[107]
+	mi := &file_stacks_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6950,7 +6450,7 @@ type AppliedChange_Nothing struct {
 
 func (x *AppliedChange_Nothing) Reset() {
 	*x = AppliedChange_Nothing{}
-	mi := &file_stacks_proto_msgTypes[108]
+	mi := &file_stacks_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6962,7 +6462,7 @@ func (x *AppliedChange_Nothing) String() string {
 func (*AppliedChange_Nothing) ProtoMessage() {}
 
 func (x *AppliedChange_Nothing) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[108]
+	mi := &file_stacks_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6990,7 +6490,7 @@ type StackChangeProgress_ComponentInstanceStatus struct {
 
 func (x *StackChangeProgress_ComponentInstanceStatus) Reset() {
 	*x = StackChangeProgress_ComponentInstanceStatus{}
-	mi := &file_stacks_proto_msgTypes[110]
+	mi := &file_stacks_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7002,7 +6502,7 @@ func (x *StackChangeProgress_ComponentInstanceStatus) String() string {
 func (*StackChangeProgress_ComponentInstanceStatus) ProtoMessage() {}
 
 func (x *StackChangeProgress_ComponentInstanceStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[110]
+	mi := &file_stacks_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7045,7 +6545,7 @@ type StackChangeProgress_ResourceInstanceStatus struct {
 
 func (x *StackChangeProgress_ResourceInstanceStatus) Reset() {
 	*x = StackChangeProgress_ResourceInstanceStatus{}
-	mi := &file_stacks_proto_msgTypes[111]
+	mi := &file_stacks_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7057,7 +6557,7 @@ func (x *StackChangeProgress_ResourceInstanceStatus) String() string {
 func (*StackChangeProgress_ResourceInstanceStatus) ProtoMessage() {}
 
 func (x *StackChangeProgress_ResourceInstanceStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[111]
+	mi := &file_stacks_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7112,7 +6612,7 @@ type StackChangeProgress_ResourceInstancePlannedChange struct {
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange) Reset() {
 	*x = StackChangeProgress_ResourceInstancePlannedChange{}
-	mi := &file_stacks_proto_msgTypes[112]
+	mi := &file_stacks_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7124,7 +6624,7 @@ func (x *StackChangeProgress_ResourceInstancePlannedChange) String() string {
 func (*StackChangeProgress_ResourceInstancePlannedChange) ProtoMessage() {}
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[112]
+	mi := &file_stacks_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7187,7 +6687,7 @@ type StackChangeProgress_DeferredResourceInstancePlannedChange struct {
 
 func (x *StackChangeProgress_DeferredResourceInstancePlannedChange) Reset() {
 	*x = StackChangeProgress_DeferredResourceInstancePlannedChange{}
-	mi := &file_stacks_proto_msgTypes[113]
+	mi := &file_stacks_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7199,7 +6699,7 @@ func (x *StackChangeProgress_DeferredResourceInstancePlannedChange) String() str
 func (*StackChangeProgress_DeferredResourceInstancePlannedChange) ProtoMessage() {}
 
 func (x *StackChangeProgress_DeferredResourceInstancePlannedChange) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[113]
+	mi := &file_stacks_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7244,7 +6744,7 @@ type StackChangeProgress_ActionInvocationPlanned struct {
 
 func (x *StackChangeProgress_ActionInvocationPlanned) Reset() {
 	*x = StackChangeProgress_ActionInvocationPlanned{}
-	mi := &file_stacks_proto_msgTypes[114]
+	mi := &file_stacks_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7256,7 +6756,7 @@ func (x *StackChangeProgress_ActionInvocationPlanned) String() string {
 func (*StackChangeProgress_ActionInvocationPlanned) ProtoMessage() {}
 
 func (x *StackChangeProgress_ActionInvocationPlanned) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[114]
+	mi := &file_stacks_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7345,7 +6845,7 @@ type StackChangeProgress_ActionInvocationStatus struct {
 
 func (x *StackChangeProgress_ActionInvocationStatus) Reset() {
 	*x = StackChangeProgress_ActionInvocationStatus{}
-	mi := &file_stacks_proto_msgTypes[115]
+	mi := &file_stacks_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7357,7 +6857,7 @@ func (x *StackChangeProgress_ActionInvocationStatus) String() string {
 func (*StackChangeProgress_ActionInvocationStatus) ProtoMessage() {}
 
 func (x *StackChangeProgress_ActionInvocationStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[115]
+	mi := &file_stacks_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7453,7 +6953,7 @@ type StackChangeProgress_ActionInvocationProgress struct {
 
 func (x *StackChangeProgress_ActionInvocationProgress) Reset() {
 	*x = StackChangeProgress_ActionInvocationProgress{}
-	mi := &file_stacks_proto_msgTypes[116]
+	mi := &file_stacks_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7465,7 +6965,7 @@ func (x *StackChangeProgress_ActionInvocationProgress) String() string {
 func (*StackChangeProgress_ActionInvocationProgress) ProtoMessage() {}
 
 func (x *StackChangeProgress_ActionInvocationProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[116]
+	mi := &file_stacks_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7559,7 +7059,7 @@ type StackChangeProgress_ResourceActionTrigger struct {
 
 func (x *StackChangeProgress_ResourceActionTrigger) Reset() {
 	*x = StackChangeProgress_ResourceActionTrigger{}
-	mi := &file_stacks_proto_msgTypes[117]
+	mi := &file_stacks_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7571,7 +7071,7 @@ func (x *StackChangeProgress_ResourceActionTrigger) String() string {
 func (*StackChangeProgress_ResourceActionTrigger) ProtoMessage() {}
 
 func (x *StackChangeProgress_ResourceActionTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[117]
+	mi := &file_stacks_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7625,7 +7125,7 @@ type StackChangeProgress_InvokeActionTrigger struct {
 
 func (x *StackChangeProgress_InvokeActionTrigger) Reset() {
 	*x = StackChangeProgress_InvokeActionTrigger{}
-	mi := &file_stacks_proto_msgTypes[118]
+	mi := &file_stacks_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7637,7 +7137,7 @@ func (x *StackChangeProgress_InvokeActionTrigger) String() string {
 func (*StackChangeProgress_InvokeActionTrigger) ProtoMessage() {}
 
 func (x *StackChangeProgress_InvokeActionTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[118]
+	mi := &file_stacks_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7666,7 +7166,7 @@ type StackChangeProgress_ProvisionerStatus struct {
 
 func (x *StackChangeProgress_ProvisionerStatus) Reset() {
 	*x = StackChangeProgress_ProvisionerStatus{}
-	mi := &file_stacks_proto_msgTypes[119]
+	mi := &file_stacks_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7678,7 +7178,7 @@ func (x *StackChangeProgress_ProvisionerStatus) String() string {
 func (*StackChangeProgress_ProvisionerStatus) ProtoMessage() {}
 
 func (x *StackChangeProgress_ProvisionerStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[119]
+	mi := &file_stacks_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7728,7 +7228,7 @@ type StackChangeProgress_ProvisionerOutput struct {
 
 func (x *StackChangeProgress_ProvisionerOutput) Reset() {
 	*x = StackChangeProgress_ProvisionerOutput{}
-	mi := &file_stacks_proto_msgTypes[120]
+	mi := &file_stacks_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7740,7 +7240,7 @@ func (x *StackChangeProgress_ProvisionerOutput) String() string {
 func (*StackChangeProgress_ProvisionerOutput) ProtoMessage() {}
 
 func (x *StackChangeProgress_ProvisionerOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[120]
+	mi := &file_stacks_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7804,7 +7304,7 @@ type StackChangeProgress_ComponentInstanceChanges struct {
 
 func (x *StackChangeProgress_ComponentInstanceChanges) Reset() {
 	*x = StackChangeProgress_ComponentInstanceChanges{}
-	mi := &file_stacks_proto_msgTypes[121]
+	mi := &file_stacks_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7816,7 +7316,7 @@ func (x *StackChangeProgress_ComponentInstanceChanges) String() string {
 func (*StackChangeProgress_ComponentInstanceChanges) ProtoMessage() {}
 
 func (x *StackChangeProgress_ComponentInstanceChanges) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[121]
+	mi := &file_stacks_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7914,7 +7414,7 @@ type StackChangeProgress_ComponentInstances struct {
 
 func (x *StackChangeProgress_ComponentInstances) Reset() {
 	*x = StackChangeProgress_ComponentInstances{}
-	mi := &file_stacks_proto_msgTypes[122]
+	mi := &file_stacks_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7926,7 +7426,7 @@ func (x *StackChangeProgress_ComponentInstances) String() string {
 func (*StackChangeProgress_ComponentInstances) ProtoMessage() {}
 
 func (x *StackChangeProgress_ComponentInstances) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[122]
+	mi := &file_stacks_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7965,7 +7465,7 @@ type StackChangeProgress_ResourceInstancePlannedChange_Moved struct {
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange_Moved) Reset() {
 	*x = StackChangeProgress_ResourceInstancePlannedChange_Moved{}
-	mi := &file_stacks_proto_msgTypes[123]
+	mi := &file_stacks_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7977,7 +7477,7 @@ func (x *StackChangeProgress_ResourceInstancePlannedChange_Moved) String() strin
 func (*StackChangeProgress_ResourceInstancePlannedChange_Moved) ProtoMessage() {}
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange_Moved) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[123]
+	mi := &file_stacks_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8010,7 +7510,7 @@ type StackChangeProgress_ResourceInstancePlannedChange_Imported struct {
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange_Imported) Reset() {
 	*x = StackChangeProgress_ResourceInstancePlannedChange_Imported{}
-	mi := &file_stacks_proto_msgTypes[124]
+	mi := &file_stacks_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8022,7 +7522,7 @@ func (x *StackChangeProgress_ResourceInstancePlannedChange_Imported) String() st
 func (*StackChangeProgress_ResourceInstancePlannedChange_Imported) ProtoMessage() {}
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange_Imported) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[124]
+	mi := &file_stacks_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8063,7 +7563,7 @@ type ListResourceIdentities_Request struct {
 
 func (x *ListResourceIdentities_Request) Reset() {
 	*x = ListResourceIdentities_Request{}
-	mi := &file_stacks_proto_msgTypes[125]
+	mi := &file_stacks_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8075,7 +7575,7 @@ func (x *ListResourceIdentities_Request) String() string {
 func (*ListResourceIdentities_Request) ProtoMessage() {}
 
 func (x *ListResourceIdentities_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[125]
+	mi := &file_stacks_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8121,7 +7621,7 @@ type ListResourceIdentities_Response struct {
 
 func (x *ListResourceIdentities_Response) Reset() {
 	*x = ListResourceIdentities_Response{}
-	mi := &file_stacks_proto_msgTypes[126]
+	mi := &file_stacks_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8133,7 +7633,7 @@ func (x *ListResourceIdentities_Response) String() string {
 func (*ListResourceIdentities_Response) ProtoMessage() {}
 
 func (x *ListResourceIdentities_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[126]
+	mi := &file_stacks_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8172,7 +7672,7 @@ type ListResourceIdentities_Resource struct {
 
 func (x *ListResourceIdentities_Resource) Reset() {
 	*x = ListResourceIdentities_Resource{}
-	mi := &file_stacks_proto_msgTypes[127]
+	mi := &file_stacks_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8184,7 +7684,7 @@ func (x *ListResourceIdentities_Resource) String() string {
 func (*ListResourceIdentities_Resource) ProtoMessage() {}
 
 func (x *ListResourceIdentities_Resource) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[127]
+	mi := &file_stacks_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8759,56 +8259,17 @@ const file_stacks_proto_rawDesc = "" +
 	"\x0ecomponent_addr\x18\x01 \x01(\tR\rcomponentAddr\x126\n" +
 	"\x17component_instance_addr\x18\x02 \x01(\tR\x15componentInstanceAddr\x124\n" +
 	"\x16resource_instance_addr\x18\x03 \x01(\tR\x14resourceInstanceAddr\x12L\n" +
-	"\x11resource_identity\x18\x04 \x01(\v2\x1f.terraform1.stacks.DynamicValueR\x10resourceIdentity\"\x9f\x02\n" +
+	"\x11resource_identity\x18\x04 \x01(\v2\x1f.terraform1.stacks.DynamicValueR\x10resourceIdentity\"\x8a\x02\n" +
 	"!ComponentInstancePolicyEvaluation\x12C\n" +
-	"\x04addr\x18\x01 \x01(\v2/.terraform1.stacks.ComponentInstanceInStackAddrR\x04addr\x129\n" +
-	"\aresults\x18\x02 \x03(\v2\x1f.terraform1.stacks.PolicyResultR\aresults\x123\n" +
-	"\x05infos\x18\x03 \x03(\v2\x1d.terraform1.stacks.PolicyInfoR\x05infos\x12E\n" +
-	"\vdiagnostics\x18\x04 \x03(\v2#.terraform1.stacks.PolicyDiagnosticR\vdiagnostics\"\x9d\x02\n" +
+	"\x04addr\x18\x01 \x01(\v2/.terraform1.stacks.ComponentInstanceInStackAddrR\x04addr\x122\n" +
+	"\aresults\x18\x02 \x03(\v2\x18.terraform1.PolicyResultR\aresults\x12,\n" +
+	"\x05infos\x18\x03 \x03(\v2\x16.terraform1.PolicyInfoR\x05infos\x12>\n" +
+	"\vdiagnostics\x18\x04 \x03(\v2\x1c.terraform1.PolicyDiagnosticR\vdiagnostics\"\x88\x02\n" +
 	" ProviderInstancePolicyEvaluation\x12B\n" +
-	"\x04addr\x18\x01 \x01(\v2..terraform1.stacks.ProviderInstanceInStackAddrR\x04addr\x129\n" +
-	"\aresults\x18\x02 \x03(\v2\x1f.terraform1.stacks.PolicyResultR\aresults\x123\n" +
-	"\x05infos\x18\x03 \x03(\v2\x1d.terraform1.stacks.PolicyInfoR\x05infos\x12E\n" +
-	"\vdiagnostics\x18\x04 \x03(\v2#.terraform1.stacks.PolicyDiagnosticR\vdiagnostics\"\xc8\x01\n" +
-	"\x0ePolicyMetaData\x12\x1f\n" +
-	"\vpolicy_name\x18\x01 \x01(\tR\n" +
-	"policyName\x12&\n" +
-	"\x0fpolicy_set_name\x18\x02 \x01(\tR\rpolicySetName\x12+\n" +
-	"\x11enforcement_level\x18\x03 \x01(\tR\x10enforcementLevel\x12\x1b\n" +
-	"\tfile_name\x18\x04 \x01(\tR\bfileName\x12#\n" +
-	"\renforce_index\x18\x05 \x01(\x05R\fenforceIndex\"\xbc\x01\n" +
-	"\fPolicyResult\x12%\n" +
-	"\x0etarget_address\x18\x01 \x01(\tR\rtargetAddress\x12J\n" +
-	"\x0fpolicy_metadata\x18\x02 \x01(\v2!.terraform1.stacks.PolicyMetaDataR\x0epolicyMetadata\x129\n" +
-	"\x06result\x18\x03 \x01(\x0e2!.terraform1.stacks.EvaluateResultR\x06result\"\xd9\x02\n" +
-	"\n" +
-	"PolicyInfo\x12%\n" +
-	"\x0etarget_address\x18\x01 \x01(\tR\rtargetAddress\x12J\n" +
-	"\x0fpolicy_metadata\x18\x02 \x01(\v2!.terraform1.stacks.PolicyMetaDataR\x0epolicyMetadata\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\x12:\n" +
-	"\fpolicy_range\x18\x04 \x01(\v2\x17.terraform1.SourceRangeR\vpolicyRange\x12G\n" +
-	"\x0epolicy_snippet\x18\x05 \x01(\v2 .terraform1.stacks.PolicySnippetR\rpolicySnippet\x129\n" +
-	"\x06result\x18\x06 \x01(\x0e2!.terraform1.stacks.EvaluateResultR\x06result\"\xc4\x01\n" +
-	"\rPolicySnippet\x12\x18\n" +
-	"\acontext\x18\x01 \x01(\tR\acontext\x12\x12\n" +
-	"\x04code\x18\x02 \x01(\tR\x04code\x12\x1d\n" +
-	"\n" +
-	"start_line\x18\x03 \x01(\x03R\tstartLine\x124\n" +
-	"\x16highlight_start_offset\x18\x04 \x01(\x03R\x14highlightStartOffset\x120\n" +
-	"\x14highlight_end_offset\x18\x05 \x01(\x03R\x12highlightEndOffset\"\xce\x03\n" +
-	"\x10PolicyDiagnostic\x12%\n" +
-	"\x0etarget_address\x18\x01 \x01(\tR\rtargetAddress\x12J\n" +
-	"\x0fpolicy_metadata\x18\x02 \x01(\v2!.terraform1.stacks.PolicyMetaDataR\x0epolicyMetadata\x129\n" +
-	"\x06result\x18\x03 \x01(\x0e2!.terraform1.stacks.EvaluateResultR\x06result\x126\n" +
-	"\n" +
-	"diagnostic\x18\x04 \x01(\v2\x16.terraform1.DiagnosticR\n" +
-	"diagnostic\x12G\n" +
-	"\x0epolicy_snippet\x18\x05 \x01(\v2 .terraform1.stacks.PolicySnippetR\rpolicySnippet\x12:\n" +
-	"\fpolicy_range\x18\x06 \x01(\v2\x17.terraform1.SourceRangeR\vpolicyRange\x12O\n" +
-	"\x11expression_values\x18\a \x03(\v2\".terraform1.stacks.ExpressionValueR\x10expressionValues\"g\n" +
-	"\x0fExpressionValue\x12>\n" +
-	"\ttraversal\x18\x01 \x01(\v2 .terraform1.stacks.AttributePathR\ttraversal\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value*2\n" +
+	"\x04addr\x18\x01 \x01(\v2..terraform1.stacks.ProviderInstanceInStackAddrR\x04addr\x122\n" +
+	"\aresults\x18\x02 \x03(\v2\x18.terraform1.PolicyResultR\aresults\x12,\n" +
+	"\x05infos\x18\x03 \x03(\v2\x16.terraform1.PolicyInfoR\x05infos\x12>\n" +
+	"\vdiagnostics\x18\x04 \x03(\v2\x1c.terraform1.PolicyDiagnosticR\vdiagnostics*2\n" +
 	"\fResourceMode\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aMANAGED\x10\x01\x12\b\n" +
@@ -8829,14 +8290,7 @@ const file_stacks_proto_rawDesc = "" +
 	"\n" +
 	"\x06DELETE\x10\x04\x12\n" +
 	"\n" +
-	"\x06FORGET\x10\x05*\xbb\x01\n" +
-	"\x0eEvaluateResult\x12\x1b\n" +
-	"\x17INVALID_EVALUATE_RESULT\x10\x00\x12\x1b\n" +
-	"\x17UNKNOWN_EVALUATE_RESULT\x10\x01\x12\x19\n" +
-	"\x15ERROR_EVALUATE_RESULT\x10\x02\x12\x19\n" +
-	"\x15ALLOW_EVALUATE_RESULT\x10\x03\x12\x18\n" +
-	"\x14DENY_EVALUATE_RESULT\x10\x04\x12\x1f\n" +
-	"\x1bSETUP_ERROR_EVALUATE_RESULT\x10\x052\x9c\x0f\n" +
+	"\x06FORGET\x10\x052\x9c\x0f\n" +
 	"\x06Stacks\x12\x7f\n" +
 	"\x16OpenStackConfiguration\x121.terraform1.stacks.OpenStackConfiguration.Request\x1a2.terraform1.stacks.OpenStackConfiguration.Response\x12\x82\x01\n" +
 	"\x17CloseStackConfiguration\x122.terraform1.stacks.CloseStackConfiguration.Request\x1a3.terraform1.stacks.CloseStackConfiguration.Response\x12\x8b\x01\n" +
@@ -8868,367 +8322,350 @@ func file_stacks_proto_rawDescGZIP() []byte {
 	return file_stacks_proto_rawDescData
 }
 
-var file_stacks_proto_enumTypes = make([]protoimpl.EnumInfo, 12)
-var file_stacks_proto_msgTypes = make([]protoimpl.MessageInfo, 128)
+var file_stacks_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
+var file_stacks_proto_msgTypes = make([]protoimpl.MessageInfo, 122)
 var file_stacks_proto_goTypes = []any{
-	(ResourceMode)(0),   // 0: terraform1.stacks.ResourceMode
-	(PlanMode)(0),       // 1: terraform1.stacks.PlanMode
-	(ChangeType)(0),     // 2: terraform1.stacks.ChangeType
-	(EvaluateResult)(0), // 3: terraform1.stacks.EvaluateResult
-	(FindStackConfigurationComponents_Instances)(0),         // 4: terraform1.stacks.FindStackConfigurationComponents.Instances
-	(PlannedChange_ActionTriggerEvent)(0),                   // 5: terraform1.stacks.PlannedChange.ActionTriggerEvent
-	(Deferred_Reason)(0),                                    // 6: terraform1.stacks.Deferred.Reason
-	(StackChangeProgress_ActionTriggerEvent)(0),             // 7: terraform1.stacks.StackChangeProgress.ActionTriggerEvent
-	(StackChangeProgress_ComponentInstanceStatus_Status)(0), // 8: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.Status
-	(StackChangeProgress_ResourceInstanceStatus_Status)(0),  // 9: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.Status
-	(StackChangeProgress_ActionInvocationStatus_Status)(0),  // 10: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.Status
-	(StackChangeProgress_ProvisionerStatus_Status)(0),       // 11: terraform1.stacks.StackChangeProgress.ProvisionerStatus.Status
-	(*OpenTerraformState)(nil),                              // 12: terraform1.stacks.OpenTerraformState
-	(*CloseTerraformState)(nil),                             // 13: terraform1.stacks.CloseTerraformState
-	(*MigrateTerraformState)(nil),                           // 14: terraform1.stacks.MigrateTerraformState
-	(*OpenStackConfiguration)(nil),                          // 15: terraform1.stacks.OpenStackConfiguration
-	(*CloseStackConfiguration)(nil),                         // 16: terraform1.stacks.CloseStackConfiguration
-	(*ValidateStackConfiguration)(nil),                      // 17: terraform1.stacks.ValidateStackConfiguration
-	(*FindStackConfigurationComponents)(nil),                // 18: terraform1.stacks.FindStackConfigurationComponents
-	(*OpenStackState)(nil),                                  // 19: terraform1.stacks.OpenStackState
-	(*CloseStackState)(nil),                                 // 20: terraform1.stacks.CloseStackState
-	(*PlanStackChanges)(nil),                                // 21: terraform1.stacks.PlanStackChanges
-	(*OpenStackPlan)(nil),                                   // 22: terraform1.stacks.OpenStackPlan
-	(*CloseStackPlan)(nil),                                  // 23: terraform1.stacks.CloseStackPlan
-	(*ApplyStackChanges)(nil),                               // 24: terraform1.stacks.ApplyStackChanges
-	(*OpenStackInspector)(nil),                              // 25: terraform1.stacks.OpenStackInspector
-	(*InspectExpressionResult)(nil),                         // 26: terraform1.stacks.InspectExpressionResult
-	(*DynamicValue)(nil),                                    // 27: terraform1.stacks.DynamicValue
-	(*DynamicValueChange)(nil),                              // 28: terraform1.stacks.DynamicValueChange
-	(*DynamicValueWithSource)(nil),                          // 29: terraform1.stacks.DynamicValueWithSource
-	(*AttributePath)(nil),                                   // 30: terraform1.stacks.AttributePath
-	(*ProviderInstanceInStackAddr)(nil),                     // 31: terraform1.stacks.ProviderInstanceInStackAddr
-	(*ComponentInstanceInStackAddr)(nil),                    // 32: terraform1.stacks.ComponentInstanceInStackAddr
-	(*ActionInvocationInstanceInStackAddr)(nil),             // 33: terraform1.stacks.ActionInvocationInstanceInStackAddr
-	(*ResourceInstanceInStackAddr)(nil),                     // 34: terraform1.stacks.ResourceInstanceInStackAddr
-	(*ResourceInstanceObjectInStackAddr)(nil),               // 35: terraform1.stacks.ResourceInstanceObjectInStackAddr
-	(*PlannedChange)(nil),                                   // 36: terraform1.stacks.PlannedChange
-	(*Deferred)(nil),                                        // 37: terraform1.stacks.Deferred
-	(*AppliedChange)(nil),                                   // 38: terraform1.stacks.AppliedChange
-	(*StackChangeProgress)(nil),                             // 39: terraform1.stacks.StackChangeProgress
-	(*ListResourceIdentities)(nil),                          // 40: terraform1.stacks.ListResourceIdentities
-	(*ComponentInstancePolicyEvaluation)(nil),               // 41: terraform1.stacks.ComponentInstancePolicyEvaluation
-	(*ProviderInstancePolicyEvaluation)(nil),                // 42: terraform1.stacks.ProviderInstancePolicyEvaluation
-	(*PolicyMetaData)(nil),                                  // 43: terraform1.stacks.PolicyMetaData
-	(*PolicyResult)(nil),                                    // 44: terraform1.stacks.PolicyResult
-	(*PolicyInfo)(nil),                                      // 45: terraform1.stacks.PolicyInfo
-	(*PolicySnippet)(nil),                                   // 46: terraform1.stacks.PolicySnippet
-	(*PolicyDiagnostic)(nil),                                // 47: terraform1.stacks.PolicyDiagnostic
-	(*ExpressionValue)(nil),                                 // 48: terraform1.stacks.ExpressionValue
-	(*OpenTerraformState_Request)(nil),                      // 49: terraform1.stacks.OpenTerraformState.Request
-	(*OpenTerraformState_Response)(nil),                     // 50: terraform1.stacks.OpenTerraformState.Response
-	(*CloseTerraformState_Request)(nil),                     // 51: terraform1.stacks.CloseTerraformState.Request
-	(*CloseTerraformState_Response)(nil),                    // 52: terraform1.stacks.CloseTerraformState.Response
-	(*MigrateTerraformState_Request)(nil),                   // 53: terraform1.stacks.MigrateTerraformState.Request
-	(*MigrateTerraformState_Event)(nil),                     // 54: terraform1.stacks.MigrateTerraformState.Event
-	(*MigrateTerraformState_Request_Mapping)(nil),           // 55: terraform1.stacks.MigrateTerraformState.Request.Mapping
-	nil,                                      // 56: terraform1.stacks.MigrateTerraformState.Request.Mapping.ResourceAddressMapEntry
-	nil,                                      // 57: terraform1.stacks.MigrateTerraformState.Request.Mapping.ModuleAddressMapEntry
-	(*OpenStackConfiguration_Request)(nil),   // 58: terraform1.stacks.OpenStackConfiguration.Request
-	(*OpenStackConfiguration_Response)(nil),  // 59: terraform1.stacks.OpenStackConfiguration.Response
-	(*CloseStackConfiguration_Request)(nil),  // 60: terraform1.stacks.CloseStackConfiguration.Request
-	(*CloseStackConfiguration_Response)(nil), // 61: terraform1.stacks.CloseStackConfiguration.Response
-	(*ValidateStackConfiguration_Request)(nil),             // 62: terraform1.stacks.ValidateStackConfiguration.Request
-	(*ValidateStackConfiguration_Response)(nil),            // 63: terraform1.stacks.ValidateStackConfiguration.Response
-	(*FindStackConfigurationComponents_Request)(nil),       // 64: terraform1.stacks.FindStackConfigurationComponents.Request
-	(*FindStackConfigurationComponents_Response)(nil),      // 65: terraform1.stacks.FindStackConfigurationComponents.Response
-	(*FindStackConfigurationComponents_StackConfig)(nil),   // 66: terraform1.stacks.FindStackConfigurationComponents.StackConfig
-	(*FindStackConfigurationComponents_EmbeddedStack)(nil), // 67: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack
-	(*FindStackConfigurationComponents_Component)(nil),     // 68: terraform1.stacks.FindStackConfigurationComponents.Component
-	(*FindStackConfigurationComponents_Removed)(nil),       // 69: terraform1.stacks.FindStackConfigurationComponents.Removed
-	(*FindStackConfigurationComponents_InputVariable)(nil), // 70: terraform1.stacks.FindStackConfigurationComponents.InputVariable
-	(*FindStackConfigurationComponents_OutputValue)(nil),   // 71: terraform1.stacks.FindStackConfigurationComponents.OutputValue
-	nil, // 72: terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry
-	nil, // 73: terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry
-	nil, // 74: terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry
-	nil, // 75: terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry
-	nil, // 76: terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry
-	(*FindStackConfigurationComponents_Removed_Block)(nil), // 77: terraform1.stacks.FindStackConfigurationComponents.Removed.Block
-	(*OpenStackState_RequestItem)(nil),                     // 78: terraform1.stacks.OpenStackState.RequestItem
-	(*OpenStackState_Response)(nil),                        // 79: terraform1.stacks.OpenStackState.Response
-	(*CloseStackState_Request)(nil),                        // 80: terraform1.stacks.CloseStackState.Request
-	(*CloseStackState_Response)(nil),                       // 81: terraform1.stacks.CloseStackState.Response
-	(*PlanStackChanges_Request)(nil),                       // 82: terraform1.stacks.PlanStackChanges.Request
-	(*PlanStackChanges_Event)(nil),                         // 83: terraform1.stacks.PlanStackChanges.Event
-	nil,                                                    // 84: terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry
-	nil,                                                    // 85: terraform1.stacks.PlanStackChanges.Request.InputValuesEntry
-	(*OpenStackPlan_RequestItem)(nil),                      // 86: terraform1.stacks.OpenStackPlan.RequestItem
-	(*OpenStackPlan_Response)(nil),                         // 87: terraform1.stacks.OpenStackPlan.Response
-	(*CloseStackPlan_Request)(nil),                         // 88: terraform1.stacks.CloseStackPlan.Request
-	(*CloseStackPlan_Response)(nil),                        // 89: terraform1.stacks.CloseStackPlan.Response
-	(*ApplyStackChanges_Request)(nil),                      // 90: terraform1.stacks.ApplyStackChanges.Request
-	(*ApplyStackChanges_Event)(nil),                        // 91: terraform1.stacks.ApplyStackChanges.Event
-	nil,                                                    // 92: terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry
-	(*OpenStackInspector_Request)(nil),                     // 93: terraform1.stacks.OpenStackInspector.Request
-	(*OpenStackInspector_Response)(nil),                    // 94: terraform1.stacks.OpenStackInspector.Response
-	nil,                                                    // 95: terraform1.stacks.OpenStackInspector.Request.StateEntry
-	nil,                                                    // 96: terraform1.stacks.OpenStackInspector.Request.InputValuesEntry
-	(*InspectExpressionResult_Request)(nil),                // 97: terraform1.stacks.InspectExpressionResult.Request
-	(*InspectExpressionResult_Response)(nil),               // 98: terraform1.stacks.InspectExpressionResult.Response
-	(*AttributePath_Step)(nil),                             // 99: terraform1.stacks.AttributePath.Step
-	(*PlannedChange_ChangeDescription)(nil),                // 100: terraform1.stacks.PlannedChange.ChangeDescription
-	(*PlannedChange_ComponentInstance)(nil),                // 101: terraform1.stacks.PlannedChange.ComponentInstance
-	(*PlannedChange_ResourceInstance)(nil),                 // 102: terraform1.stacks.PlannedChange.ResourceInstance
-	(*PlannedChange_OutputValue)(nil),                      // 103: terraform1.stacks.PlannedChange.OutputValue
-	(*PlannedChange_ResourceInstanceDeferred)(nil),         // 104: terraform1.stacks.PlannedChange.ResourceInstanceDeferred
-	(*PlannedChange_InputVariable)(nil),                    // 105: terraform1.stacks.PlannedChange.InputVariable
-	(*PlannedChange_ActionInvocationInstance)(nil),         // 106: terraform1.stacks.PlannedChange.ActionInvocationInstance
-	(*PlannedChange_ActionInvocationDeferred)(nil),         // 107: terraform1.stacks.PlannedChange.ActionInvocationDeferred
-	(*PlannedChange_ResourceActionTrigger)(nil),            // 108: terraform1.stacks.PlannedChange.ResourceActionTrigger
-	(*PlannedChange_InvokeActionTrigger)(nil),              // 109: terraform1.stacks.PlannedChange.InvokeActionTrigger
-	nil, // 110: terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry
-	(*PlannedChange_ResourceInstance_Index)(nil),                       // 111: terraform1.stacks.PlannedChange.ResourceInstance.Index
-	(*PlannedChange_ResourceInstance_Moved)(nil),                       // 112: terraform1.stacks.PlannedChange.ResourceInstance.Moved
-	(*PlannedChange_ResourceInstance_Imported)(nil),                    // 113: terraform1.stacks.PlannedChange.ResourceInstance.Imported
-	(*AppliedChange_RawChange)(nil),                                    // 114: terraform1.stacks.AppliedChange.RawChange
-	(*AppliedChange_ChangeDescription)(nil),                            // 115: terraform1.stacks.AppliedChange.ChangeDescription
-	(*AppliedChange_ResourceInstance)(nil),                             // 116: terraform1.stacks.AppliedChange.ResourceInstance
-	(*AppliedChange_ComponentInstance)(nil),                            // 117: terraform1.stacks.AppliedChange.ComponentInstance
-	(*AppliedChange_OutputValue)(nil),                                  // 118: terraform1.stacks.AppliedChange.OutputValue
-	(*AppliedChange_InputVariable)(nil),                                // 119: terraform1.stacks.AppliedChange.InputVariable
-	(*AppliedChange_Nothing)(nil),                                      // 120: terraform1.stacks.AppliedChange.Nothing
-	nil,                                                                // 121: terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry
-	(*StackChangeProgress_ComponentInstanceStatus)(nil),                // 122: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus
-	(*StackChangeProgress_ResourceInstanceStatus)(nil),                 // 123: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus
-	(*StackChangeProgress_ResourceInstancePlannedChange)(nil),          // 124: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
-	(*StackChangeProgress_DeferredResourceInstancePlannedChange)(nil),  // 125: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange
-	(*StackChangeProgress_ActionInvocationPlanned)(nil),                // 126: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned
-	(*StackChangeProgress_ActionInvocationStatus)(nil),                 // 127: terraform1.stacks.StackChangeProgress.ActionInvocationStatus
-	(*StackChangeProgress_ActionInvocationProgress)(nil),               // 128: terraform1.stacks.StackChangeProgress.ActionInvocationProgress
-	(*StackChangeProgress_ResourceActionTrigger)(nil),                  // 129: terraform1.stacks.StackChangeProgress.ResourceActionTrigger
-	(*StackChangeProgress_InvokeActionTrigger)(nil),                    // 130: terraform1.stacks.StackChangeProgress.InvokeActionTrigger
-	(*StackChangeProgress_ProvisionerStatus)(nil),                      // 131: terraform1.stacks.StackChangeProgress.ProvisionerStatus
-	(*StackChangeProgress_ProvisionerOutput)(nil),                      // 132: terraform1.stacks.StackChangeProgress.ProvisionerOutput
-	(*StackChangeProgress_ComponentInstanceChanges)(nil),               // 133: terraform1.stacks.StackChangeProgress.ComponentInstanceChanges
-	(*StackChangeProgress_ComponentInstances)(nil),                     // 134: terraform1.stacks.StackChangeProgress.ComponentInstances
-	(*StackChangeProgress_ResourceInstancePlannedChange_Moved)(nil),    // 135: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved
-	(*StackChangeProgress_ResourceInstancePlannedChange_Imported)(nil), // 136: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Imported
-	(*ListResourceIdentities_Request)(nil),                             // 137: terraform1.stacks.ListResourceIdentities.Request
-	(*ListResourceIdentities_Response)(nil),                            // 138: terraform1.stacks.ListResourceIdentities.Response
-	(*ListResourceIdentities_Resource)(nil),                            // 139: terraform1.stacks.ListResourceIdentities.Resource
-	(*terraform1.SourceRange)(nil),                                     // 140: terraform1.SourceRange
-	(*anypb.Any)(nil),                                                  // 141: google.protobuf.Any
-	(*terraform1.Diagnostic)(nil),                                      // 142: terraform1.Diagnostic
-	(*terraform1.SourceAddress)(nil),                                   // 143: terraform1.SourceAddress
+	(ResourceMode)(0), // 0: terraform1.stacks.ResourceMode
+	(PlanMode)(0),     // 1: terraform1.stacks.PlanMode
+	(ChangeType)(0),   // 2: terraform1.stacks.ChangeType
+	(FindStackConfigurationComponents_Instances)(0),         // 3: terraform1.stacks.FindStackConfigurationComponents.Instances
+	(PlannedChange_ActionTriggerEvent)(0),                   // 4: terraform1.stacks.PlannedChange.ActionTriggerEvent
+	(Deferred_Reason)(0),                                    // 5: terraform1.stacks.Deferred.Reason
+	(StackChangeProgress_ActionTriggerEvent)(0),             // 6: terraform1.stacks.StackChangeProgress.ActionTriggerEvent
+	(StackChangeProgress_ComponentInstanceStatus_Status)(0), // 7: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.Status
+	(StackChangeProgress_ResourceInstanceStatus_Status)(0),  // 8: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.Status
+	(StackChangeProgress_ActionInvocationStatus_Status)(0),  // 9: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.Status
+	(StackChangeProgress_ProvisionerStatus_Status)(0),       // 10: terraform1.stacks.StackChangeProgress.ProvisionerStatus.Status
+	(*OpenTerraformState)(nil),                              // 11: terraform1.stacks.OpenTerraformState
+	(*CloseTerraformState)(nil),                             // 12: terraform1.stacks.CloseTerraformState
+	(*MigrateTerraformState)(nil),                           // 13: terraform1.stacks.MigrateTerraformState
+	(*OpenStackConfiguration)(nil),                          // 14: terraform1.stacks.OpenStackConfiguration
+	(*CloseStackConfiguration)(nil),                         // 15: terraform1.stacks.CloseStackConfiguration
+	(*ValidateStackConfiguration)(nil),                      // 16: terraform1.stacks.ValidateStackConfiguration
+	(*FindStackConfigurationComponents)(nil),                // 17: terraform1.stacks.FindStackConfigurationComponents
+	(*OpenStackState)(nil),                                  // 18: terraform1.stacks.OpenStackState
+	(*CloseStackState)(nil),                                 // 19: terraform1.stacks.CloseStackState
+	(*PlanStackChanges)(nil),                                // 20: terraform1.stacks.PlanStackChanges
+	(*OpenStackPlan)(nil),                                   // 21: terraform1.stacks.OpenStackPlan
+	(*CloseStackPlan)(nil),                                  // 22: terraform1.stacks.CloseStackPlan
+	(*ApplyStackChanges)(nil),                               // 23: terraform1.stacks.ApplyStackChanges
+	(*OpenStackInspector)(nil),                              // 24: terraform1.stacks.OpenStackInspector
+	(*InspectExpressionResult)(nil),                         // 25: terraform1.stacks.InspectExpressionResult
+	(*DynamicValue)(nil),                                    // 26: terraform1.stacks.DynamicValue
+	(*DynamicValueChange)(nil),                              // 27: terraform1.stacks.DynamicValueChange
+	(*DynamicValueWithSource)(nil),                          // 28: terraform1.stacks.DynamicValueWithSource
+	(*AttributePath)(nil),                                   // 29: terraform1.stacks.AttributePath
+	(*ProviderInstanceInStackAddr)(nil),                     // 30: terraform1.stacks.ProviderInstanceInStackAddr
+	(*ComponentInstanceInStackAddr)(nil),                    // 31: terraform1.stacks.ComponentInstanceInStackAddr
+	(*ActionInvocationInstanceInStackAddr)(nil),             // 32: terraform1.stacks.ActionInvocationInstanceInStackAddr
+	(*ResourceInstanceInStackAddr)(nil),                     // 33: terraform1.stacks.ResourceInstanceInStackAddr
+	(*ResourceInstanceObjectInStackAddr)(nil),               // 34: terraform1.stacks.ResourceInstanceObjectInStackAddr
+	(*PlannedChange)(nil),                                   // 35: terraform1.stacks.PlannedChange
+	(*Deferred)(nil),                                        // 36: terraform1.stacks.Deferred
+	(*AppliedChange)(nil),                                   // 37: terraform1.stacks.AppliedChange
+	(*StackChangeProgress)(nil),                             // 38: terraform1.stacks.StackChangeProgress
+	(*ListResourceIdentities)(nil),                          // 39: terraform1.stacks.ListResourceIdentities
+	(*ComponentInstancePolicyEvaluation)(nil),               // 40: terraform1.stacks.ComponentInstancePolicyEvaluation
+	(*ProviderInstancePolicyEvaluation)(nil),                // 41: terraform1.stacks.ProviderInstancePolicyEvaluation
+	(*OpenTerraformState_Request)(nil),                      // 42: terraform1.stacks.OpenTerraformState.Request
+	(*OpenTerraformState_Response)(nil),                     // 43: terraform1.stacks.OpenTerraformState.Response
+	(*CloseTerraformState_Request)(nil),                     // 44: terraform1.stacks.CloseTerraformState.Request
+	(*CloseTerraformState_Response)(nil),                    // 45: terraform1.stacks.CloseTerraformState.Response
+	(*MigrateTerraformState_Request)(nil),                   // 46: terraform1.stacks.MigrateTerraformState.Request
+	(*MigrateTerraformState_Event)(nil),                     // 47: terraform1.stacks.MigrateTerraformState.Event
+	(*MigrateTerraformState_Request_Mapping)(nil),           // 48: terraform1.stacks.MigrateTerraformState.Request.Mapping
+	nil,                                      // 49: terraform1.stacks.MigrateTerraformState.Request.Mapping.ResourceAddressMapEntry
+	nil,                                      // 50: terraform1.stacks.MigrateTerraformState.Request.Mapping.ModuleAddressMapEntry
+	(*OpenStackConfiguration_Request)(nil),   // 51: terraform1.stacks.OpenStackConfiguration.Request
+	(*OpenStackConfiguration_Response)(nil),  // 52: terraform1.stacks.OpenStackConfiguration.Response
+	(*CloseStackConfiguration_Request)(nil),  // 53: terraform1.stacks.CloseStackConfiguration.Request
+	(*CloseStackConfiguration_Response)(nil), // 54: terraform1.stacks.CloseStackConfiguration.Response
+	(*ValidateStackConfiguration_Request)(nil),             // 55: terraform1.stacks.ValidateStackConfiguration.Request
+	(*ValidateStackConfiguration_Response)(nil),            // 56: terraform1.stacks.ValidateStackConfiguration.Response
+	(*FindStackConfigurationComponents_Request)(nil),       // 57: terraform1.stacks.FindStackConfigurationComponents.Request
+	(*FindStackConfigurationComponents_Response)(nil),      // 58: terraform1.stacks.FindStackConfigurationComponents.Response
+	(*FindStackConfigurationComponents_StackConfig)(nil),   // 59: terraform1.stacks.FindStackConfigurationComponents.StackConfig
+	(*FindStackConfigurationComponents_EmbeddedStack)(nil), // 60: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack
+	(*FindStackConfigurationComponents_Component)(nil),     // 61: terraform1.stacks.FindStackConfigurationComponents.Component
+	(*FindStackConfigurationComponents_Removed)(nil),       // 62: terraform1.stacks.FindStackConfigurationComponents.Removed
+	(*FindStackConfigurationComponents_InputVariable)(nil), // 63: terraform1.stacks.FindStackConfigurationComponents.InputVariable
+	(*FindStackConfigurationComponents_OutputValue)(nil),   // 64: terraform1.stacks.FindStackConfigurationComponents.OutputValue
+	nil, // 65: terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry
+	nil, // 66: terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry
+	nil, // 67: terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry
+	nil, // 68: terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry
+	nil, // 69: terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry
+	(*FindStackConfigurationComponents_Removed_Block)(nil), // 70: terraform1.stacks.FindStackConfigurationComponents.Removed.Block
+	(*OpenStackState_RequestItem)(nil),                     // 71: terraform1.stacks.OpenStackState.RequestItem
+	(*OpenStackState_Response)(nil),                        // 72: terraform1.stacks.OpenStackState.Response
+	(*CloseStackState_Request)(nil),                        // 73: terraform1.stacks.CloseStackState.Request
+	(*CloseStackState_Response)(nil),                       // 74: terraform1.stacks.CloseStackState.Response
+	(*PlanStackChanges_Request)(nil),                       // 75: terraform1.stacks.PlanStackChanges.Request
+	(*PlanStackChanges_Event)(nil),                         // 76: terraform1.stacks.PlanStackChanges.Event
+	nil,                                                    // 77: terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry
+	nil,                                                    // 78: terraform1.stacks.PlanStackChanges.Request.InputValuesEntry
+	(*OpenStackPlan_RequestItem)(nil),                      // 79: terraform1.stacks.OpenStackPlan.RequestItem
+	(*OpenStackPlan_Response)(nil),                         // 80: terraform1.stacks.OpenStackPlan.Response
+	(*CloseStackPlan_Request)(nil),                         // 81: terraform1.stacks.CloseStackPlan.Request
+	(*CloseStackPlan_Response)(nil),                        // 82: terraform1.stacks.CloseStackPlan.Response
+	(*ApplyStackChanges_Request)(nil),                      // 83: terraform1.stacks.ApplyStackChanges.Request
+	(*ApplyStackChanges_Event)(nil),                        // 84: terraform1.stacks.ApplyStackChanges.Event
+	nil,                                                    // 85: terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry
+	(*OpenStackInspector_Request)(nil),                     // 86: terraform1.stacks.OpenStackInspector.Request
+	(*OpenStackInspector_Response)(nil),                    // 87: terraform1.stacks.OpenStackInspector.Response
+	nil,                                                    // 88: terraform1.stacks.OpenStackInspector.Request.StateEntry
+	nil,                                                    // 89: terraform1.stacks.OpenStackInspector.Request.InputValuesEntry
+	(*InspectExpressionResult_Request)(nil),                // 90: terraform1.stacks.InspectExpressionResult.Request
+	(*InspectExpressionResult_Response)(nil),               // 91: terraform1.stacks.InspectExpressionResult.Response
+	(*AttributePath_Step)(nil),                             // 92: terraform1.stacks.AttributePath.Step
+	(*PlannedChange_ChangeDescription)(nil),                // 93: terraform1.stacks.PlannedChange.ChangeDescription
+	(*PlannedChange_ComponentInstance)(nil),                // 94: terraform1.stacks.PlannedChange.ComponentInstance
+	(*PlannedChange_ResourceInstance)(nil),                 // 95: terraform1.stacks.PlannedChange.ResourceInstance
+	(*PlannedChange_OutputValue)(nil),                      // 96: terraform1.stacks.PlannedChange.OutputValue
+	(*PlannedChange_ResourceInstanceDeferred)(nil),         // 97: terraform1.stacks.PlannedChange.ResourceInstanceDeferred
+	(*PlannedChange_InputVariable)(nil),                    // 98: terraform1.stacks.PlannedChange.InputVariable
+	(*PlannedChange_ActionInvocationInstance)(nil),         // 99: terraform1.stacks.PlannedChange.ActionInvocationInstance
+	(*PlannedChange_ActionInvocationDeferred)(nil),         // 100: terraform1.stacks.PlannedChange.ActionInvocationDeferred
+	(*PlannedChange_ResourceActionTrigger)(nil),            // 101: terraform1.stacks.PlannedChange.ResourceActionTrigger
+	(*PlannedChange_InvokeActionTrigger)(nil),              // 102: terraform1.stacks.PlannedChange.InvokeActionTrigger
+	nil, // 103: terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry
+	(*PlannedChange_ResourceInstance_Index)(nil),                       // 104: terraform1.stacks.PlannedChange.ResourceInstance.Index
+	(*PlannedChange_ResourceInstance_Moved)(nil),                       // 105: terraform1.stacks.PlannedChange.ResourceInstance.Moved
+	(*PlannedChange_ResourceInstance_Imported)(nil),                    // 106: terraform1.stacks.PlannedChange.ResourceInstance.Imported
+	(*AppliedChange_RawChange)(nil),                                    // 107: terraform1.stacks.AppliedChange.RawChange
+	(*AppliedChange_ChangeDescription)(nil),                            // 108: terraform1.stacks.AppliedChange.ChangeDescription
+	(*AppliedChange_ResourceInstance)(nil),                             // 109: terraform1.stacks.AppliedChange.ResourceInstance
+	(*AppliedChange_ComponentInstance)(nil),                            // 110: terraform1.stacks.AppliedChange.ComponentInstance
+	(*AppliedChange_OutputValue)(nil),                                  // 111: terraform1.stacks.AppliedChange.OutputValue
+	(*AppliedChange_InputVariable)(nil),                                // 112: terraform1.stacks.AppliedChange.InputVariable
+	(*AppliedChange_Nothing)(nil),                                      // 113: terraform1.stacks.AppliedChange.Nothing
+	nil,                                                                // 114: terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry
+	(*StackChangeProgress_ComponentInstanceStatus)(nil),                // 115: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus
+	(*StackChangeProgress_ResourceInstanceStatus)(nil),                 // 116: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus
+	(*StackChangeProgress_ResourceInstancePlannedChange)(nil),          // 117: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
+	(*StackChangeProgress_DeferredResourceInstancePlannedChange)(nil),  // 118: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange
+	(*StackChangeProgress_ActionInvocationPlanned)(nil),                // 119: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned
+	(*StackChangeProgress_ActionInvocationStatus)(nil),                 // 120: terraform1.stacks.StackChangeProgress.ActionInvocationStatus
+	(*StackChangeProgress_ActionInvocationProgress)(nil),               // 121: terraform1.stacks.StackChangeProgress.ActionInvocationProgress
+	(*StackChangeProgress_ResourceActionTrigger)(nil),                  // 122: terraform1.stacks.StackChangeProgress.ResourceActionTrigger
+	(*StackChangeProgress_InvokeActionTrigger)(nil),                    // 123: terraform1.stacks.StackChangeProgress.InvokeActionTrigger
+	(*StackChangeProgress_ProvisionerStatus)(nil),                      // 124: terraform1.stacks.StackChangeProgress.ProvisionerStatus
+	(*StackChangeProgress_ProvisionerOutput)(nil),                      // 125: terraform1.stacks.StackChangeProgress.ProvisionerOutput
+	(*StackChangeProgress_ComponentInstanceChanges)(nil),               // 126: terraform1.stacks.StackChangeProgress.ComponentInstanceChanges
+	(*StackChangeProgress_ComponentInstances)(nil),                     // 127: terraform1.stacks.StackChangeProgress.ComponentInstances
+	(*StackChangeProgress_ResourceInstancePlannedChange_Moved)(nil),    // 128: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved
+	(*StackChangeProgress_ResourceInstancePlannedChange_Imported)(nil), // 129: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Imported
+	(*ListResourceIdentities_Request)(nil),                             // 130: terraform1.stacks.ListResourceIdentities.Request
+	(*ListResourceIdentities_Response)(nil),                            // 131: terraform1.stacks.ListResourceIdentities.Response
+	(*ListResourceIdentities_Resource)(nil),                            // 132: terraform1.stacks.ListResourceIdentities.Resource
+	(*terraform1.SourceRange)(nil),                                     // 133: terraform1.SourceRange
+	(*anypb.Any)(nil),                                                  // 134: google.protobuf.Any
+	(*terraform1.PolicyResult)(nil),                                    // 135: terraform1.PolicyResult
+	(*terraform1.PolicyInfo)(nil),                                      // 136: terraform1.PolicyInfo
+	(*terraform1.PolicyDiagnostic)(nil),                                // 137: terraform1.PolicyDiagnostic
+	(*terraform1.Diagnostic)(nil),                                      // 138: terraform1.Diagnostic
+	(*terraform1.SourceAddress)(nil),                                   // 139: terraform1.SourceAddress
 }
 var file_stacks_proto_depIdxs = []int32{
-	30,  // 0: terraform1.stacks.DynamicValue.sensitive:type_name -> terraform1.stacks.AttributePath
-	27,  // 1: terraform1.stacks.DynamicValueChange.old:type_name -> terraform1.stacks.DynamicValue
-	27,  // 2: terraform1.stacks.DynamicValueChange.new:type_name -> terraform1.stacks.DynamicValue
-	27,  // 3: terraform1.stacks.DynamicValueWithSource.value:type_name -> terraform1.stacks.DynamicValue
-	140, // 4: terraform1.stacks.DynamicValueWithSource.source_range:type_name -> terraform1.SourceRange
-	99,  // 5: terraform1.stacks.AttributePath.steps:type_name -> terraform1.stacks.AttributePath.Step
-	141, // 6: terraform1.stacks.PlannedChange.raw:type_name -> google.protobuf.Any
-	100, // 7: terraform1.stacks.PlannedChange.descriptions:type_name -> terraform1.stacks.PlannedChange.ChangeDescription
-	6,   // 8: terraform1.stacks.Deferred.reason:type_name -> terraform1.stacks.Deferred.Reason
-	114, // 9: terraform1.stacks.AppliedChange.raw:type_name -> terraform1.stacks.AppliedChange.RawChange
-	115, // 10: terraform1.stacks.AppliedChange.descriptions:type_name -> terraform1.stacks.AppliedChange.ChangeDescription
-	122, // 11: terraform1.stacks.StackChangeProgress.component_instance_status:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceStatus
-	123, // 12: terraform1.stacks.StackChangeProgress.resource_instance_status:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstanceStatus
-	124, // 13: terraform1.stacks.StackChangeProgress.resource_instance_planned_change:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
-	131, // 14: terraform1.stacks.StackChangeProgress.provisioner_status:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerStatus
-	132, // 15: terraform1.stacks.StackChangeProgress.provisioner_output:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerOutput
-	133, // 16: terraform1.stacks.StackChangeProgress.component_instance_changes:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceChanges
-	134, // 17: terraform1.stacks.StackChangeProgress.component_instances:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstances
-	125, // 18: terraform1.stacks.StackChangeProgress.deferred_resource_instance_planned_change:type_name -> terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange
-	126, // 19: terraform1.stacks.StackChangeProgress.action_invocation_planned:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationPlanned
-	127, // 20: terraform1.stacks.StackChangeProgress.action_invocation_status:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationStatus
-	128, // 21: terraform1.stacks.StackChangeProgress.action_invocation_progress:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationProgress
-	32,  // 22: terraform1.stacks.ComponentInstancePolicyEvaluation.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
-	44,  // 23: terraform1.stacks.ComponentInstancePolicyEvaluation.results:type_name -> terraform1.stacks.PolicyResult
-	45,  // 24: terraform1.stacks.ComponentInstancePolicyEvaluation.infos:type_name -> terraform1.stacks.PolicyInfo
-	47,  // 25: terraform1.stacks.ComponentInstancePolicyEvaluation.diagnostics:type_name -> terraform1.stacks.PolicyDiagnostic
-	31,  // 26: terraform1.stacks.ProviderInstancePolicyEvaluation.addr:type_name -> terraform1.stacks.ProviderInstanceInStackAddr
-	44,  // 27: terraform1.stacks.ProviderInstancePolicyEvaluation.results:type_name -> terraform1.stacks.PolicyResult
-	45,  // 28: terraform1.stacks.ProviderInstancePolicyEvaluation.infos:type_name -> terraform1.stacks.PolicyInfo
-	47,  // 29: terraform1.stacks.ProviderInstancePolicyEvaluation.diagnostics:type_name -> terraform1.stacks.PolicyDiagnostic
-	43,  // 30: terraform1.stacks.PolicyResult.policy_metadata:type_name -> terraform1.stacks.PolicyMetaData
-	3,   // 31: terraform1.stacks.PolicyResult.result:type_name -> terraform1.stacks.EvaluateResult
-	43,  // 32: terraform1.stacks.PolicyInfo.policy_metadata:type_name -> terraform1.stacks.PolicyMetaData
-	140, // 33: terraform1.stacks.PolicyInfo.policy_range:type_name -> terraform1.SourceRange
-	46,  // 34: terraform1.stacks.PolicyInfo.policy_snippet:type_name -> terraform1.stacks.PolicySnippet
-	3,   // 35: terraform1.stacks.PolicyInfo.result:type_name -> terraform1.stacks.EvaluateResult
-	43,  // 36: terraform1.stacks.PolicyDiagnostic.policy_metadata:type_name -> terraform1.stacks.PolicyMetaData
-	3,   // 37: terraform1.stacks.PolicyDiagnostic.result:type_name -> terraform1.stacks.EvaluateResult
-	142, // 38: terraform1.stacks.PolicyDiagnostic.diagnostic:type_name -> terraform1.Diagnostic
-	46,  // 39: terraform1.stacks.PolicyDiagnostic.policy_snippet:type_name -> terraform1.stacks.PolicySnippet
-	140, // 40: terraform1.stacks.PolicyDiagnostic.policy_range:type_name -> terraform1.SourceRange
-	48,  // 41: terraform1.stacks.PolicyDiagnostic.expression_values:type_name -> terraform1.stacks.ExpressionValue
-	30,  // 42: terraform1.stacks.ExpressionValue.traversal:type_name -> terraform1.stacks.AttributePath
-	142, // 43: terraform1.stacks.OpenTerraformState.Response.diagnostics:type_name -> terraform1.Diagnostic
-	55,  // 44: terraform1.stacks.MigrateTerraformState.Request.simple:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping
-	142, // 45: terraform1.stacks.MigrateTerraformState.Event.diagnostic:type_name -> terraform1.Diagnostic
-	38,  // 46: terraform1.stacks.MigrateTerraformState.Event.applied_change:type_name -> terraform1.stacks.AppliedChange
-	56,  // 47: terraform1.stacks.MigrateTerraformState.Request.Mapping.resource_address_map:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping.ResourceAddressMapEntry
-	57,  // 48: terraform1.stacks.MigrateTerraformState.Request.Mapping.module_address_map:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping.ModuleAddressMapEntry
-	143, // 49: terraform1.stacks.OpenStackConfiguration.Request.source_address:type_name -> terraform1.SourceAddress
-	142, // 50: terraform1.stacks.OpenStackConfiguration.Response.diagnostics:type_name -> terraform1.Diagnostic
-	142, // 51: terraform1.stacks.ValidateStackConfiguration.Response.diagnostics:type_name -> terraform1.Diagnostic
-	66,  // 52: terraform1.stacks.FindStackConfigurationComponents.Response.config:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig
-	72,  // 53: terraform1.stacks.FindStackConfigurationComponents.StackConfig.components:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry
-	73,  // 54: terraform1.stacks.FindStackConfigurationComponents.StackConfig.embedded_stacks:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry
-	74,  // 55: terraform1.stacks.FindStackConfigurationComponents.StackConfig.input_variables:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry
-	75,  // 56: terraform1.stacks.FindStackConfigurationComponents.StackConfig.output_values:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry
-	76,  // 57: terraform1.stacks.FindStackConfigurationComponents.StackConfig.removed:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry
-	4,   // 58: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
-	66,  // 59: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack.config:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig
-	4,   // 60: terraform1.stacks.FindStackConfigurationComponents.Component.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
-	4,   // 61: terraform1.stacks.FindStackConfigurationComponents.Removed.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
-	77,  // 62: terraform1.stacks.FindStackConfigurationComponents.Removed.blocks:type_name -> terraform1.stacks.FindStackConfigurationComponents.Removed.Block
-	68,  // 63: terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.Component
-	67,  // 64: terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack
-	70,  // 65: terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.InputVariable
-	71,  // 66: terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.OutputValue
-	69,  // 67: terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.Removed
-	4,   // 68: terraform1.stacks.FindStackConfigurationComponents.Removed.Block.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
-	114, // 69: terraform1.stacks.OpenStackState.RequestItem.raw:type_name -> terraform1.stacks.AppliedChange.RawChange
-	1,   // 70: terraform1.stacks.PlanStackChanges.Request.plan_mode:type_name -> terraform1.stacks.PlanMode
-	84,  // 71: terraform1.stacks.PlanStackChanges.Request.previous_state:type_name -> terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry
-	85,  // 72: terraform1.stacks.PlanStackChanges.Request.input_values:type_name -> terraform1.stacks.PlanStackChanges.Request.InputValuesEntry
-	36,  // 73: terraform1.stacks.PlanStackChanges.Event.planned_change:type_name -> terraform1.stacks.PlannedChange
-	142, // 74: terraform1.stacks.PlanStackChanges.Event.diagnostic:type_name -> terraform1.Diagnostic
-	39,  // 75: terraform1.stacks.PlanStackChanges.Event.progress:type_name -> terraform1.stacks.StackChangeProgress
-	41,  // 76: terraform1.stacks.PlanStackChanges.Event.component_instance_policy_evaluation:type_name -> terraform1.stacks.ComponentInstancePolicyEvaluation
-	42,  // 77: terraform1.stacks.PlanStackChanges.Event.provider_instance_policy_evaluation:type_name -> terraform1.stacks.ProviderInstancePolicyEvaluation
-	141, // 78: terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry.value:type_name -> google.protobuf.Any
-	29,  // 79: terraform1.stacks.PlanStackChanges.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
-	141, // 80: terraform1.stacks.OpenStackPlan.RequestItem.raw:type_name -> google.protobuf.Any
-	141, // 81: terraform1.stacks.ApplyStackChanges.Request.planned_changes:type_name -> google.protobuf.Any
-	92,  // 82: terraform1.stacks.ApplyStackChanges.Request.input_values:type_name -> terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry
-	38,  // 83: terraform1.stacks.ApplyStackChanges.Event.applied_change:type_name -> terraform1.stacks.AppliedChange
-	142, // 84: terraform1.stacks.ApplyStackChanges.Event.diagnostic:type_name -> terraform1.Diagnostic
-	39,  // 85: terraform1.stacks.ApplyStackChanges.Event.progress:type_name -> terraform1.stacks.StackChangeProgress
-	41,  // 86: terraform1.stacks.ApplyStackChanges.Event.component_instance_policy_evaluation:type_name -> terraform1.stacks.ComponentInstancePolicyEvaluation
-	42,  // 87: terraform1.stacks.ApplyStackChanges.Event.provider_instance_policy_evaluation:type_name -> terraform1.stacks.ProviderInstancePolicyEvaluation
-	29,  // 88: terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
-	95,  // 89: terraform1.stacks.OpenStackInspector.Request.state:type_name -> terraform1.stacks.OpenStackInspector.Request.StateEntry
-	96,  // 90: terraform1.stacks.OpenStackInspector.Request.input_values:type_name -> terraform1.stacks.OpenStackInspector.Request.InputValuesEntry
-	142, // 91: terraform1.stacks.OpenStackInspector.Response.diagnostics:type_name -> terraform1.Diagnostic
-	141, // 92: terraform1.stacks.OpenStackInspector.Request.StateEntry.value:type_name -> google.protobuf.Any
-	29,  // 93: terraform1.stacks.OpenStackInspector.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
-	27,  // 94: terraform1.stacks.InspectExpressionResult.Response.result:type_name -> terraform1.stacks.DynamicValue
-	142, // 95: terraform1.stacks.InspectExpressionResult.Response.diagnostics:type_name -> terraform1.Diagnostic
-	101, // 96: terraform1.stacks.PlannedChange.ChangeDescription.component_instance_planned:type_name -> terraform1.stacks.PlannedChange.ComponentInstance
-	102, // 97: terraform1.stacks.PlannedChange.ChangeDescription.resource_instance_planned:type_name -> terraform1.stacks.PlannedChange.ResourceInstance
-	103, // 98: terraform1.stacks.PlannedChange.ChangeDescription.output_value_planned:type_name -> terraform1.stacks.PlannedChange.OutputValue
-	104, // 99: terraform1.stacks.PlannedChange.ChangeDescription.resource_instance_deferred:type_name -> terraform1.stacks.PlannedChange.ResourceInstanceDeferred
-	105, // 100: terraform1.stacks.PlannedChange.ChangeDescription.input_variable_planned:type_name -> terraform1.stacks.PlannedChange.InputVariable
-	106, // 101: terraform1.stacks.PlannedChange.ChangeDescription.action_invocation_planned:type_name -> terraform1.stacks.PlannedChange.ActionInvocationInstance
-	107, // 102: terraform1.stacks.PlannedChange.ChangeDescription.action_invocation_deferred:type_name -> terraform1.stacks.PlannedChange.ActionInvocationDeferred
-	32,  // 103: terraform1.stacks.PlannedChange.ComponentInstance.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
-	2,   // 104: terraform1.stacks.PlannedChange.ComponentInstance.actions:type_name -> terraform1.stacks.ChangeType
-	110, // 105: terraform1.stacks.PlannedChange.ComponentInstance.output_values:type_name -> terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry
-	35,  // 106: terraform1.stacks.PlannedChange.ResourceInstance.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	2,   // 107: terraform1.stacks.PlannedChange.ResourceInstance.actions:type_name -> terraform1.stacks.ChangeType
-	28,  // 108: terraform1.stacks.PlannedChange.ResourceInstance.values:type_name -> terraform1.stacks.DynamicValueChange
-	112, // 109: terraform1.stacks.PlannedChange.ResourceInstance.moved:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Moved
-	113, // 110: terraform1.stacks.PlannedChange.ResourceInstance.imported:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Imported
-	0,   // 111: terraform1.stacks.PlannedChange.ResourceInstance.resource_mode:type_name -> terraform1.stacks.ResourceMode
-	27,  // 112: terraform1.stacks.PlannedChange.ResourceInstance.previous_run_value:type_name -> terraform1.stacks.DynamicValue
-	30,  // 113: terraform1.stacks.PlannedChange.ResourceInstance.replace_paths:type_name -> terraform1.stacks.AttributePath
-	111, // 114: terraform1.stacks.PlannedChange.ResourceInstance.index:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Index
-	2,   // 115: terraform1.stacks.PlannedChange.OutputValue.actions:type_name -> terraform1.stacks.ChangeType
-	28,  // 116: terraform1.stacks.PlannedChange.OutputValue.values:type_name -> terraform1.stacks.DynamicValueChange
-	102, // 117: terraform1.stacks.PlannedChange.ResourceInstanceDeferred.resource_instance:type_name -> terraform1.stacks.PlannedChange.ResourceInstance
-	37,  // 118: terraform1.stacks.PlannedChange.ResourceInstanceDeferred.deferred:type_name -> terraform1.stacks.Deferred
-	2,   // 119: terraform1.stacks.PlannedChange.InputVariable.actions:type_name -> terraform1.stacks.ChangeType
-	28,  // 120: terraform1.stacks.PlannedChange.InputVariable.values:type_name -> terraform1.stacks.DynamicValueChange
-	33,  // 121: terraform1.stacks.PlannedChange.ActionInvocationInstance.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
-	27,  // 122: terraform1.stacks.PlannedChange.ActionInvocationInstance.config_value:type_name -> terraform1.stacks.DynamicValue
-	108, // 123: terraform1.stacks.PlannedChange.ActionInvocationInstance.resource_action_trigger:type_name -> terraform1.stacks.PlannedChange.ResourceActionTrigger
-	109, // 124: terraform1.stacks.PlannedChange.ActionInvocationInstance.invoke_action_trigger:type_name -> terraform1.stacks.PlannedChange.InvokeActionTrigger
-	37,  // 125: terraform1.stacks.PlannedChange.ActionInvocationDeferred.deferred:type_name -> terraform1.stacks.Deferred
-	106, // 126: terraform1.stacks.PlannedChange.ActionInvocationDeferred.action_invocation:type_name -> terraform1.stacks.PlannedChange.ActionInvocationInstance
-	34,  // 127: terraform1.stacks.PlannedChange.ResourceActionTrigger.triggering_resource_address:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
-	5,   // 128: terraform1.stacks.PlannedChange.ResourceActionTrigger.trigger_event:type_name -> terraform1.stacks.PlannedChange.ActionTriggerEvent
-	27,  // 129: terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry.value:type_name -> terraform1.stacks.DynamicValue
-	27,  // 130: terraform1.stacks.PlannedChange.ResourceInstance.Index.value:type_name -> terraform1.stacks.DynamicValue
-	34,  // 131: terraform1.stacks.PlannedChange.ResourceInstance.Moved.prev_addr:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
-	141, // 132: terraform1.stacks.AppliedChange.RawChange.value:type_name -> google.protobuf.Any
-	120, // 133: terraform1.stacks.AppliedChange.ChangeDescription.deleted:type_name -> terraform1.stacks.AppliedChange.Nothing
-	120, // 134: terraform1.stacks.AppliedChange.ChangeDescription.moved:type_name -> terraform1.stacks.AppliedChange.Nothing
-	116, // 135: terraform1.stacks.AppliedChange.ChangeDescription.resource_instance:type_name -> terraform1.stacks.AppliedChange.ResourceInstance
-	118, // 136: terraform1.stacks.AppliedChange.ChangeDescription.output_value:type_name -> terraform1.stacks.AppliedChange.OutputValue
-	119, // 137: terraform1.stacks.AppliedChange.ChangeDescription.input_variable:type_name -> terraform1.stacks.AppliedChange.InputVariable
-	117, // 138: terraform1.stacks.AppliedChange.ChangeDescription.component_instance:type_name -> terraform1.stacks.AppliedChange.ComponentInstance
-	35,  // 139: terraform1.stacks.AppliedChange.ResourceInstance.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	27,  // 140: terraform1.stacks.AppliedChange.ResourceInstance.new_value:type_name -> terraform1.stacks.DynamicValue
-	0,   // 141: terraform1.stacks.AppliedChange.ResourceInstance.resource_mode:type_name -> terraform1.stacks.ResourceMode
-	121, // 142: terraform1.stacks.AppliedChange.ComponentInstance.output_values:type_name -> terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry
-	27,  // 143: terraform1.stacks.AppliedChange.OutputValue.new_value:type_name -> terraform1.stacks.DynamicValue
-	27,  // 144: terraform1.stacks.AppliedChange.InputVariable.new_value:type_name -> terraform1.stacks.DynamicValue
-	27,  // 145: terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry.value:type_name -> terraform1.stacks.DynamicValue
-	32,  // 146: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
-	8,   // 147: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.Status
-	35,  // 148: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	9,   // 149: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.Status
-	35,  // 150: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	2,   // 151: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.actions:type_name -> terraform1.stacks.ChangeType
-	135, // 152: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.moved:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved
-	136, // 153: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.imported:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Imported
-	37,  // 154: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange.deferred:type_name -> terraform1.stacks.Deferred
-	124, // 155: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange.change:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
-	33,  // 156: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
-	129, // 157: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
-	130, // 158: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
-	33,  // 159: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
-	10,  // 160: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationStatus.Status
-	129, // 161: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
-	130, // 162: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
-	33,  // 163: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
-	129, // 164: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
-	130, // 165: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
-	34,  // 166: terraform1.stacks.StackChangeProgress.ResourceActionTrigger.triggering_resource_address:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
-	7,   // 167: terraform1.stacks.StackChangeProgress.ResourceActionTrigger.trigger_event:type_name -> terraform1.stacks.StackChangeProgress.ActionTriggerEvent
-	35,  // 168: terraform1.stacks.StackChangeProgress.ProvisionerStatus.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	131, // 169: terraform1.stacks.StackChangeProgress.ProvisionerStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerStatus
-	35,  // 170: terraform1.stacks.StackChangeProgress.ProvisionerOutput.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	32,  // 171: terraform1.stacks.StackChangeProgress.ComponentInstanceChanges.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
-	34,  // 172: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved.prev_addr:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
-	139, // 173: terraform1.stacks.ListResourceIdentities.Response.resource:type_name -> terraform1.stacks.ListResourceIdentities.Resource
-	27,  // 174: terraform1.stacks.ListResourceIdentities.Resource.resource_identity:type_name -> terraform1.stacks.DynamicValue
-	58,  // 175: terraform1.stacks.Stacks.OpenStackConfiguration:input_type -> terraform1.stacks.OpenStackConfiguration.Request
-	60,  // 176: terraform1.stacks.Stacks.CloseStackConfiguration:input_type -> terraform1.stacks.CloseStackConfiguration.Request
-	62,  // 177: terraform1.stacks.Stacks.ValidateStackConfiguration:input_type -> terraform1.stacks.ValidateStackConfiguration.Request
-	64,  // 178: terraform1.stacks.Stacks.FindStackConfigurationComponents:input_type -> terraform1.stacks.FindStackConfigurationComponents.Request
-	78,  // 179: terraform1.stacks.Stacks.OpenState:input_type -> terraform1.stacks.OpenStackState.RequestItem
-	80,  // 180: terraform1.stacks.Stacks.CloseState:input_type -> terraform1.stacks.CloseStackState.Request
-	82,  // 181: terraform1.stacks.Stacks.PlanStackChanges:input_type -> terraform1.stacks.PlanStackChanges.Request
-	86,  // 182: terraform1.stacks.Stacks.OpenPlan:input_type -> terraform1.stacks.OpenStackPlan.RequestItem
-	88,  // 183: terraform1.stacks.Stacks.ClosePlan:input_type -> terraform1.stacks.CloseStackPlan.Request
-	90,  // 184: terraform1.stacks.Stacks.ApplyStackChanges:input_type -> terraform1.stacks.ApplyStackChanges.Request
-	93,  // 185: terraform1.stacks.Stacks.OpenStackInspector:input_type -> terraform1.stacks.OpenStackInspector.Request
-	97,  // 186: terraform1.stacks.Stacks.InspectExpressionResult:input_type -> terraform1.stacks.InspectExpressionResult.Request
-	49,  // 187: terraform1.stacks.Stacks.OpenTerraformState:input_type -> terraform1.stacks.OpenTerraformState.Request
-	51,  // 188: terraform1.stacks.Stacks.CloseTerraformState:input_type -> terraform1.stacks.CloseTerraformState.Request
-	53,  // 189: terraform1.stacks.Stacks.MigrateTerraformState:input_type -> terraform1.stacks.MigrateTerraformState.Request
-	137, // 190: terraform1.stacks.Stacks.ListResourceIdentities:input_type -> terraform1.stacks.ListResourceIdentities.Request
-	59,  // 191: terraform1.stacks.Stacks.OpenStackConfiguration:output_type -> terraform1.stacks.OpenStackConfiguration.Response
-	61,  // 192: terraform1.stacks.Stacks.CloseStackConfiguration:output_type -> terraform1.stacks.CloseStackConfiguration.Response
-	63,  // 193: terraform1.stacks.Stacks.ValidateStackConfiguration:output_type -> terraform1.stacks.ValidateStackConfiguration.Response
-	65,  // 194: terraform1.stacks.Stacks.FindStackConfigurationComponents:output_type -> terraform1.stacks.FindStackConfigurationComponents.Response
-	79,  // 195: terraform1.stacks.Stacks.OpenState:output_type -> terraform1.stacks.OpenStackState.Response
-	81,  // 196: terraform1.stacks.Stacks.CloseState:output_type -> terraform1.stacks.CloseStackState.Response
-	83,  // 197: terraform1.stacks.Stacks.PlanStackChanges:output_type -> terraform1.stacks.PlanStackChanges.Event
-	87,  // 198: terraform1.stacks.Stacks.OpenPlan:output_type -> terraform1.stacks.OpenStackPlan.Response
-	89,  // 199: terraform1.stacks.Stacks.ClosePlan:output_type -> terraform1.stacks.CloseStackPlan.Response
-	91,  // 200: terraform1.stacks.Stacks.ApplyStackChanges:output_type -> terraform1.stacks.ApplyStackChanges.Event
-	94,  // 201: terraform1.stacks.Stacks.OpenStackInspector:output_type -> terraform1.stacks.OpenStackInspector.Response
-	98,  // 202: terraform1.stacks.Stacks.InspectExpressionResult:output_type -> terraform1.stacks.InspectExpressionResult.Response
-	50,  // 203: terraform1.stacks.Stacks.OpenTerraformState:output_type -> terraform1.stacks.OpenTerraformState.Response
-	52,  // 204: terraform1.stacks.Stacks.CloseTerraformState:output_type -> terraform1.stacks.CloseTerraformState.Response
-	54,  // 205: terraform1.stacks.Stacks.MigrateTerraformState:output_type -> terraform1.stacks.MigrateTerraformState.Event
-	138, // 206: terraform1.stacks.Stacks.ListResourceIdentities:output_type -> terraform1.stacks.ListResourceIdentities.Response
-	191, // [191:207] is the sub-list for method output_type
-	175, // [175:191] is the sub-list for method input_type
-	175, // [175:175] is the sub-list for extension type_name
-	175, // [175:175] is the sub-list for extension extendee
-	0,   // [0:175] is the sub-list for field type_name
+	29,  // 0: terraform1.stacks.DynamicValue.sensitive:type_name -> terraform1.stacks.AttributePath
+	26,  // 1: terraform1.stacks.DynamicValueChange.old:type_name -> terraform1.stacks.DynamicValue
+	26,  // 2: terraform1.stacks.DynamicValueChange.new:type_name -> terraform1.stacks.DynamicValue
+	26,  // 3: terraform1.stacks.DynamicValueWithSource.value:type_name -> terraform1.stacks.DynamicValue
+	133, // 4: terraform1.stacks.DynamicValueWithSource.source_range:type_name -> terraform1.SourceRange
+	92,  // 5: terraform1.stacks.AttributePath.steps:type_name -> terraform1.stacks.AttributePath.Step
+	134, // 6: terraform1.stacks.PlannedChange.raw:type_name -> google.protobuf.Any
+	93,  // 7: terraform1.stacks.PlannedChange.descriptions:type_name -> terraform1.stacks.PlannedChange.ChangeDescription
+	5,   // 8: terraform1.stacks.Deferred.reason:type_name -> terraform1.stacks.Deferred.Reason
+	107, // 9: terraform1.stacks.AppliedChange.raw:type_name -> terraform1.stacks.AppliedChange.RawChange
+	108, // 10: terraform1.stacks.AppliedChange.descriptions:type_name -> terraform1.stacks.AppliedChange.ChangeDescription
+	115, // 11: terraform1.stacks.StackChangeProgress.component_instance_status:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceStatus
+	116, // 12: terraform1.stacks.StackChangeProgress.resource_instance_status:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstanceStatus
+	117, // 13: terraform1.stacks.StackChangeProgress.resource_instance_planned_change:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
+	124, // 14: terraform1.stacks.StackChangeProgress.provisioner_status:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerStatus
+	125, // 15: terraform1.stacks.StackChangeProgress.provisioner_output:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerOutput
+	126, // 16: terraform1.stacks.StackChangeProgress.component_instance_changes:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceChanges
+	127, // 17: terraform1.stacks.StackChangeProgress.component_instances:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstances
+	118, // 18: terraform1.stacks.StackChangeProgress.deferred_resource_instance_planned_change:type_name -> terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange
+	119, // 19: terraform1.stacks.StackChangeProgress.action_invocation_planned:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationPlanned
+	120, // 20: terraform1.stacks.StackChangeProgress.action_invocation_status:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationStatus
+	121, // 21: terraform1.stacks.StackChangeProgress.action_invocation_progress:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationProgress
+	31,  // 22: terraform1.stacks.ComponentInstancePolicyEvaluation.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
+	135, // 23: terraform1.stacks.ComponentInstancePolicyEvaluation.results:type_name -> terraform1.PolicyResult
+	136, // 24: terraform1.stacks.ComponentInstancePolicyEvaluation.infos:type_name -> terraform1.PolicyInfo
+	137, // 25: terraform1.stacks.ComponentInstancePolicyEvaluation.diagnostics:type_name -> terraform1.PolicyDiagnostic
+	30,  // 26: terraform1.stacks.ProviderInstancePolicyEvaluation.addr:type_name -> terraform1.stacks.ProviderInstanceInStackAddr
+	135, // 27: terraform1.stacks.ProviderInstancePolicyEvaluation.results:type_name -> terraform1.PolicyResult
+	136, // 28: terraform1.stacks.ProviderInstancePolicyEvaluation.infos:type_name -> terraform1.PolicyInfo
+	137, // 29: terraform1.stacks.ProviderInstancePolicyEvaluation.diagnostics:type_name -> terraform1.PolicyDiagnostic
+	138, // 30: terraform1.stacks.OpenTerraformState.Response.diagnostics:type_name -> terraform1.Diagnostic
+	48,  // 31: terraform1.stacks.MigrateTerraformState.Request.simple:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping
+	138, // 32: terraform1.stacks.MigrateTerraformState.Event.diagnostic:type_name -> terraform1.Diagnostic
+	37,  // 33: terraform1.stacks.MigrateTerraformState.Event.applied_change:type_name -> terraform1.stacks.AppliedChange
+	49,  // 34: terraform1.stacks.MigrateTerraformState.Request.Mapping.resource_address_map:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping.ResourceAddressMapEntry
+	50,  // 35: terraform1.stacks.MigrateTerraformState.Request.Mapping.module_address_map:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping.ModuleAddressMapEntry
+	139, // 36: terraform1.stacks.OpenStackConfiguration.Request.source_address:type_name -> terraform1.SourceAddress
+	138, // 37: terraform1.stacks.OpenStackConfiguration.Response.diagnostics:type_name -> terraform1.Diagnostic
+	138, // 38: terraform1.stacks.ValidateStackConfiguration.Response.diagnostics:type_name -> terraform1.Diagnostic
+	59,  // 39: terraform1.stacks.FindStackConfigurationComponents.Response.config:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig
+	65,  // 40: terraform1.stacks.FindStackConfigurationComponents.StackConfig.components:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry
+	66,  // 41: terraform1.stacks.FindStackConfigurationComponents.StackConfig.embedded_stacks:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry
+	67,  // 42: terraform1.stacks.FindStackConfigurationComponents.StackConfig.input_variables:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry
+	68,  // 43: terraform1.stacks.FindStackConfigurationComponents.StackConfig.output_values:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry
+	69,  // 44: terraform1.stacks.FindStackConfigurationComponents.StackConfig.removed:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry
+	3,   // 45: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
+	59,  // 46: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack.config:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig
+	3,   // 47: terraform1.stacks.FindStackConfigurationComponents.Component.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
+	3,   // 48: terraform1.stacks.FindStackConfigurationComponents.Removed.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
+	70,  // 49: terraform1.stacks.FindStackConfigurationComponents.Removed.blocks:type_name -> terraform1.stacks.FindStackConfigurationComponents.Removed.Block
+	61,  // 50: terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.Component
+	60,  // 51: terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack
+	63,  // 52: terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.InputVariable
+	64,  // 53: terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.OutputValue
+	62,  // 54: terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.Removed
+	3,   // 55: terraform1.stacks.FindStackConfigurationComponents.Removed.Block.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
+	107, // 56: terraform1.stacks.OpenStackState.RequestItem.raw:type_name -> terraform1.stacks.AppliedChange.RawChange
+	1,   // 57: terraform1.stacks.PlanStackChanges.Request.plan_mode:type_name -> terraform1.stacks.PlanMode
+	77,  // 58: terraform1.stacks.PlanStackChanges.Request.previous_state:type_name -> terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry
+	78,  // 59: terraform1.stacks.PlanStackChanges.Request.input_values:type_name -> terraform1.stacks.PlanStackChanges.Request.InputValuesEntry
+	35,  // 60: terraform1.stacks.PlanStackChanges.Event.planned_change:type_name -> terraform1.stacks.PlannedChange
+	138, // 61: terraform1.stacks.PlanStackChanges.Event.diagnostic:type_name -> terraform1.Diagnostic
+	38,  // 62: terraform1.stacks.PlanStackChanges.Event.progress:type_name -> terraform1.stacks.StackChangeProgress
+	40,  // 63: terraform1.stacks.PlanStackChanges.Event.component_instance_policy_evaluation:type_name -> terraform1.stacks.ComponentInstancePolicyEvaluation
+	41,  // 64: terraform1.stacks.PlanStackChanges.Event.provider_instance_policy_evaluation:type_name -> terraform1.stacks.ProviderInstancePolicyEvaluation
+	134, // 65: terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry.value:type_name -> google.protobuf.Any
+	28,  // 66: terraform1.stacks.PlanStackChanges.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
+	134, // 67: terraform1.stacks.OpenStackPlan.RequestItem.raw:type_name -> google.protobuf.Any
+	134, // 68: terraform1.stacks.ApplyStackChanges.Request.planned_changes:type_name -> google.protobuf.Any
+	85,  // 69: terraform1.stacks.ApplyStackChanges.Request.input_values:type_name -> terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry
+	37,  // 70: terraform1.stacks.ApplyStackChanges.Event.applied_change:type_name -> terraform1.stacks.AppliedChange
+	138, // 71: terraform1.stacks.ApplyStackChanges.Event.diagnostic:type_name -> terraform1.Diagnostic
+	38,  // 72: terraform1.stacks.ApplyStackChanges.Event.progress:type_name -> terraform1.stacks.StackChangeProgress
+	40,  // 73: terraform1.stacks.ApplyStackChanges.Event.component_instance_policy_evaluation:type_name -> terraform1.stacks.ComponentInstancePolicyEvaluation
+	41,  // 74: terraform1.stacks.ApplyStackChanges.Event.provider_instance_policy_evaluation:type_name -> terraform1.stacks.ProviderInstancePolicyEvaluation
+	28,  // 75: terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
+	88,  // 76: terraform1.stacks.OpenStackInspector.Request.state:type_name -> terraform1.stacks.OpenStackInspector.Request.StateEntry
+	89,  // 77: terraform1.stacks.OpenStackInspector.Request.input_values:type_name -> terraform1.stacks.OpenStackInspector.Request.InputValuesEntry
+	138, // 78: terraform1.stacks.OpenStackInspector.Response.diagnostics:type_name -> terraform1.Diagnostic
+	134, // 79: terraform1.stacks.OpenStackInspector.Request.StateEntry.value:type_name -> google.protobuf.Any
+	28,  // 80: terraform1.stacks.OpenStackInspector.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
+	26,  // 81: terraform1.stacks.InspectExpressionResult.Response.result:type_name -> terraform1.stacks.DynamicValue
+	138, // 82: terraform1.stacks.InspectExpressionResult.Response.diagnostics:type_name -> terraform1.Diagnostic
+	94,  // 83: terraform1.stacks.PlannedChange.ChangeDescription.component_instance_planned:type_name -> terraform1.stacks.PlannedChange.ComponentInstance
+	95,  // 84: terraform1.stacks.PlannedChange.ChangeDescription.resource_instance_planned:type_name -> terraform1.stacks.PlannedChange.ResourceInstance
+	96,  // 85: terraform1.stacks.PlannedChange.ChangeDescription.output_value_planned:type_name -> terraform1.stacks.PlannedChange.OutputValue
+	97,  // 86: terraform1.stacks.PlannedChange.ChangeDescription.resource_instance_deferred:type_name -> terraform1.stacks.PlannedChange.ResourceInstanceDeferred
+	98,  // 87: terraform1.stacks.PlannedChange.ChangeDescription.input_variable_planned:type_name -> terraform1.stacks.PlannedChange.InputVariable
+	99,  // 88: terraform1.stacks.PlannedChange.ChangeDescription.action_invocation_planned:type_name -> terraform1.stacks.PlannedChange.ActionInvocationInstance
+	100, // 89: terraform1.stacks.PlannedChange.ChangeDescription.action_invocation_deferred:type_name -> terraform1.stacks.PlannedChange.ActionInvocationDeferred
+	31,  // 90: terraform1.stacks.PlannedChange.ComponentInstance.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
+	2,   // 91: terraform1.stacks.PlannedChange.ComponentInstance.actions:type_name -> terraform1.stacks.ChangeType
+	103, // 92: terraform1.stacks.PlannedChange.ComponentInstance.output_values:type_name -> terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry
+	34,  // 93: terraform1.stacks.PlannedChange.ResourceInstance.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	2,   // 94: terraform1.stacks.PlannedChange.ResourceInstance.actions:type_name -> terraform1.stacks.ChangeType
+	27,  // 95: terraform1.stacks.PlannedChange.ResourceInstance.values:type_name -> terraform1.stacks.DynamicValueChange
+	105, // 96: terraform1.stacks.PlannedChange.ResourceInstance.moved:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Moved
+	106, // 97: terraform1.stacks.PlannedChange.ResourceInstance.imported:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Imported
+	0,   // 98: terraform1.stacks.PlannedChange.ResourceInstance.resource_mode:type_name -> terraform1.stacks.ResourceMode
+	26,  // 99: terraform1.stacks.PlannedChange.ResourceInstance.previous_run_value:type_name -> terraform1.stacks.DynamicValue
+	29,  // 100: terraform1.stacks.PlannedChange.ResourceInstance.replace_paths:type_name -> terraform1.stacks.AttributePath
+	104, // 101: terraform1.stacks.PlannedChange.ResourceInstance.index:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Index
+	2,   // 102: terraform1.stacks.PlannedChange.OutputValue.actions:type_name -> terraform1.stacks.ChangeType
+	27,  // 103: terraform1.stacks.PlannedChange.OutputValue.values:type_name -> terraform1.stacks.DynamicValueChange
+	95,  // 104: terraform1.stacks.PlannedChange.ResourceInstanceDeferred.resource_instance:type_name -> terraform1.stacks.PlannedChange.ResourceInstance
+	36,  // 105: terraform1.stacks.PlannedChange.ResourceInstanceDeferred.deferred:type_name -> terraform1.stacks.Deferred
+	2,   // 106: terraform1.stacks.PlannedChange.InputVariable.actions:type_name -> terraform1.stacks.ChangeType
+	27,  // 107: terraform1.stacks.PlannedChange.InputVariable.values:type_name -> terraform1.stacks.DynamicValueChange
+	32,  // 108: terraform1.stacks.PlannedChange.ActionInvocationInstance.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
+	26,  // 109: terraform1.stacks.PlannedChange.ActionInvocationInstance.config_value:type_name -> terraform1.stacks.DynamicValue
+	101, // 110: terraform1.stacks.PlannedChange.ActionInvocationInstance.resource_action_trigger:type_name -> terraform1.stacks.PlannedChange.ResourceActionTrigger
+	102, // 111: terraform1.stacks.PlannedChange.ActionInvocationInstance.invoke_action_trigger:type_name -> terraform1.stacks.PlannedChange.InvokeActionTrigger
+	36,  // 112: terraform1.stacks.PlannedChange.ActionInvocationDeferred.deferred:type_name -> terraform1.stacks.Deferred
+	99,  // 113: terraform1.stacks.PlannedChange.ActionInvocationDeferred.action_invocation:type_name -> terraform1.stacks.PlannedChange.ActionInvocationInstance
+	33,  // 114: terraform1.stacks.PlannedChange.ResourceActionTrigger.triggering_resource_address:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
+	4,   // 115: terraform1.stacks.PlannedChange.ResourceActionTrigger.trigger_event:type_name -> terraform1.stacks.PlannedChange.ActionTriggerEvent
+	26,  // 116: terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry.value:type_name -> terraform1.stacks.DynamicValue
+	26,  // 117: terraform1.stacks.PlannedChange.ResourceInstance.Index.value:type_name -> terraform1.stacks.DynamicValue
+	33,  // 118: terraform1.stacks.PlannedChange.ResourceInstance.Moved.prev_addr:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
+	134, // 119: terraform1.stacks.AppliedChange.RawChange.value:type_name -> google.protobuf.Any
+	113, // 120: terraform1.stacks.AppliedChange.ChangeDescription.deleted:type_name -> terraform1.stacks.AppliedChange.Nothing
+	113, // 121: terraform1.stacks.AppliedChange.ChangeDescription.moved:type_name -> terraform1.stacks.AppliedChange.Nothing
+	109, // 122: terraform1.stacks.AppliedChange.ChangeDescription.resource_instance:type_name -> terraform1.stacks.AppliedChange.ResourceInstance
+	111, // 123: terraform1.stacks.AppliedChange.ChangeDescription.output_value:type_name -> terraform1.stacks.AppliedChange.OutputValue
+	112, // 124: terraform1.stacks.AppliedChange.ChangeDescription.input_variable:type_name -> terraform1.stacks.AppliedChange.InputVariable
+	110, // 125: terraform1.stacks.AppliedChange.ChangeDescription.component_instance:type_name -> terraform1.stacks.AppliedChange.ComponentInstance
+	34,  // 126: terraform1.stacks.AppliedChange.ResourceInstance.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	26,  // 127: terraform1.stacks.AppliedChange.ResourceInstance.new_value:type_name -> terraform1.stacks.DynamicValue
+	0,   // 128: terraform1.stacks.AppliedChange.ResourceInstance.resource_mode:type_name -> terraform1.stacks.ResourceMode
+	114, // 129: terraform1.stacks.AppliedChange.ComponentInstance.output_values:type_name -> terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry
+	26,  // 130: terraform1.stacks.AppliedChange.OutputValue.new_value:type_name -> terraform1.stacks.DynamicValue
+	26,  // 131: terraform1.stacks.AppliedChange.InputVariable.new_value:type_name -> terraform1.stacks.DynamicValue
+	26,  // 132: terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry.value:type_name -> terraform1.stacks.DynamicValue
+	31,  // 133: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
+	7,   // 134: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.Status
+	34,  // 135: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	8,   // 136: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.Status
+	34,  // 137: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	2,   // 138: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.actions:type_name -> terraform1.stacks.ChangeType
+	128, // 139: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.moved:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved
+	129, // 140: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.imported:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Imported
+	36,  // 141: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange.deferred:type_name -> terraform1.stacks.Deferred
+	117, // 142: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange.change:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
+	32,  // 143: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
+	122, // 144: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
+	123, // 145: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
+	32,  // 146: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
+	9,   // 147: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationStatus.Status
+	122, // 148: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
+	123, // 149: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
+	32,  // 150: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
+	122, // 151: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
+	123, // 152: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
+	33,  // 153: terraform1.stacks.StackChangeProgress.ResourceActionTrigger.triggering_resource_address:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
+	6,   // 154: terraform1.stacks.StackChangeProgress.ResourceActionTrigger.trigger_event:type_name -> terraform1.stacks.StackChangeProgress.ActionTriggerEvent
+	34,  // 155: terraform1.stacks.StackChangeProgress.ProvisionerStatus.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	124, // 156: terraform1.stacks.StackChangeProgress.ProvisionerStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerStatus
+	34,  // 157: terraform1.stacks.StackChangeProgress.ProvisionerOutput.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	31,  // 158: terraform1.stacks.StackChangeProgress.ComponentInstanceChanges.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
+	33,  // 159: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved.prev_addr:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
+	132, // 160: terraform1.stacks.ListResourceIdentities.Response.resource:type_name -> terraform1.stacks.ListResourceIdentities.Resource
+	26,  // 161: terraform1.stacks.ListResourceIdentities.Resource.resource_identity:type_name -> terraform1.stacks.DynamicValue
+	51,  // 162: terraform1.stacks.Stacks.OpenStackConfiguration:input_type -> terraform1.stacks.OpenStackConfiguration.Request
+	53,  // 163: terraform1.stacks.Stacks.CloseStackConfiguration:input_type -> terraform1.stacks.CloseStackConfiguration.Request
+	55,  // 164: terraform1.stacks.Stacks.ValidateStackConfiguration:input_type -> terraform1.stacks.ValidateStackConfiguration.Request
+	57,  // 165: terraform1.stacks.Stacks.FindStackConfigurationComponents:input_type -> terraform1.stacks.FindStackConfigurationComponents.Request
+	71,  // 166: terraform1.stacks.Stacks.OpenState:input_type -> terraform1.stacks.OpenStackState.RequestItem
+	73,  // 167: terraform1.stacks.Stacks.CloseState:input_type -> terraform1.stacks.CloseStackState.Request
+	75,  // 168: terraform1.stacks.Stacks.PlanStackChanges:input_type -> terraform1.stacks.PlanStackChanges.Request
+	79,  // 169: terraform1.stacks.Stacks.OpenPlan:input_type -> terraform1.stacks.OpenStackPlan.RequestItem
+	81,  // 170: terraform1.stacks.Stacks.ClosePlan:input_type -> terraform1.stacks.CloseStackPlan.Request
+	83,  // 171: terraform1.stacks.Stacks.ApplyStackChanges:input_type -> terraform1.stacks.ApplyStackChanges.Request
+	86,  // 172: terraform1.stacks.Stacks.OpenStackInspector:input_type -> terraform1.stacks.OpenStackInspector.Request
+	90,  // 173: terraform1.stacks.Stacks.InspectExpressionResult:input_type -> terraform1.stacks.InspectExpressionResult.Request
+	42,  // 174: terraform1.stacks.Stacks.OpenTerraformState:input_type -> terraform1.stacks.OpenTerraformState.Request
+	44,  // 175: terraform1.stacks.Stacks.CloseTerraformState:input_type -> terraform1.stacks.CloseTerraformState.Request
+	46,  // 176: terraform1.stacks.Stacks.MigrateTerraformState:input_type -> terraform1.stacks.MigrateTerraformState.Request
+	130, // 177: terraform1.stacks.Stacks.ListResourceIdentities:input_type -> terraform1.stacks.ListResourceIdentities.Request
+	52,  // 178: terraform1.stacks.Stacks.OpenStackConfiguration:output_type -> terraform1.stacks.OpenStackConfiguration.Response
+	54,  // 179: terraform1.stacks.Stacks.CloseStackConfiguration:output_type -> terraform1.stacks.CloseStackConfiguration.Response
+	56,  // 180: terraform1.stacks.Stacks.ValidateStackConfiguration:output_type -> terraform1.stacks.ValidateStackConfiguration.Response
+	58,  // 181: terraform1.stacks.Stacks.FindStackConfigurationComponents:output_type -> terraform1.stacks.FindStackConfigurationComponents.Response
+	72,  // 182: terraform1.stacks.Stacks.OpenState:output_type -> terraform1.stacks.OpenStackState.Response
+	74,  // 183: terraform1.stacks.Stacks.CloseState:output_type -> terraform1.stacks.CloseStackState.Response
+	76,  // 184: terraform1.stacks.Stacks.PlanStackChanges:output_type -> terraform1.stacks.PlanStackChanges.Event
+	80,  // 185: terraform1.stacks.Stacks.OpenPlan:output_type -> terraform1.stacks.OpenStackPlan.Response
+	82,  // 186: terraform1.stacks.Stacks.ClosePlan:output_type -> terraform1.stacks.CloseStackPlan.Response
+	84,  // 187: terraform1.stacks.Stacks.ApplyStackChanges:output_type -> terraform1.stacks.ApplyStackChanges.Event
+	87,  // 188: terraform1.stacks.Stacks.OpenStackInspector:output_type -> terraform1.stacks.OpenStackInspector.Response
+	91,  // 189: terraform1.stacks.Stacks.InspectExpressionResult:output_type -> terraform1.stacks.InspectExpressionResult.Response
+	43,  // 190: terraform1.stacks.Stacks.OpenTerraformState:output_type -> terraform1.stacks.OpenTerraformState.Response
+	45,  // 191: terraform1.stacks.Stacks.CloseTerraformState:output_type -> terraform1.stacks.CloseTerraformState.Response
+	47,  // 192: terraform1.stacks.Stacks.MigrateTerraformState:output_type -> terraform1.stacks.MigrateTerraformState.Event
+	131, // 193: terraform1.stacks.Stacks.ListResourceIdentities:output_type -> terraform1.stacks.ListResourceIdentities.Response
+	178, // [178:194] is the sub-list for method output_type
+	162, // [162:178] is the sub-list for method input_type
+	162, // [162:162] is the sub-list for extension type_name
+	162, // [162:162] is the sub-list for extension extendee
+	0,   // [0:162] is the sub-list for field type_name
 }
 
 func init() { file_stacks_proto_init() }
@@ -9249,39 +8686,39 @@ func file_stacks_proto_init() {
 		(*StackChangeProgress_ActionInvocationStatus_)(nil),
 		(*StackChangeProgress_ActionInvocationProgress_)(nil),
 	}
-	file_stacks_proto_msgTypes[37].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[31].OneofWrappers = []any{
 		(*OpenTerraformState_Request_ConfigPath)(nil),
 		(*OpenTerraformState_Request_Raw)(nil),
 	}
-	file_stacks_proto_msgTypes[41].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[35].OneofWrappers = []any{
 		(*MigrateTerraformState_Request_Simple)(nil),
 	}
-	file_stacks_proto_msgTypes[42].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[36].OneofWrappers = []any{
 		(*MigrateTerraformState_Event_Diagnostic)(nil),
 		(*MigrateTerraformState_Event_AppliedChange)(nil),
 	}
-	file_stacks_proto_msgTypes[70].OneofWrappers = []any{}
-	file_stacks_proto_msgTypes[71].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[64].OneofWrappers = []any{}
+	file_stacks_proto_msgTypes[65].OneofWrappers = []any{
 		(*PlanStackChanges_Event_PlannedChange)(nil),
 		(*PlanStackChanges_Event_Diagnostic)(nil),
 		(*PlanStackChanges_Event_Progress)(nil),
 		(*PlanStackChanges_Event_ComponentInstancePolicyEvaluation)(nil),
 		(*PlanStackChanges_Event_ProviderInstancePolicyEvaluation)(nil),
 	}
-	file_stacks_proto_msgTypes[78].OneofWrappers = []any{}
-	file_stacks_proto_msgTypes[79].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[72].OneofWrappers = []any{}
+	file_stacks_proto_msgTypes[73].OneofWrappers = []any{
 		(*ApplyStackChanges_Event_AppliedChange)(nil),
 		(*ApplyStackChanges_Event_Diagnostic)(nil),
 		(*ApplyStackChanges_Event_Progress)(nil),
 		(*ApplyStackChanges_Event_ComponentInstancePolicyEvaluation)(nil),
 		(*ApplyStackChanges_Event_ProviderInstancePolicyEvaluation)(nil),
 	}
-	file_stacks_proto_msgTypes[87].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[81].OneofWrappers = []any{
 		(*AttributePath_Step_AttributeName)(nil),
 		(*AttributePath_Step_ElementKeyString)(nil),
 		(*AttributePath_Step_ElementKeyInt)(nil),
 	}
-	file_stacks_proto_msgTypes[88].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[82].OneofWrappers = []any{
 		(*PlannedChange_ChangeDescription_ComponentInstancePlanned)(nil),
 		(*PlannedChange_ChangeDescription_ResourceInstancePlanned)(nil),
 		(*PlannedChange_ChangeDescription_OutputValuePlanned)(nil),
@@ -9291,11 +8728,11 @@ func file_stacks_proto_init() {
 		(*PlannedChange_ChangeDescription_ActionInvocationPlanned)(nil),
 		(*PlannedChange_ChangeDescription_ActionInvocationDeferred)(nil),
 	}
-	file_stacks_proto_msgTypes[94].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[88].OneofWrappers = []any{
 		(*PlannedChange_ActionInvocationInstance_ResourceActionTrigger)(nil),
 		(*PlannedChange_ActionInvocationInstance_InvokeActionTrigger)(nil),
 	}
-	file_stacks_proto_msgTypes[103].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[97].OneofWrappers = []any{
 		(*AppliedChange_ChangeDescription_Deleted)(nil),
 		(*AppliedChange_ChangeDescription_Moved)(nil),
 		(*AppliedChange_ChangeDescription_ResourceInstance)(nil),
@@ -9303,15 +8740,15 @@ func file_stacks_proto_init() {
 		(*AppliedChange_ChangeDescription_InputVariable)(nil),
 		(*AppliedChange_ChangeDescription_ComponentInstance)(nil),
 	}
-	file_stacks_proto_msgTypes[114].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[108].OneofWrappers = []any{
 		(*StackChangeProgress_ActionInvocationPlanned_ResourceActionTrigger)(nil),
 		(*StackChangeProgress_ActionInvocationPlanned_InvokeActionTrigger)(nil),
 	}
-	file_stacks_proto_msgTypes[115].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[109].OneofWrappers = []any{
 		(*StackChangeProgress_ActionInvocationStatus_ResourceActionTrigger)(nil),
 		(*StackChangeProgress_ActionInvocationStatus_InvokeActionTrigger)(nil),
 	}
-	file_stacks_proto_msgTypes[116].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[110].OneofWrappers = []any{
 		(*StackChangeProgress_ActionInvocationProgress_ResourceActionTrigger)(nil),
 		(*StackChangeProgress_ActionInvocationProgress_InvokeActionTrigger)(nil),
 	}
@@ -9320,8 +8757,8 @@ func file_stacks_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_stacks_proto_rawDesc), len(file_stacks_proto_rawDesc)),
-			NumEnums:      12,
-			NumMessages:   128,
+			NumEnums:      11,
+			NumMessages:   122,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/rpcapi/terraform1/stacks/stacks.proto
+++ b/internal/rpcapi/terraform1/stacks/stacks.proto
@@ -1110,71 +1110,14 @@ message ListResourceIdentities {
 
 message ComponentInstancePolicyEvaluation {
   ComponentInstanceInStackAddr addr = 1;
-  repeated PolicyResult results = 2;
-  repeated PolicyInfo infos = 3;
-  repeated PolicyDiagnostic diagnostics = 4;
+  repeated terraform1.PolicyResult results = 2;
+  repeated terraform1.PolicyInfo infos = 3;
+  repeated terraform1.PolicyDiagnostic diagnostics = 4;
 }
 
 message ProviderInstancePolicyEvaluation {
   ProviderInstanceInStackAddr addr = 1;
-  repeated PolicyResult results = 2;
-  repeated PolicyInfo infos = 3;
-  repeated PolicyDiagnostic diagnostics = 4;
-}
-
-message PolicyMetaData {
-  string policy_name = 1;
-  string policy_set_name = 2;
-  string enforcement_level = 3;
-  string file_name = 4;
-  int32 enforce_index = 5;
-}
-
-message PolicyResult {
-  string target_address = 1;
-  PolicyMetaData policy_metadata = 2;
-  EvaluateResult result = 3;
-}
-
-message PolicyInfo {
-  string target_address = 1;
-  PolicyMetaData policy_metadata = 2;
-  string message = 3;
-  terraform1.SourceRange policy_range = 4;
-  PolicySnippet policy_snippet = 5;
-  EvaluateResult result = 6;
-}
-
-message PolicySnippet {
-  string context = 1;
-  string code = 2;
-  int64 start_line = 3;
-  int64 highlight_start_offset = 4;
-  int64 highlight_end_offset = 5;
-}
-
-message PolicyDiagnostic {
-  string target_address = 1;
-  PolicyMetaData policy_metadata = 2;
-  EvaluateResult result = 3;
-  terraform1.Diagnostic diagnostic = 4;
-  PolicySnippet policy_snippet = 5;
-  terraform1.SourceRange policy_range = 6;
-  repeated ExpressionValue expression_values = 7;
-}
-
-// Sourced from: /terraform/internal/policy/proto/types.proto#EvaluateResult
-enum EvaluateResult {
-  INVALID_EVALUATE_RESULT = 0;
-  UNKNOWN_EVALUATE_RESULT = 1;
-  ERROR_EVALUATE_RESULT = 2;
-  ALLOW_EVALUATE_RESULT = 3;
-  DENY_EVALUATE_RESULT = 4;
-  SETUP_ERROR_EVALUATE_RESULT = 5;
-}
-
-// Sourced from: /terraform/internal/policy/proto/diagnostics.proto#ExpressionValue
-message ExpressionValue {
-  AttributePath traversal = 1;
-  bytes value = 2;
+  repeated terraform1.PolicyResult results = 2;
+  repeated terraform1.PolicyInfo infos = 3;
+  repeated terraform1.PolicyDiagnostic diagnostics = 4;
 }

--- a/internal/rpcapi/terraform1/terraform1.pb.go
+++ b/internal/rpcapi/terraform1/terraform1.pb.go
@@ -24,7 +24,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Sourced from: /terraform/internal/policy/proto/types.proto#EvaluateResult
+// Sourced from: /internal/policy/proto/types.proto#EvaluateResult
 type EvaluateResult int32
 
 const (
@@ -862,7 +862,7 @@ func (x *PolicyDiagnostic) GetExpressionValues() []*ExpressionValue {
 	return nil
 }
 
-// Sourced from: /terraform/internal/policy/proto/diagnostics.proto#ExpressionValue
+// Sourced from: /internal/policy/proto/diagnostics.proto#ExpressionValue
 type ExpressionValue struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Traversal     *AttributePath         `protobuf:"bytes,1,opt,name=traversal,proto3" json:"traversal,omitempty"`
@@ -915,6 +915,7 @@ func (x *ExpressionValue) GetValue() []byte {
 	return nil
 }
 
+// Sourced from: /internal/rpcapi/terraform1/stacks.proto#AttributePath
 type AttributePath struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Steps         []*AttributePath_Step  `protobuf:"bytes,1,rep,name=steps,proto3" json:"steps,omitempty"`
@@ -1100,14 +1101,10 @@ type isAttributePath_Step_Selector interface {
 }
 
 type AttributePath_Step_AttributeName struct {
-	// Set "attribute_name" to represent looking up an attribute
-	// in the current object value.
 	AttributeName string `protobuf:"bytes,1,opt,name=attribute_name,json=attributeName,proto3,oneof"`
 }
 
 type AttributePath_Step_ElementKeyString struct {
-	// Set "element_key_*" to represent looking up an element in
-	// an indexable collection type.
 	ElementKeyString string `protobuf:"bytes,2,opt,name=element_key_string,json=elementKeyString,proto3,oneof"`
 }
 

--- a/internal/rpcapi/terraform1/terraform1.pb.go
+++ b/internal/rpcapi/terraform1/terraform1.pb.go
@@ -24,6 +24,65 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Sourced from: /terraform/internal/policy/proto/types.proto#EvaluateResult
+type EvaluateResult int32
+
+const (
+	EvaluateResult_INVALID_EVALUATE_RESULT     EvaluateResult = 0
+	EvaluateResult_UNKNOWN_EVALUATE_RESULT     EvaluateResult = 1
+	EvaluateResult_ERROR_EVALUATE_RESULT       EvaluateResult = 2
+	EvaluateResult_ALLOW_EVALUATE_RESULT       EvaluateResult = 3
+	EvaluateResult_DENY_EVALUATE_RESULT        EvaluateResult = 4
+	EvaluateResult_SETUP_ERROR_EVALUATE_RESULT EvaluateResult = 5
+)
+
+// Enum value maps for EvaluateResult.
+var (
+	EvaluateResult_name = map[int32]string{
+		0: "INVALID_EVALUATE_RESULT",
+		1: "UNKNOWN_EVALUATE_RESULT",
+		2: "ERROR_EVALUATE_RESULT",
+		3: "ALLOW_EVALUATE_RESULT",
+		4: "DENY_EVALUATE_RESULT",
+		5: "SETUP_ERROR_EVALUATE_RESULT",
+	}
+	EvaluateResult_value = map[string]int32{
+		"INVALID_EVALUATE_RESULT":     0,
+		"UNKNOWN_EVALUATE_RESULT":     1,
+		"ERROR_EVALUATE_RESULT":       2,
+		"ALLOW_EVALUATE_RESULT":       3,
+		"DENY_EVALUATE_RESULT":        4,
+		"SETUP_ERROR_EVALUATE_RESULT": 5,
+	}
+)
+
+func (x EvaluateResult) Enum() *EvaluateResult {
+	p := new(EvaluateResult)
+	*p = x
+	return p
+}
+
+func (x EvaluateResult) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (EvaluateResult) Descriptor() protoreflect.EnumDescriptor {
+	return file_terraform1_proto_enumTypes[0].Descriptor()
+}
+
+func (EvaluateResult) Type() protoreflect.EnumType {
+	return &file_terraform1_proto_enumTypes[0]
+}
+
+func (x EvaluateResult) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use EvaluateResult.Descriptor instead.
+func (EvaluateResult) EnumDescriptor() ([]byte, []int) {
+	return file_terraform1_proto_rawDescGZIP(), []int{0}
+}
+
 type Diagnostic_Severity int32
 
 const (
@@ -57,11 +116,11 @@ func (x Diagnostic_Severity) String() string {
 }
 
 func (Diagnostic_Severity) Descriptor() protoreflect.EnumDescriptor {
-	return file_terraform1_proto_enumTypes[0].Descriptor()
+	return file_terraform1_proto_enumTypes[1].Descriptor()
 }
 
 func (Diagnostic_Severity) Type() protoreflect.EnumType {
-	return &file_terraform1_proto_enumTypes[0]
+	return &file_terraform1_proto_enumTypes[1]
 }
 
 func (x Diagnostic_Severity) Number() protoreflect.EnumNumber {
@@ -415,6 +474,653 @@ func (x *SourcePos) GetColumn() int64 {
 	return 0
 }
 
+type PolicyMetaData struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	PolicyName       string                 `protobuf:"bytes,1,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
+	PolicySetName    string                 `protobuf:"bytes,2,opt,name=policy_set_name,json=policySetName,proto3" json:"policy_set_name,omitempty"`
+	EnforcementLevel string                 `protobuf:"bytes,3,opt,name=enforcement_level,json=enforcementLevel,proto3" json:"enforcement_level,omitempty"`
+	FileName         string                 `protobuf:"bytes,4,opt,name=file_name,json=fileName,proto3" json:"file_name,omitempty"`
+	EnforceIndex     int32                  `protobuf:"varint,5,opt,name=enforce_index,json=enforceIndex,proto3" json:"enforce_index,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *PolicyMetaData) Reset() {
+	*x = PolicyMetaData{}
+	mi := &file_terraform1_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyMetaData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyMetaData) ProtoMessage() {}
+
+func (x *PolicyMetaData) ProtoReflect() protoreflect.Message {
+	mi := &file_terraform1_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyMetaData.ProtoReflect.Descriptor instead.
+func (*PolicyMetaData) Descriptor() ([]byte, []int) {
+	return file_terraform1_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *PolicyMetaData) GetPolicyName() string {
+	if x != nil {
+		return x.PolicyName
+	}
+	return ""
+}
+
+func (x *PolicyMetaData) GetPolicySetName() string {
+	if x != nil {
+		return x.PolicySetName
+	}
+	return ""
+}
+
+func (x *PolicyMetaData) GetEnforcementLevel() string {
+	if x != nil {
+		return x.EnforcementLevel
+	}
+	return ""
+}
+
+func (x *PolicyMetaData) GetFileName() string {
+	if x != nil {
+		return x.FileName
+	}
+	return ""
+}
+
+func (x *PolicyMetaData) GetEnforceIndex() int32 {
+	if x != nil {
+		return x.EnforceIndex
+	}
+	return 0
+}
+
+type PolicyResult struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	TargetAddress  string                 `protobuf:"bytes,1,opt,name=target_address,json=targetAddress,proto3" json:"target_address,omitempty"`
+	PolicyMetadata *PolicyMetaData        `protobuf:"bytes,2,opt,name=policy_metadata,json=policyMetadata,proto3" json:"policy_metadata,omitempty"`
+	Result         EvaluateResult         `protobuf:"varint,3,opt,name=result,proto3,enum=terraform1.EvaluateResult" json:"result,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *PolicyResult) Reset() {
+	*x = PolicyResult{}
+	mi := &file_terraform1_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyResult) ProtoMessage() {}
+
+func (x *PolicyResult) ProtoReflect() protoreflect.Message {
+	mi := &file_terraform1_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyResult.ProtoReflect.Descriptor instead.
+func (*PolicyResult) Descriptor() ([]byte, []int) {
+	return file_terraform1_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *PolicyResult) GetTargetAddress() string {
+	if x != nil {
+		return x.TargetAddress
+	}
+	return ""
+}
+
+func (x *PolicyResult) GetPolicyMetadata() *PolicyMetaData {
+	if x != nil {
+		return x.PolicyMetadata
+	}
+	return nil
+}
+
+func (x *PolicyResult) GetResult() EvaluateResult {
+	if x != nil {
+		return x.Result
+	}
+	return EvaluateResult_INVALID_EVALUATE_RESULT
+}
+
+type PolicyInfo struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	TargetAddress  string                 `protobuf:"bytes,1,opt,name=target_address,json=targetAddress,proto3" json:"target_address,omitempty"`
+	PolicyMetadata *PolicyMetaData        `protobuf:"bytes,2,opt,name=policy_metadata,json=policyMetadata,proto3" json:"policy_metadata,omitempty"`
+	Message        string                 `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	PolicyRange    *SourceRange           `protobuf:"bytes,4,opt,name=policy_range,json=policyRange,proto3" json:"policy_range,omitempty"`
+	PolicySnippet  *PolicySnippet         `protobuf:"bytes,5,opt,name=policy_snippet,json=policySnippet,proto3" json:"policy_snippet,omitempty"`
+	Result         EvaluateResult         `protobuf:"varint,6,opt,name=result,proto3,enum=terraform1.EvaluateResult" json:"result,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *PolicyInfo) Reset() {
+	*x = PolicyInfo{}
+	mi := &file_terraform1_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyInfo) ProtoMessage() {}
+
+func (x *PolicyInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_terraform1_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyInfo.ProtoReflect.Descriptor instead.
+func (*PolicyInfo) Descriptor() ([]byte, []int) {
+	return file_terraform1_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *PolicyInfo) GetTargetAddress() string {
+	if x != nil {
+		return x.TargetAddress
+	}
+	return ""
+}
+
+func (x *PolicyInfo) GetPolicyMetadata() *PolicyMetaData {
+	if x != nil {
+		return x.PolicyMetadata
+	}
+	return nil
+}
+
+func (x *PolicyInfo) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *PolicyInfo) GetPolicyRange() *SourceRange {
+	if x != nil {
+		return x.PolicyRange
+	}
+	return nil
+}
+
+func (x *PolicyInfo) GetPolicySnippet() *PolicySnippet {
+	if x != nil {
+		return x.PolicySnippet
+	}
+	return nil
+}
+
+func (x *PolicyInfo) GetResult() EvaluateResult {
+	if x != nil {
+		return x.Result
+	}
+	return EvaluateResult_INVALID_EVALUATE_RESULT
+}
+
+type PolicySnippet struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	Context              string                 `protobuf:"bytes,1,opt,name=context,proto3" json:"context,omitempty"`
+	Code                 string                 `protobuf:"bytes,2,opt,name=code,proto3" json:"code,omitempty"`
+	StartLine            int64                  `protobuf:"varint,3,opt,name=start_line,json=startLine,proto3" json:"start_line,omitempty"`
+	HighlightStartOffset int64                  `protobuf:"varint,4,opt,name=highlight_start_offset,json=highlightStartOffset,proto3" json:"highlight_start_offset,omitempty"`
+	HighlightEndOffset   int64                  `protobuf:"varint,5,opt,name=highlight_end_offset,json=highlightEndOffset,proto3" json:"highlight_end_offset,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *PolicySnippet) Reset() {
+	*x = PolicySnippet{}
+	mi := &file_terraform1_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySnippet) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySnippet) ProtoMessage() {}
+
+func (x *PolicySnippet) ProtoReflect() protoreflect.Message {
+	mi := &file_terraform1_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySnippet.ProtoReflect.Descriptor instead.
+func (*PolicySnippet) Descriptor() ([]byte, []int) {
+	return file_terraform1_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *PolicySnippet) GetContext() string {
+	if x != nil {
+		return x.Context
+	}
+	return ""
+}
+
+func (x *PolicySnippet) GetCode() string {
+	if x != nil {
+		return x.Code
+	}
+	return ""
+}
+
+func (x *PolicySnippet) GetStartLine() int64 {
+	if x != nil {
+		return x.StartLine
+	}
+	return 0
+}
+
+func (x *PolicySnippet) GetHighlightStartOffset() int64 {
+	if x != nil {
+		return x.HighlightStartOffset
+	}
+	return 0
+}
+
+func (x *PolicySnippet) GetHighlightEndOffset() int64 {
+	if x != nil {
+		return x.HighlightEndOffset
+	}
+	return 0
+}
+
+type PolicyDiagnostic struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	TargetAddress    string                 `protobuf:"bytes,1,opt,name=target_address,json=targetAddress,proto3" json:"target_address,omitempty"`
+	PolicyMetadata   *PolicyMetaData        `protobuf:"bytes,2,opt,name=policy_metadata,json=policyMetadata,proto3" json:"policy_metadata,omitempty"`
+	Result           EvaluateResult         `protobuf:"varint,3,opt,name=result,proto3,enum=terraform1.EvaluateResult" json:"result,omitempty"`
+	Diagnostic       *Diagnostic            `protobuf:"bytes,4,opt,name=diagnostic,proto3" json:"diagnostic,omitempty"`
+	PolicySnippet    *PolicySnippet         `protobuf:"bytes,5,opt,name=policy_snippet,json=policySnippet,proto3" json:"policy_snippet,omitempty"`
+	PolicyRange      *SourceRange           `protobuf:"bytes,6,opt,name=policy_range,json=policyRange,proto3" json:"policy_range,omitempty"`
+	ExpressionValues []*ExpressionValue     `protobuf:"bytes,7,rep,name=expression_values,json=expressionValues,proto3" json:"expression_values,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *PolicyDiagnostic) Reset() {
+	*x = PolicyDiagnostic{}
+	mi := &file_terraform1_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyDiagnostic) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyDiagnostic) ProtoMessage() {}
+
+func (x *PolicyDiagnostic) ProtoReflect() protoreflect.Message {
+	mi := &file_terraform1_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyDiagnostic.ProtoReflect.Descriptor instead.
+func (*PolicyDiagnostic) Descriptor() ([]byte, []int) {
+	return file_terraform1_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *PolicyDiagnostic) GetTargetAddress() string {
+	if x != nil {
+		return x.TargetAddress
+	}
+	return ""
+}
+
+func (x *PolicyDiagnostic) GetPolicyMetadata() *PolicyMetaData {
+	if x != nil {
+		return x.PolicyMetadata
+	}
+	return nil
+}
+
+func (x *PolicyDiagnostic) GetResult() EvaluateResult {
+	if x != nil {
+		return x.Result
+	}
+	return EvaluateResult_INVALID_EVALUATE_RESULT
+}
+
+func (x *PolicyDiagnostic) GetDiagnostic() *Diagnostic {
+	if x != nil {
+		return x.Diagnostic
+	}
+	return nil
+}
+
+func (x *PolicyDiagnostic) GetPolicySnippet() *PolicySnippet {
+	if x != nil {
+		return x.PolicySnippet
+	}
+	return nil
+}
+
+func (x *PolicyDiagnostic) GetPolicyRange() *SourceRange {
+	if x != nil {
+		return x.PolicyRange
+	}
+	return nil
+}
+
+func (x *PolicyDiagnostic) GetExpressionValues() []*ExpressionValue {
+	if x != nil {
+		return x.ExpressionValues
+	}
+	return nil
+}
+
+// Sourced from: /terraform/internal/policy/proto/diagnostics.proto#ExpressionValue
+type ExpressionValue struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Traversal     *AttributePath         `protobuf:"bytes,1,opt,name=traversal,proto3" json:"traversal,omitempty"`
+	Value         []byte                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExpressionValue) Reset() {
+	*x = ExpressionValue{}
+	mi := &file_terraform1_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExpressionValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExpressionValue) ProtoMessage() {}
+
+func (x *ExpressionValue) ProtoReflect() protoreflect.Message {
+	mi := &file_terraform1_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExpressionValue.ProtoReflect.Descriptor instead.
+func (*ExpressionValue) Descriptor() ([]byte, []int) {
+	return file_terraform1_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *ExpressionValue) GetTraversal() *AttributePath {
+	if x != nil {
+		return x.Traversal
+	}
+	return nil
+}
+
+func (x *ExpressionValue) GetValue() []byte {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+type AttributePath struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Steps         []*AttributePath_Step  `protobuf:"bytes,1,rep,name=steps,proto3" json:"steps,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AttributePath) Reset() {
+	*x = AttributePath{}
+	mi := &file_terraform1_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AttributePath) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AttributePath) ProtoMessage() {}
+
+func (x *AttributePath) ProtoReflect() protoreflect.Message {
+	mi := &file_terraform1_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AttributePath.ProtoReflect.Descriptor instead.
+func (*AttributePath) Descriptor() ([]byte, []int) {
+	return file_terraform1_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *AttributePath) GetSteps() []*AttributePath_Step {
+	if x != nil {
+		return x.Steps
+	}
+	return nil
+}
+
+type PolicyEntitlement struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Token         string                 `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty"`
+	Org           string                 `protobuf:"bytes,3,opt,name=org,proto3" json:"org,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyEntitlement) Reset() {
+	*x = PolicyEntitlement{}
+	mi := &file_terraform1_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyEntitlement) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyEntitlement) ProtoMessage() {}
+
+func (x *PolicyEntitlement) ProtoReflect() protoreflect.Message {
+	mi := &file_terraform1_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyEntitlement.ProtoReflect.Descriptor instead.
+func (*PolicyEntitlement) Descriptor() ([]byte, []int) {
+	return file_terraform1_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *PolicyEntitlement) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *PolicyEntitlement) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+func (x *PolicyEntitlement) GetOrg() string {
+	if x != nil {
+		return x.Org
+	}
+	return ""
+}
+
+type AttributePath_Step struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Selector:
+	//
+	//	*AttributePath_Step_AttributeName
+	//	*AttributePath_Step_ElementKeyString
+	//	*AttributePath_Step_ElementKeyInt
+	Selector      isAttributePath_Step_Selector `protobuf_oneof:"selector"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AttributePath_Step) Reset() {
+	*x = AttributePath_Step{}
+	mi := &file_terraform1_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AttributePath_Step) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AttributePath_Step) ProtoMessage() {}
+
+func (x *AttributePath_Step) ProtoReflect() protoreflect.Message {
+	mi := &file_terraform1_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AttributePath_Step.ProtoReflect.Descriptor instead.
+func (*AttributePath_Step) Descriptor() ([]byte, []int) {
+	return file_terraform1_proto_rawDescGZIP(), []int{11, 0}
+}
+
+func (x *AttributePath_Step) GetSelector() isAttributePath_Step_Selector {
+	if x != nil {
+		return x.Selector
+	}
+	return nil
+}
+
+func (x *AttributePath_Step) GetAttributeName() string {
+	if x != nil {
+		if x, ok := x.Selector.(*AttributePath_Step_AttributeName); ok {
+			return x.AttributeName
+		}
+	}
+	return ""
+}
+
+func (x *AttributePath_Step) GetElementKeyString() string {
+	if x != nil {
+		if x, ok := x.Selector.(*AttributePath_Step_ElementKeyString); ok {
+			return x.ElementKeyString
+		}
+	}
+	return ""
+}
+
+func (x *AttributePath_Step) GetElementKeyInt() int64 {
+	if x != nil {
+		if x, ok := x.Selector.(*AttributePath_Step_ElementKeyInt); ok {
+			return x.ElementKeyInt
+		}
+	}
+	return 0
+}
+
+type isAttributePath_Step_Selector interface {
+	isAttributePath_Step_Selector()
+}
+
+type AttributePath_Step_AttributeName struct {
+	// Set "attribute_name" to represent looking up an attribute
+	// in the current object value.
+	AttributeName string `protobuf:"bytes,1,opt,name=attribute_name,json=attributeName,proto3,oneof"`
+}
+
+type AttributePath_Step_ElementKeyString struct {
+	// Set "element_key_*" to represent looking up an element in
+	// an indexable collection type.
+	ElementKeyString string `protobuf:"bytes,2,opt,name=element_key_string,json=elementKeyString,proto3,oneof"`
+}
+
+type AttributePath_Step_ElementKeyInt struct {
+	ElementKeyInt int64 `protobuf:"varint,3,opt,name=element_key_int,json=elementKeyInt,proto3,oneof"`
+}
+
+func (*AttributePath_Step_AttributeName) isAttributePath_Step_Selector() {}
+
+func (*AttributePath_Step_ElementKeyString) isAttributePath_Step_Selector() {}
+
+func (*AttributePath_Step_ElementKeyInt) isAttributePath_Step_Selector() {}
+
 var File_terraform1_proto protoreflect.FileDescriptor
 
 const file_terraform1_proto_rawDesc = "" +
@@ -448,7 +1154,65 @@ const file_terraform1_proto_rawDesc = "" +
 	"\tSourcePos\x12\x12\n" +
 	"\x04byte\x18\x01 \x01(\x03R\x04byte\x12\x12\n" +
 	"\x04line\x18\x02 \x01(\x03R\x04line\x12\x16\n" +
-	"\x06column\x18\x03 \x01(\x03R\x06columnb\x06proto3"
+	"\x06column\x18\x03 \x01(\x03R\x06column\"\xc8\x01\n" +
+	"\x0ePolicyMetaData\x12\x1f\n" +
+	"\vpolicy_name\x18\x01 \x01(\tR\n" +
+	"policyName\x12&\n" +
+	"\x0fpolicy_set_name\x18\x02 \x01(\tR\rpolicySetName\x12+\n" +
+	"\x11enforcement_level\x18\x03 \x01(\tR\x10enforcementLevel\x12\x1b\n" +
+	"\tfile_name\x18\x04 \x01(\tR\bfileName\x12#\n" +
+	"\renforce_index\x18\x05 \x01(\x05R\fenforceIndex\"\xae\x01\n" +
+	"\fPolicyResult\x12%\n" +
+	"\x0etarget_address\x18\x01 \x01(\tR\rtargetAddress\x12C\n" +
+	"\x0fpolicy_metadata\x18\x02 \x01(\v2\x1a.terraform1.PolicyMetaDataR\x0epolicyMetadata\x122\n" +
+	"\x06result\x18\x03 \x01(\x0e2\x1a.terraform1.EvaluateResultR\x06result\"\xc4\x02\n" +
+	"\n" +
+	"PolicyInfo\x12%\n" +
+	"\x0etarget_address\x18\x01 \x01(\tR\rtargetAddress\x12C\n" +
+	"\x0fpolicy_metadata\x18\x02 \x01(\v2\x1a.terraform1.PolicyMetaDataR\x0epolicyMetadata\x12\x18\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\x12:\n" +
+	"\fpolicy_range\x18\x04 \x01(\v2\x17.terraform1.SourceRangeR\vpolicyRange\x12@\n" +
+	"\x0epolicy_snippet\x18\x05 \x01(\v2\x19.terraform1.PolicySnippetR\rpolicySnippet\x122\n" +
+	"\x06result\x18\x06 \x01(\x0e2\x1a.terraform1.EvaluateResultR\x06result\"\xc4\x01\n" +
+	"\rPolicySnippet\x12\x18\n" +
+	"\acontext\x18\x01 \x01(\tR\acontext\x12\x12\n" +
+	"\x04code\x18\x02 \x01(\tR\x04code\x12\x1d\n" +
+	"\n" +
+	"start_line\x18\x03 \x01(\x03R\tstartLine\x124\n" +
+	"\x16highlight_start_offset\x18\x04 \x01(\x03R\x14highlightStartOffset\x120\n" +
+	"\x14highlight_end_offset\x18\x05 \x01(\x03R\x12highlightEndOffset\"\xb2\x03\n" +
+	"\x10PolicyDiagnostic\x12%\n" +
+	"\x0etarget_address\x18\x01 \x01(\tR\rtargetAddress\x12C\n" +
+	"\x0fpolicy_metadata\x18\x02 \x01(\v2\x1a.terraform1.PolicyMetaDataR\x0epolicyMetadata\x122\n" +
+	"\x06result\x18\x03 \x01(\x0e2\x1a.terraform1.EvaluateResultR\x06result\x126\n" +
+	"\n" +
+	"diagnostic\x18\x04 \x01(\v2\x16.terraform1.DiagnosticR\n" +
+	"diagnostic\x12@\n" +
+	"\x0epolicy_snippet\x18\x05 \x01(\v2\x19.terraform1.PolicySnippetR\rpolicySnippet\x12:\n" +
+	"\fpolicy_range\x18\x06 \x01(\v2\x17.terraform1.SourceRangeR\vpolicyRange\x12H\n" +
+	"\x11expression_values\x18\a \x03(\v2\x1b.terraform1.ExpressionValueR\x10expressionValues\"`\n" +
+	"\x0fExpressionValue\x127\n" +
+	"\ttraversal\x18\x01 \x01(\v2\x19.terraform1.AttributePathR\ttraversal\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value\"\xdd\x01\n" +
+	"\rAttributePath\x124\n" +
+	"\x05steps\x18\x01 \x03(\v2\x1e.terraform1.AttributePath.StepR\x05steps\x1a\x95\x01\n" +
+	"\x04Step\x12'\n" +
+	"\x0eattribute_name\x18\x01 \x01(\tH\x00R\rattributeName\x12.\n" +
+	"\x12element_key_string\x18\x02 \x01(\tH\x00R\x10elementKeyString\x12(\n" +
+	"\x0felement_key_int\x18\x03 \x01(\x03H\x00R\relementKeyIntB\n" +
+	"\n" +
+	"\bselector\"O\n" +
+	"\x11PolicyEntitlement\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
+	"\x05token\x18\x02 \x01(\tR\x05token\x12\x10\n" +
+	"\x03org\x18\x03 \x01(\tR\x03org*\xbb\x01\n" +
+	"\x0eEvaluateResult\x12\x1b\n" +
+	"\x17INVALID_EVALUATE_RESULT\x10\x00\x12\x1b\n" +
+	"\x17UNKNOWN_EVALUATE_RESULT\x10\x01\x12\x19\n" +
+	"\x15ERROR_EVALUATE_RESULT\x10\x02\x12\x19\n" +
+	"\x15ALLOW_EVALUATE_RESULT\x10\x03\x12\x18\n" +
+	"\x14DENY_EVALUATE_RESULT\x10\x04\x12\x1f\n" +
+	"\x1bSETUP_ERROR_EVALUATE_RESULT\x10\x05b\x06proto3"
 
 var (
 	file_terraform1_proto_rawDescOnce sync.Once
@@ -462,27 +1226,51 @@ func file_terraform1_proto_rawDescGZIP() []byte {
 	return file_terraform1_proto_rawDescData
 }
 
-var file_terraform1_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_terraform1_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_terraform1_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_terraform1_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_terraform1_proto_goTypes = []any{
-	(Diagnostic_Severity)(0), // 0: terraform1.Diagnostic.Severity
-	(*ProviderPackage)(nil),  // 1: terraform1.ProviderPackage
-	(*SourceAddress)(nil),    // 2: terraform1.SourceAddress
-	(*Diagnostic)(nil),       // 3: terraform1.Diagnostic
-	(*SourceRange)(nil),      // 4: terraform1.SourceRange
-	(*SourcePos)(nil),        // 5: terraform1.SourcePos
+	(EvaluateResult)(0),        // 0: terraform1.EvaluateResult
+	(Diagnostic_Severity)(0),   // 1: terraform1.Diagnostic.Severity
+	(*ProviderPackage)(nil),    // 2: terraform1.ProviderPackage
+	(*SourceAddress)(nil),      // 3: terraform1.SourceAddress
+	(*Diagnostic)(nil),         // 4: terraform1.Diagnostic
+	(*SourceRange)(nil),        // 5: terraform1.SourceRange
+	(*SourcePos)(nil),          // 6: terraform1.SourcePos
+	(*PolicyMetaData)(nil),     // 7: terraform1.PolicyMetaData
+	(*PolicyResult)(nil),       // 8: terraform1.PolicyResult
+	(*PolicyInfo)(nil),         // 9: terraform1.PolicyInfo
+	(*PolicySnippet)(nil),      // 10: terraform1.PolicySnippet
+	(*PolicyDiagnostic)(nil),   // 11: terraform1.PolicyDiagnostic
+	(*ExpressionValue)(nil),    // 12: terraform1.ExpressionValue
+	(*AttributePath)(nil),      // 13: terraform1.AttributePath
+	(*PolicyEntitlement)(nil),  // 14: terraform1.PolicyEntitlement
+	(*AttributePath_Step)(nil), // 15: terraform1.AttributePath.Step
 }
 var file_terraform1_proto_depIdxs = []int32{
-	0, // 0: terraform1.Diagnostic.severity:type_name -> terraform1.Diagnostic.Severity
-	4, // 1: terraform1.Diagnostic.subject:type_name -> terraform1.SourceRange
-	4, // 2: terraform1.Diagnostic.context:type_name -> terraform1.SourceRange
-	5, // 3: terraform1.SourceRange.start:type_name -> terraform1.SourcePos
-	5, // 4: terraform1.SourceRange.end:type_name -> terraform1.SourcePos
-	5, // [5:5] is the sub-list for method output_type
-	5, // [5:5] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	1,  // 0: terraform1.Diagnostic.severity:type_name -> terraform1.Diagnostic.Severity
+	5,  // 1: terraform1.Diagnostic.subject:type_name -> terraform1.SourceRange
+	5,  // 2: terraform1.Diagnostic.context:type_name -> terraform1.SourceRange
+	6,  // 3: terraform1.SourceRange.start:type_name -> terraform1.SourcePos
+	6,  // 4: terraform1.SourceRange.end:type_name -> terraform1.SourcePos
+	7,  // 5: terraform1.PolicyResult.policy_metadata:type_name -> terraform1.PolicyMetaData
+	0,  // 6: terraform1.PolicyResult.result:type_name -> terraform1.EvaluateResult
+	7,  // 7: terraform1.PolicyInfo.policy_metadata:type_name -> terraform1.PolicyMetaData
+	5,  // 8: terraform1.PolicyInfo.policy_range:type_name -> terraform1.SourceRange
+	10, // 9: terraform1.PolicyInfo.policy_snippet:type_name -> terraform1.PolicySnippet
+	0,  // 10: terraform1.PolicyInfo.result:type_name -> terraform1.EvaluateResult
+	7,  // 11: terraform1.PolicyDiagnostic.policy_metadata:type_name -> terraform1.PolicyMetaData
+	0,  // 12: terraform1.PolicyDiagnostic.result:type_name -> terraform1.EvaluateResult
+	4,  // 13: terraform1.PolicyDiagnostic.diagnostic:type_name -> terraform1.Diagnostic
+	10, // 14: terraform1.PolicyDiagnostic.policy_snippet:type_name -> terraform1.PolicySnippet
+	5,  // 15: terraform1.PolicyDiagnostic.policy_range:type_name -> terraform1.SourceRange
+	12, // 16: terraform1.PolicyDiagnostic.expression_values:type_name -> terraform1.ExpressionValue
+	13, // 17: terraform1.ExpressionValue.traversal:type_name -> terraform1.AttributePath
+	15, // 18: terraform1.AttributePath.steps:type_name -> terraform1.AttributePath.Step
+	19, // [19:19] is the sub-list for method output_type
+	19, // [19:19] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_terraform1_proto_init() }
@@ -490,13 +1278,18 @@ func file_terraform1_proto_init() {
 	if File_terraform1_proto != nil {
 		return
 	}
+	file_terraform1_proto_msgTypes[13].OneofWrappers = []any{
+		(*AttributePath_Step_AttributeName)(nil),
+		(*AttributePath_Step_ElementKeyString)(nil),
+		(*AttributePath_Step_ElementKeyInt)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_terraform1_proto_rawDesc), len(file_terraform1_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   5,
+			NumEnums:      2,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/rpcapi/terraform1/terraform1.proto
+++ b/internal/rpcapi/terraform1/terraform1.proto
@@ -76,3 +76,78 @@ message SourcePos {
     int64 line = 2;
     int64 column = 3;
 }
+
+message PolicyMetaData {
+  string policy_name = 1;
+  string policy_set_name = 2;
+  string enforcement_level = 3;
+  string file_name = 4;
+  int32 enforce_index = 5;
+}
+
+message PolicyResult {
+  string target_address = 1;
+  PolicyMetaData policy_metadata = 2;
+  EvaluateResult result = 3;
+}
+
+message PolicyInfo {
+  string target_address = 1;
+  PolicyMetaData policy_metadata = 2;
+  string message = 3;
+  SourceRange policy_range = 4;
+  PolicySnippet policy_snippet = 5;
+  EvaluateResult result = 6;
+}
+
+message PolicySnippet {
+  string context = 1;
+  string code = 2;
+  int64 start_line = 3;
+  int64 highlight_start_offset = 4;
+  int64 highlight_end_offset = 5;
+}
+
+message PolicyDiagnostic {
+  string target_address = 1;
+  PolicyMetaData policy_metadata = 2;
+  EvaluateResult result = 3;
+  Diagnostic diagnostic = 4;
+  PolicySnippet policy_snippet = 5;
+  SourceRange policy_range = 6;
+  repeated ExpressionValue expression_values = 7;
+}
+
+// Sourced from: /internal/policy/proto/types.proto#EvaluateResult
+enum EvaluateResult {
+  INVALID_EVALUATE_RESULT = 0;
+  UNKNOWN_EVALUATE_RESULT = 1;
+  ERROR_EVALUATE_RESULT = 2;
+  ALLOW_EVALUATE_RESULT = 3;
+  DENY_EVALUATE_RESULT = 4;
+  SETUP_ERROR_EVALUATE_RESULT = 5;
+}
+
+// Sourced from: /internal/policy/proto/diagnostics.proto#ExpressionValue
+message ExpressionValue {
+  AttributePath traversal = 1;
+  bytes value = 2;
+}
+
+// Sourced from: /internal/rpcapi/terraform1/stacks.proto#AttributePath
+message AttributePath {
+  message Step {
+    oneof selector {
+      string attribute_name = 1;
+      string element_key_string = 2;
+      int64 element_key_int = 3;
+    }
+  }
+  repeated Step steps = 1;
+}
+
+message PolicyEntitlement { 
+  string host  = 1;
+  string token = 2;
+  string org   = 3;
+}


### PR DESCRIPTION
This PR introduces provider policy evaluation to `BuildProviderPluginCache`, which can prevent providers from being installed by the RPC. (similar to `terraform init` policy evaluation, see #38519)

This PR also proposes refactoring the existing stacks protocol to share mapping code with the existing policy evaluation logic in `PlanStackChanges` and `ApplyStackChanges`. No behavior changes have been made to those RPCs.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
