### PR TITLE
fixes #37680

### DIFF
--- a/.changes/v1.16/fix-azure-backend-panic.yaml
+++ b/.changes/v1.16/fix-azure-backend-panic.yaml
@@ -1,0 +1,2 @@
+﻿kind: BUG FIXES
+body: Fixed a nil pointer dereference panic in the Azure remote state backend when credentials time out.

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -106,11 +106,16 @@ func (c *RemoteClient) Put(data []byte) tfdiags.Diagnostics {
 	}
 
 	blob, err := c.giovanniBlobClient.GetProperties(ctx, c.containerName, c.keyName, getOptions)
-	if err != nil {
-		if !response.WasNotFound(blob.HttpResponse) {
-			return diags.Append(err)
-		}
-	}
+    if err != nil {
+        // Explicitly prevent passing a nil pointer into WasNotFound
+        if blob.HttpResponse == nil {
+            return diags.Append(err)
+        }
+        
+        if !response.WasNotFound(blob.HttpResponse) {
+            return diags.Append(err)
+        }
+    }
 
 	contentType := "application/json"
 	putOptions.Content = &data


### PR DESCRIPTION
Fixes #37680

## Description

This PR fixes a panic (invalid memory address or nil pointer dereference) in the Azure remote state backend. 

During long-running Terraform operations, temporary Azure credentials can expire. When Terraform attempts to persist the state using the `Put()` function in `internal/backend/remote-state/azure/client.go`, the `GetProperties` API call fails. This results in the `blob.HttpResponse` returning as `nil`. 

Previously, the code passed this `nil` pointer directly into `response.WasNotFound(blob.HttpResponse)` without verifying if it existed. Attempting to read from this `nil` pointer caused Terraform to crash. 

The proposed change adds an explicit check to verify that `blob.HttpResponse` is not `nil` before it is accessed. This allows Terraform to return a proper, human-readable error instead of panicking.

## Target Release

1.16.x

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

There are no changes to access controls, encryption, or logging in this pull request.

## CHANGELOG entry

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.