### PR TITLE
feat(search): wire query resource policy nodes into the policy evaluation subgraph

### DIFF
--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -308,7 +308,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&CloseProviderTransformer{},
 
 		// Request policy evaluation for resources.
-		&policyEvalTransformer{PolicyClient: b.PolicyClient},
+		&policyEvalTransformer{PolicyClient: b.PolicyClient, QueryPlan: b.queryPlan},
 
 		// Close the root module
 		&CloseRootModuleTransformer{},

--- a/internal/terraform/graph_builder_plan_test.go
+++ b/internal/terraform/graph_builder_plan_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/policy"
@@ -227,6 +228,54 @@ output "value" {
 		testGraphHappensBefore(t, g, "module.child.data.aws_data_source.a (expand)", "(evaluate policies)")
 		testGraphHappensBefore(t, g, "module.child (close)", "(evaluate policies)")
 	})
+}
+
+// TestPlanGraphBuilder_QueryPlan_PolicyWiring verifies that when queryPlan == true
+// and a PolicyClient is set, policyEvalTransformer wires nodePolicyEval to depend
+// only on list block nodes.
+func TestPlanGraphBuilder_QueryPlan_PolicyWiring(t *testing.T) {
+	provider := mockProviderWithResourceTypeSchema("test_resource", simpleTestSchema())
+	plugins := newContextPlugins(map[addrs.Provider]providers.Factory{
+		addrs.NewDefaultProvider("test"): providers.FactoryFixed(provider),
+	}, nil, nil)
+
+	config := testModuleInline(t, map[string]string{
+		"main.tf": `
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}
+`,
+		"main.tfquery.hcl": `
+list "test_resource" "mylist" {
+  provider = test
+}
+`,
+	}, configs.MatchQueryFiles())
+
+	b := &PlanGraphBuilder{
+		Config:       config,
+		Plugins:      plugins,
+		PolicyClient: policy.NewTestMockClient(t),
+		queryPlan:    true,
+		Operation:    walkPlan,
+	}
+
+	g, diags := b.Build(addrs.RootModuleInstance)
+	if diags.HasErrors() {
+		t.Fatalf("Build failed: %s", diags.Err())
+	}
+
+	nodes := dag.SelectSeq[*nodePolicyEval](g.VerticesSeq()).Collect()
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 nodePolicyEval node in query plan graph, got %d", len(nodes))
+	}
+
+	// The list block node must be scheduled before policy evaluation.
+	testGraphHappensBefore(t, g, "list.test_resource.mylist (expand)", "(evaluate policies)")
 }
 
 func TestPlanGraphBuilder_dynamicBlock(t *testing.T) {

--- a/internal/terraform/graph_builder_plan_test.go
+++ b/internal/terraform/graph_builder_plan_test.go
@@ -248,10 +248,19 @@ terraform {
     }
   }
 }
+
+resource "test_resource" "example" {
+  id = "example"
+}
+
+provider "test" {
+  alias = "example"
+  id = resource.test_resource.example.id
+}
 `,
 		"main.tfquery.hcl": `
 list "test_resource" "mylist" {
-  provider = test
+  provider = test.example
 }
 `,
 	}, configs.MatchQueryFiles())
@@ -263,6 +272,7 @@ list "test_resource" "mylist" {
 		queryPlan:    true,
 		Operation:    walkPlan,
 	}
+	assertPlanGraphBuilderPolicyTransformerQueryPlan(t, b)
 
 	g, diags := b.Build(addrs.RootModuleInstance)
 	if diags.HasErrors() {
@@ -276,6 +286,30 @@ list "test_resource" "mylist" {
 
 	// The list block node must be scheduled before policy evaluation.
 	testGraphHappensBefore(t, g, "list.test_resource.mylist (expand)", "(evaluate policies)")
+
+	policyNode := nodes[0]
+	for _, dep := range g.DownEdges(policyNode) {
+		if res, ok := dep.(GraphNodeConfigResource); ok && res.ResourceAddr().Resource.Mode != addrs.ListResourceMode {
+			t.Errorf("policy node should not directly depend on non-list resource %q in query mode", dag.VertexName(dep))
+		}
+	}
+}
+
+func assertPlanGraphBuilderPolicyTransformerQueryPlan(t *testing.T, b *PlanGraphBuilder) {
+	t.Helper()
+
+	for _, step := range b.Steps() {
+		tr, ok := step.(*policyEvalTransformer)
+		if !ok {
+			continue
+		}
+		if !tr.QueryPlan {
+			t.Fatal("expected PlanGraphBuilder to propagate queryPlan to policyEvalTransformer")
+		}
+		return
+	}
+
+	t.Fatal("expected PlanGraphBuilder to include policyEvalTransformer")
 }
 
 func TestPlanGraphBuilder_dynamicBlock(t *testing.T) {

--- a/internal/terraform/graph_policy.go
+++ b/internal/terraform/graph_policy.go
@@ -6,6 +6,7 @@ package terraform
 import (
 	"sync"
 
+	"github.com/hashicorp/terraform/internal/dag"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -36,4 +37,40 @@ func (ps *policySubgraph) AddQuery(node *nodeQueryResourcePolicy) {
 	defer ps.lock.Unlock()
 
 	ps.graph.Add(node)
+}
+
+func (ps *policySubgraph) evalGraph(span trace.Span) *Graph {
+	ps.lock.Lock()
+	defer ps.lock.Unlock()
+
+	ps.span = span
+
+	g := ps.graphCopyLocked()
+	finish := &nodePolicyEvalFinish{span: span}
+	g.Add(finish)
+	for pn := range g.VerticesSeq() {
+		// Wire finish only to policy node types; all other vertices are skipped.
+		switch pn.(type) {
+		case *nodeResourcePolicy, *nodeQueryResourcePolicy:
+		default:
+			continue
+		}
+		// finish depends on pn, so pn runs first and finish runs after.
+		g.Connect(dag.BasicEdge(finish, pn))
+	}
+
+	// ensure the graph has a single root
+	addRootNodeToGraph(&g)
+	return &g
+}
+
+func (ps *policySubgraph) graphCopyLocked() Graph {
+	var g Graph
+	for _, v := range ps.graph.Vertices() {
+		g.Add(v)
+	}
+	for _, e := range ps.graph.Edges() {
+		g.Connect(e)
+	}
+	return g
 }

--- a/internal/terraform/graph_policy.go
+++ b/internal/terraform/graph_policy.go
@@ -30,3 +30,10 @@ func (ps *policySubgraph) Add(node *nodeResourcePolicy) {
 
 	ps.graph.Add(node)
 }
+
+func (ps *policySubgraph) AddQuery(node *nodeQueryResourcePolicy) {
+	ps.lock.Lock()
+	defer ps.lock.Unlock()
+
+	ps.graph.Add(node)
+}

--- a/internal/terraform/node_policy_eval.go
+++ b/internal/terraform/node_policy_eval.go
@@ -36,26 +36,7 @@ func (n *nodePolicyEval) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnos
 	ctx.State().Close()
 
 	_, span := tracer().Start(ctx.StopCtx(), "terraform.policy.evaluate")
-	policyGraph.span = span
-
-	// Add a finish node that depends on every policy node, so it runs last and
-	// ends the phase span once all policy evaluation has completed.
-	finish := &nodePolicyEvalFinish{span: policyGraph.span}
-	policyGraph.graph.Add(finish)
-	for pn := range policyGraph.graph.VerticesSeq() {
-		// Wire finish only to policy node types; all other vertices are skipped.
-		switch pn.(type) {
-		case *nodeResourcePolicy, *nodeQueryResourcePolicy:
-		default:
-			continue
-		}
-		// finish depends on pn, so pn runs first and finish runs after.
-		policyGraph.graph.Connect(dag.BasicEdge(finish, pn))
-	}
-
-	// ensure the graph has a single root
-	addRootNodeToGraph(&policyGraph.graph)
-	return &policyGraph.graph, nil
+	return policyGraph.evalGraph(span), nil
 }
 
 // AllowUpstreamFailure allows failures from upstream nodes to be tolerated

--- a/internal/terraform/node_policy_eval.go
+++ b/internal/terraform/node_policy_eval.go
@@ -43,7 +43,10 @@ func (n *nodePolicyEval) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnos
 	finish := &nodePolicyEvalFinish{span: policyGraph.span}
 	policyGraph.graph.Add(finish)
 	for pn := range policyGraph.graph.VerticesSeq() {
-		if _, ok := pn.(*nodeResourcePolicy); !ok {
+		// Wire finish only to policy node types; all other vertices are skipped.
+		switch pn.(type) {
+		case *nodeResourcePolicy, *nodeQueryResourcePolicy:
+		default:
 			continue
 		}
 		// finish depends on pn, so pn runs first and finish runs after.
@@ -86,6 +89,9 @@ func (n *nodePolicyEvalFinish) Execute(ctx EvalContext, op walkOperation) tfdiag
 // AllowUpstreamFailure tolerates failures from the policy nodes so the phase
 // span is always ended.
 func (n *nodePolicyEvalFinish) AllowUpstreamFailure(dep dag.Vertex) bool {
-	_, ok := dep.(*nodeResourcePolicy)
-	return ok
+	switch dep.(type) {
+	case *nodeResourcePolicy, *nodeQueryResourcePolicy:
+		return true
+	}
+	return false
 }

--- a/internal/terraform/node_policy_eval_test.go
+++ b/internal/terraform/node_policy_eval_test.go
@@ -1,0 +1,122 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/states"
+)
+
+// TestNodePolicyEvalFinish_AllowUpstreamFailure verifies that only
+// nodeResourcePolicy and nodeQueryResourcePolicy return true; all other vertex
+// types return false.
+func TestNodePolicyEvalFinish_AllowUpstreamFailure(t *testing.T) {
+	finish := &nodePolicyEvalFinish{span: trace.SpanFromContext(context.Background())}
+
+	cases := []struct {
+		name string
+		dep  dag.Vertex
+		want bool
+	}{
+		{
+			name: "nodeResourcePolicy",
+			dep: &nodeResourcePolicy{
+				ResourceAddr: addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "aws_instance",
+					Name: "foo",
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			},
+			want: true,
+		},
+		{
+			name: "nodeQueryResourcePolicy",
+			dep: &nodeQueryResourcePolicy{
+				ResourceAddr: addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "aws_instance",
+					Name: "bar",
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			},
+			want: true,
+		},
+		{
+			name: "nodePolicyEvalFinish",
+			dep:  &nodePolicyEvalFinish{},
+			want: false,
+		},
+		{
+			name: "nodePolicyEval",
+			dep:  &nodePolicyEval{},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := finish.AllowUpstreamFailure(tc.dep)
+			if got != tc.want {
+				t.Errorf("AllowUpstreamFailure(%T) = %v, want %v", tc.dep, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNodePolicyEval_DynamicExpand_FinishWiring verifies that DynamicExpand
+// appends a nodePolicyEvalFinish node to the policy subgraph and wires it to
+// depend on every nodeResourcePolicy and nodeQueryResourcePolicy node already
+// present in the subgraph.
+func TestNodePolicyEval_DynamicExpand_FinishWiring(t *testing.T) {
+	rp := &nodeResourcePolicy{
+		ResourceAddr: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "foo",
+		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+	}
+	qrp := &nodeQueryResourcePolicy{
+		ResourceAddr: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "bar",
+		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+	}
+
+	ps := newPolicySubgraph()
+	ps.Add(rp)
+	ps.AddQuery(qrp)
+
+	ctx := &MockEvalContext{
+		PolicyGraphValue: ps,
+		ChangesChanges:   plans.NewChanges().SyncWrapper(),
+		StateState:       states.NewState().SyncWrapper(),
+		StopCtxValue:     context.Background(),
+	}
+
+	n := &nodePolicyEval{}
+	g, diags := n.DynamicExpand(ctx)
+	if diags.HasErrors() {
+		t.Fatalf("DynamicExpand returned errors: %s", diags.Err())
+	}
+	if g == nil {
+		t.Fatal("DynamicExpand returned nil graph")
+	}
+
+	// nodePolicyEvalFinish must be present in the expanded graph.
+	finishNodes := dag.SelectSeq[*nodePolicyEvalFinish](g.VerticesSeq()).Collect()
+	if len(finishNodes) != 1 {
+		t.Fatalf("expected 1 nodePolicyEvalFinish node, got %d", len(finishNodes))
+	}
+
+	// Both policy node types must be scheduled before the finish node.
+	testGraphHappensBefore(t, g, rp.Name(), "(policy evaluation complete)")
+	testGraphHappensBefore(t, g, qrp.Name(), "(policy evaluation complete)")
+}

--- a/internal/terraform/node_policy_eval_test.go
+++ b/internal/terraform/node_policy_eval_test.go
@@ -119,4 +119,9 @@ func TestNodePolicyEval_DynamicExpand_FinishWiring(t *testing.T) {
 	// Both policy node types must be scheduled before the finish node.
 	testGraphHappensBefore(t, g, rp.Name(), "(policy evaluation complete)")
 	testGraphHappensBefore(t, g, qrp.Name(), "(policy evaluation complete)")
+
+	// Dynamic expansion returns a walk graph, but must not mutate the accumulated
+	// policy subgraph while doing finish/root wiring.
+	testGraphNotContains(t, &ps.graph, "(policy evaluation complete)")
+	testGraphNotContains(t, &ps.graph, rootNodeName)
 }

--- a/internal/terraform/node_policy_eval_test.go
+++ b/internal/terraform/node_policy_eval_test.go
@@ -125,3 +125,77 @@ func TestNodePolicyEval_DynamicExpand_FinishWiring(t *testing.T) {
 	testGraphNotContains(t, &ps.graph, "(policy evaluation complete)")
 	testGraphNotContains(t, &ps.graph, rootNodeName)
 }
+
+// TestNodePolicyEval_DynamicExpand_ConcurrentExecution verifies that when
+// DynamicExpand returns a graph with multiple nodeQueryResourcePolicy nodes,
+// those nodes have no dependency edges between them, allowing the graph walker
+// to execute them concurrently.
+func TestNodePolicyEval_DynamicExpand_ConcurrentExecution(t *testing.T) {
+	const count = 10
+
+	ps := newPolicySubgraph()
+
+	// Add multiple nodeQueryResourcePolicy nodes to simulate a list block
+	// returning multiple resources
+	for i := 0; i < count; i++ {
+		qrp := &nodeQueryResourcePolicy{
+			ResourceAddr: addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "aws_instance",
+				Name: "discovered",
+			}.Instance(addrs.IntKey(i)).Absolute(addrs.RootModuleInstance),
+		}
+		ps.AddQuery(qrp)
+	}
+
+	ctx := &MockEvalContext{
+		PolicyGraphValue: ps,
+		ChangesChanges:   plans.NewChanges().SyncWrapper(),
+		StateState:       states.NewState().SyncWrapper(),
+		StopCtxValue:     context.Background(),
+	}
+
+	n := &nodePolicyEval{}
+	g, diags := n.DynamicExpand(ctx)
+	if diags.HasErrors() {
+		t.Fatalf("DynamicExpand returned errors: %s", diags.Err())
+	}
+	if g == nil {
+		t.Fatal("DynamicExpand returned nil graph")
+	}
+
+	// Collect all nodeQueryResourcePolicy nodes in the expanded graph
+	policyNodes := dag.SelectSeq[*nodeQueryResourcePolicy](g.VerticesSeq()).Collect()
+	if len(policyNodes) != count {
+		t.Fatalf("expected %d policy nodes in expanded graph, got %d", count, len(policyNodes))
+	}
+
+	// The critical requirement for concurrent execution: verify no edges exist
+	// between any pair of nodeQueryResourcePolicy nodes. This allows the graph
+	// walker to execute all policy nodes in parallel.
+	for _, node := range policyNodes {
+		// Check upstream edges (what this node depends on)
+		upEdges := g.UpEdges(node)
+		for _, dep := range upEdges {
+			if otherPolicy, ok := dep.(*nodeQueryResourcePolicy); ok {
+				t.Errorf("policy node %s has upstream dependency on another policy node %s; nodes must be independent for concurrent execution",
+					node.Name(), otherPolicy.Name())
+			}
+		}
+
+		// Check downstream edges (what depends on this node)
+		downEdges := g.DownEdges(node)
+		for _, dep := range downEdges {
+			if otherPolicy, ok := dep.(*nodeQueryResourcePolicy); ok {
+				t.Errorf("policy node %s has downstream dependency on another policy node %s; nodes must be independent for concurrent execution",
+					node.Name(), otherPolicy.Name())
+			}
+		}
+	}
+
+	// Verify finish node exists (wiring is tested in TestNodePolicyEval_DynamicExpand_FinishWiring)
+	finishNodes := dag.SelectSeq[*nodePolicyEvalFinish](g.VerticesSeq()).Collect()
+	if len(finishNodes) != 1 {
+		t.Errorf("expected 1 finish node in expanded graph, got %d", len(finishNodes))
+	}
+}

--- a/internal/terraform/node_query_resource_policy.go
+++ b/internal/terraform/node_query_resource_policy.go
@@ -24,7 +24,7 @@ type nodeQueryResourcePolicy struct {
 
 	// Identity and ListBlockAddr are passed to the policy client in a following revision.
 	// Correlates policy results to UI rows.
-	Identity      cty.Value
+	Identity cty.Value
 	// Groups results by the originating list block.
 	ListBlockAddr addrs.AbsResourceInstance
 }

--- a/internal/terraform/node_query_resource_policy.go
+++ b/internal/terraform/node_query_resource_policy.go
@@ -1,0 +1,36 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// nodeQueryResourcePolicy is a node in the policy subgraph that evaluates
+// policy for a single resource discovered during a list block walk. Like
+// nodeResourcePolicy, it runs as part of nodePolicyEval's DynamicExpand.
+type nodeQueryResourcePolicy struct {
+	// ResourceAddr is the address of this discovered resource instance.
+	ResourceAddr addrs.AbsResourceInstance
+	// ProviderAddr is the resolved provider for the originating list block.
+	ProviderAddr addrs.AbsProviderConfig
+	// GeneratedConfig is the provider-generated cty object for this resource.
+	GeneratedConfig cty.Value
+	// ResourceConfig is the list block config, used for diagnostic source locations.
+	ResourceConfig *configs.Resource
+
+	// Identity and ListBlockAddr are passed to the policy client in a following revision.
+	// Correlates policy results to UI rows.
+	Identity      cty.Value
+	// Groups results by the originating list block.
+	ListBlockAddr addrs.AbsResourceInstance
+}
+
+func (n *nodeQueryResourcePolicy) Name() string {
+	return n.ResourceAddr.String() + " (query policy evaluation)"
+}
+
+// TODO(CORE-6): implement Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics

--- a/internal/terraform/node_query_resource_policy_test.go
+++ b/internal/terraform/node_query_resource_policy_test.go
@@ -1,0 +1,219 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/policy"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+)
+
+// insertQueryPolicyNodes test helper mirrors the insertion loop in listResourceExecute,
+// exercising it in isolation without requiring the full listResourceExecute setup.
+func insertQueryPolicyNodes(t *testing.T, inputs []listResourcePolicy, ctx *MockEvalContext, n *NodePlannableResourceInstance) {
+	t.Helper()
+	if ctx.PolicyGraph() == nil {
+		return
+	}
+	for _, input := range inputs {
+		if input.Unknown {
+			continue
+		}
+		ctx.PolicyGraph().AddQuery(&nodeQueryResourcePolicy{
+			ResourceAddr:    input.SyntheticAddr,
+			ProviderAddr:    n.ResolvedProvider,
+			GeneratedConfig: input.GeneratedConfig,
+			Identity:        input.Identity,
+			ResourceConfig:  input.ResourceConfig,
+			ListBlockAddr:   input.ListBlockAddr,
+		})
+	}
+}
+
+// TestQueryPolicyNodeInsertion_CountMatchesResources verifies that a list block
+// returning N non-unknown resources produces exactly N nodeQueryResourcePolicy
+// nodes in the policy subgraph.
+func TestQueryPolicyNodeInsertion_CountMatchesResources(t *testing.T) {
+	const count = 3
+
+	p := &testing_provider.MockProvider{}
+	schema := listPolicyTestProviderSchema(false)
+	n := listPolicyTestNode("test_resource", "mylist")
+	listBlockAddr := n.Addr
+
+	ctx := listPolicyTestContext(listBlockAddr, p, schema)
+	ps := newPolicySubgraph()
+	ctx.PolicyClientValue = policy.NewTestMockClient(t)
+	ctx.PolicyGraphValue = ps
+
+	stateVal := cty.ObjectVal(map[string]cty.Value{
+		"instance_type": cty.StringVal("t2.micro"),
+		"ami":           cty.StringVal("ami-12345"),
+	})
+	identityVal := cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("i-1")})
+
+	elements := make([]cty.Value, count)
+	for i := range elements {
+		elements[i] = listPolicyTestElement(stateVal, identityVal)
+	}
+	data := cty.TupleVal(elements)
+
+	inputs, diags := n.generateListResourcePolicyData(ctx, listBlockAddr, data)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors generating policy data: %s", diags.Err())
+	}
+
+	insertQueryPolicyNodes(t, inputs, ctx, n)
+
+	// Verify N nodes in policy subgraph
+	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](ps.graph.VerticesSeq()).Collect()
+	if len(nodes) != count {
+		t.Errorf("expected %d policy nodes, got %d", count, len(nodes))
+	}
+}
+
+// TestQueryPolicyNodeInsertion_UnknownResourcesSkipped verifies that policy
+// inputs with Unknown == true do not produce a nodeQueryResourcePolicy in the
+// policy subgraph.
+func TestQueryPolicyNodeInsertion_UnknownResourcesSkipped(t *testing.T) {
+	p := &testing_provider.MockProvider{}
+	schema := listPolicyTestProviderSchema(false)
+	n := listPolicyTestNode("test_resource", "mylist")
+	listBlockAddr := n.Addr
+
+	ctx := listPolicyTestContext(listBlockAddr, p, schema)
+	ps := newPolicySubgraph()
+	ctx.PolicyClientValue = policy.NewTestMockClient(t)
+	ctx.PolicyGraphValue = ps
+
+	stateVal := cty.ObjectVal(map[string]cty.Value{
+		"instance_type": cty.StringVal("t2.micro"),
+		"ami":           cty.StringVal("ami-12345"),
+	})
+	identityVal := cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("i-1")})
+
+	// Two elements with state (non-unknown) and one without (include_resource = false).
+	data := cty.TupleVal([]cty.Value{
+		listPolicyTestElement(stateVal, identityVal),
+		listPolicyTestElementNoState(identityVal),
+		listPolicyTestElement(stateVal, identityVal),
+	})
+
+	inputs, diags := n.generateListResourcePolicyData(ctx, listBlockAddr, data)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors generating policy data: %s", diags.Err())
+	}
+
+	insertQueryPolicyNodes(t, inputs, ctx, n)
+
+	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](ps.graph.VerticesSeq()).Collect()
+
+	// Verify N nodes in policy subgraph, accounting for skipped unknowns
+	if len(nodes) != 2 {
+		t.Errorf("expected 2 policy nodes (unknown skipped), got %d", len(nodes))
+	}
+}
+
+// TestQueryPolicyNodeInsertion_NodePayload verifies that the nodeQueryResourcePolicy
+// added to the policy subgraph carries the correct field values from the
+// listResourcePolicy input.
+func TestQueryPolicyNodeInsertion_NodePayload(t *testing.T) {
+	p := &testing_provider.MockProvider{}
+	schema := listPolicyTestProviderSchema(false)
+	n := listPolicyTestNode("test_resource", "mylist")
+	listBlockAddr := n.Addr
+
+	ctx := listPolicyTestContext(listBlockAddr, p, schema)
+	ps := newPolicySubgraph()
+	ctx.PolicyClientValue = policy.NewTestMockClient(t)
+	ctx.PolicyGraphValue = ps
+
+	stateVal := cty.ObjectVal(map[string]cty.Value{
+		"instance_type": cty.StringVal("m5.large"),
+		"ami":           cty.StringVal("ami-99999"),
+	})
+	identityVal := cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("i-abc")})
+	data := cty.TupleVal([]cty.Value{listPolicyTestElement(stateVal, identityVal)})
+
+	inputs, diags := n.generateListResourcePolicyData(ctx, listBlockAddr, data)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors generating policy data: %s", diags.Err())
+	}
+
+	insertQueryPolicyNodes(t, inputs, ctx, n)
+
+	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](ps.graph.VerticesSeq()).Collect()
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 policy node, got %d", len(nodes))
+	}
+
+	got := nodes[0]
+
+	if got.ResourceAddr.String() != inputs[0].SyntheticAddr.String() {
+		t.Errorf("ResourceAddr = %s, want %s", got.ResourceAddr, inputs[0].SyntheticAddr)
+	}
+	if got.ProviderAddr.String() != n.ResolvedProvider.String() {
+		t.Errorf("ProviderAddr = %s, want %s", got.ProviderAddr, n.ResolvedProvider)
+	}
+	if got.GeneratedConfig == cty.NilVal {
+		t.Error("expected non-nil GeneratedConfig")
+	}
+	if !got.Identity.RawEquals(identityVal) {
+		t.Errorf("Identity = %#v, want %#v", got.Identity, identityVal)
+	}
+	if got.ResourceConfig != n.Config {
+		t.Error("ResourceConfig should point to n.Config")
+	}
+	if got.ListBlockAddr.String() != listBlockAddr.String() {
+		t.Errorf("ListBlockAddr = %s, want %s", got.ListBlockAddr, listBlockAddr)
+	}
+}
+
+// TestNodeQueryResourcePolicy_Name verifies that Name() returns the resource
+// address followed by the "(query policy evaluation)" suffix.
+func TestNodeQueryResourcePolicy_Name(t *testing.T) {
+	addr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "aws_instance",
+		Name: "foo",
+	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
+
+	n := &nodeQueryResourcePolicy{ResourceAddr: addr}
+	want := addr.String() + " (query policy evaluation)"
+	if got := n.Name(); got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}
+
+// TestQueryPolicyNodeInsertion_NilPolicyGraph verifies that insertQueryPolicyNodes
+// does not panic when ctx.PolicyGraph() returns nil.
+func TestQueryPolicyNodeInsertion_NilPolicyGraph(t *testing.T) {
+	p := &testing_provider.MockProvider{}
+	schema := listPolicyTestProviderSchema(false)
+	n := listPolicyTestNode("test_resource", "mylist")
+	listBlockAddr := n.Addr
+
+	// PolicyGraphValue is intentionally left nil.
+	ctx := listPolicyTestContext(listBlockAddr, p, schema)
+
+	stateVal := cty.ObjectVal(map[string]cty.Value{
+		"instance_type": cty.StringVal("t2.micro"),
+		"ami":           cty.StringVal("ami-12345"),
+	})
+	identityVal := cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("i-1")})
+	data := cty.TupleVal([]cty.Value{listPolicyTestElement(stateVal, identityVal)})
+
+	inputs, diags := n.generateListResourcePolicyData(ctx, listBlockAddr, data)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	// Should not panic with nil PolicyGraph.
+	insertQueryPolicyNodes(t, inputs, ctx, n)
+}

--- a/internal/terraform/node_query_resource_policy_test.go
+++ b/internal/terraform/node_query_resource_policy_test.go
@@ -217,3 +217,74 @@ func TestQueryPolicyNodeInsertion_NilPolicyGraph(t *testing.T) {
 	// Should not panic with nil PolicyGraph.
 	insertQueryPolicyNodes(t, inputs, ctx, n)
 }
+
+// TestQueryPolicyNodeInsertion_NodeIndependence verifies that multiple
+// nodeQueryResourcePolicy nodes added to the policy subgraph have no edges
+// between them, ensuring they can be executed concurrently by the graph walker.
+func TestQueryPolicyNodeInsertion_NodeIndependence(t *testing.T) {
+	const count = 5
+
+	p := &testing_provider.MockProvider{}
+	schema := listPolicyTestProviderSchema(false)
+	n := listPolicyTestNode("test_resource", "mylist")
+	listBlockAddr := n.Addr
+
+	ctx := listPolicyTestContext(listBlockAddr, p, schema)
+	ps := newPolicySubgraph()
+	ctx.PolicyClientValue = policy.NewTestMockClient(t)
+	ctx.PolicyGraphValue = ps
+
+	stateVal := cty.ObjectVal(map[string]cty.Value{
+		"instance_type": cty.StringVal("t2.micro"),
+		"ami":           cty.StringVal("ami-12345"),
+	})
+	identityVal := cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("i-1")})
+
+	elements := make([]cty.Value, count)
+	for i := range elements {
+		elements[i] = listPolicyTestElement(stateVal, identityVal)
+	}
+	data := cty.TupleVal(elements)
+
+	inputs, diags := n.generateListResourcePolicyData(ctx, listBlockAddr, data)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors generating policy data: %s", diags.Err())
+	}
+
+	insertQueryPolicyNodes(t, inputs, ctx, n)
+
+	// Collect all nodeQueryResourcePolicy nodes
+	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](ps.graph.VerticesSeq()).Collect()
+	if len(nodes) != count {
+		t.Fatalf("expected %d policy nodes, got %d", count, len(nodes))
+	}
+
+	// Verify no edges exist between any pair of nodeQueryResourcePolicy nodes
+	for _, node := range nodes {
+		downEdges := ps.graph.DownEdges(node)
+		for _, dep := range downEdges {
+			if _, ok := dep.(*nodeQueryResourcePolicy); ok {
+				t.Errorf("found edge from %s to %s; policy nodes must be independent with no inter-node edges",
+					node.Name(), dag.VertexName(dep))
+			}
+		}
+
+		upEdges := ps.graph.UpEdges(node)
+		for _, dep := range upEdges {
+			if _, ok := dep.(*nodeQueryResourcePolicy); ok {
+				t.Errorf("found edge from %s to %s; policy nodes must be independent with no inter-node edges",
+					dag.VertexName(dep), node.Name())
+			}
+		}
+	}
+
+	// Verify the total number of edges in the subgraph is zero
+	// (before finish node is added by DynamicExpand)
+	edges := ps.graph.Edges()
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges between policy nodes in subgraph, got %d edges", len(edges))
+		for _, edge := range edges {
+			t.Logf("  edge: %s -> %s", dag.VertexName(edge.Source()), dag.VertexName(edge.Target()))
+		}
+	}
+}

--- a/internal/terraform/node_resource_plan_instance_query.go
+++ b/internal/terraform/node_resource_plan_instance_query.go
@@ -159,12 +159,24 @@ func (n *NodePlannableResourceInstance) listResourceExecute(ctx EvalContext) (di
 	if ctx.PolicyClient() != nil {
 		var policyDiags tfdiags.Diagnostics
 		policyInputs, policyDiags = n.generateListResourcePolicyData(ctx, addr, resp.Result.GetAttr("data"))
+		// Will only include warning diags so no need to check for HasErrors
 		diags = diags.Append(policyDiags)
-		// generateListResourcePolicyData only returns Warnings, so no HasErrors gate is needed.
-		// TODO: Fix if generateListResourcePolicyData is instrumented to return error diagnostics.
 	}
-	// TODO(CORE-3): iterate policyInputs to insert nodeQueryResourcePolicy nodes
-	_ = policyInputs
+	if ctx.PolicyGraph() != nil {
+		for _, input := range policyInputs {
+			if input.Unknown {
+				continue
+			}
+			ctx.PolicyGraph().AddQuery(&nodeQueryResourcePolicy{
+				ResourceAddr:    input.SyntheticAddr,
+				ProviderAddr:    n.ResolvedProvider,
+				GeneratedConfig: input.GeneratedConfig,
+				Identity:        input.Identity,
+				ResourceConfig:  input.ResourceConfig,
+				ListBlockAddr:   input.ListBlockAddr,
+			})
+		}
+	}
 
 	query := &plans.QueryInstance{
 		Addr:         n.Addr,

--- a/internal/terraform/node_resource_plan_instance_query.go
+++ b/internal/terraform/node_resource_plan_instance_query.go
@@ -159,7 +159,11 @@ func (n *NodePlannableResourceInstance) listResourceExecute(ctx EvalContext) (di
 	if ctx.PolicyClient() != nil {
 		var policyDiags tfdiags.Diagnostics
 		policyInputs, policyDiags = n.generateListResourcePolicyData(ctx, addr, resp.Result.GetAttr("data"))
-		// Will only include warning diags so no need to check for HasErrors
+		// generateListResourcePolicyData should only return warnings, never errors.
+		// If it returns errors, this is a bug that must be fixed in that function.
+		if policyDiags.HasErrors() {
+			panic(fmt.Sprintf("generateListResourcePolicyData returned errors for %s. This is a bug in Terraform and should be reported. Errors: %s", addr, policyDiags.Err()))
+		}
 		diags = diags.Append(policyDiags)
 	}
 	if ctx.PolicyGraph() != nil {

--- a/internal/terraform/transform_policy_eval.go
+++ b/internal/terraform/transform_policy_eval.go
@@ -4,6 +4,7 @@
 package terraform
 
 import (
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/policy"
 )
@@ -14,6 +15,10 @@ import (
 // providers are kept open until all policies have been evaluated.
 type policyEvalTransformer struct {
 	PolicyClient policy.Client
+
+	// QueryPlan restricts upstream wiring to GraphNodeConfigResource nodes with
+	// addrs.ListResourceMode, rather than all vertices.
+	QueryPlan bool
 }
 
 var _ GraphTransformer = (*policyEvalTransformer)(nil)
@@ -35,6 +40,18 @@ func (t *policyEvalTransformer) Transform(g *Graph) error {
 		// sources of a provider.
 		if _, ok := v.(GraphNodeCloseProvider); ok {
 			g.Connect(dag.BasicEdge(v, policyNode))
+			continue
+		}
+
+		// In query mode, policyNode only needs to depend on list block nodes since
+		// those are the only vertices that populate the policy subgraph via ctx.PolicyGraph().AddQuery.
+		// All other vertices are skipped.
+		if t.QueryPlan {
+			if res, ok := v.(GraphNodeConfigResource); ok {
+				if res.ResourceAddr().Resource.Mode == addrs.ListResourceMode {
+					g.Connect(dag.BasicEdge(policyNode, v))
+				}
+			}
 			continue
 		}
 

--- a/internal/terraform/transform_policy_eval_test.go
+++ b/internal/terraform/transform_policy_eval_test.go
@@ -1,0 +1,138 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/policy"
+)
+
+// stubConfigResource is a minimal GraphNodeConfigResource used to exercise
+// policyEvalTransformer in isolation without constructing a full
+// NodePlannableResourceInstance.
+type stubConfigResource struct {
+	addr addrs.ConfigResource
+}
+
+func (s *stubConfigResource) Name() string                       { return s.addr.String() }
+func (s *stubConfigResource) ResourceAddr() addrs.ConfigResource { return s.addr }
+
+// stubCloseProvider is a minimal GraphNodeCloseProvider used to verify that
+// policyEvalTransformer wires provider-close nodes to run after policy evaluation.
+type stubCloseProvider struct{}
+
+func (s *stubCloseProvider) Name() string {
+	return `provider["registry.terraform.io/hashicorp/test"] (close)`
+}
+func (s *stubCloseProvider) ModulePath() addrs.Module { return addrs.RootModule }
+func (s *stubCloseProvider) CloseProviderAddr() addrs.AbsProviderConfig {
+	return addrs.AbsProviderConfig{
+		Provider: addrs.NewDefaultProvider("test"),
+		Module:   addrs.RootModule,
+	}
+}
+
+// TestPolicyEvalTransformer_NilClient verifies that Transform is a no-op when
+// PolicyClient is nil: no nodePolicyEval node is added to the graph.
+func TestPolicyEvalTransformer_NilClient(t *testing.T) {
+	var g Graph
+
+	tr := &policyEvalTransformer{PolicyClient: nil}
+	if err := tr.Transform(&g); err != nil {
+		t.Fatalf("Transform returned error: %s", err)
+	}
+
+	nodes := dag.SelectSeq[*nodePolicyEval](g.VerticesSeq()).Collect()
+	if len(nodes) != 0 {
+		t.Errorf("expected 0 nodePolicyEval nodes with nil client, got %d", len(nodes))
+	}
+}
+
+// TestPolicyEvalTransformer_NonQueryMode verifies that when QueryPlan == false,
+// policyEvalTransformer wires nodePolicyEval to every non-provider-close vertex
+// and wires every provider-close vertex to run after nodePolicyEval.
+func TestPolicyEvalTransformer_NonQueryMode(t *testing.T) {
+	var g Graph
+
+	managedRes := &stubConfigResource{
+		addr: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "foo",
+		}.InModule(addrs.RootModule),
+	}
+	closeProvider := &stubCloseProvider{}
+	g.Add(managedRes)
+	g.Add(closeProvider)
+
+	tr := &policyEvalTransformer{
+		PolicyClient: policy.NewTestMockClient(t),
+		QueryPlan:    false,
+	}
+	if err := tr.Transform(&g); err != nil {
+		t.Fatalf("Transform returned error: %s", err)
+	}
+
+	nodes := dag.SelectSeq[*nodePolicyEval](g.VerticesSeq()).Collect()
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 nodePolicyEval node, got %d", len(nodes))
+	}
+
+	// All non-provider-close vertices run before policy evaluation.
+	testGraphHappensBefore(t, &g, managedRes.Name(), "(evaluate policies)")
+	// Provider-close runs after policy evaluation.
+	testGraphHappensBefore(t, &g, "(evaluate policies)", closeProvider.Name())
+}
+
+// TestPolicyEvalTransformer_QueryMode verifies that when QueryPlan == true,
+// policyEvalTransformer wires nodePolicyEval only to GraphNodeConfigResource
+// vertices whose mode is addrs.ListResourceMode. Non-list managed resources
+// are not wired as upstream dependencies of the policy node.
+func TestPolicyEvalTransformer_QueryMode(t *testing.T) {
+	var g Graph
+
+	listRes := &stubConfigResource{
+		addr: addrs.Resource{
+			Mode: addrs.ListResourceMode,
+			Type: "test_resource",
+			Name: "mylist",
+		}.InModule(addrs.RootModule),
+	}
+	managedRes := &stubConfigResource{
+		addr: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "foo",
+		}.InModule(addrs.RootModule),
+	}
+	g.Add(listRes)
+	g.Add(managedRes)
+
+	tr := &policyEvalTransformer{
+		PolicyClient: policy.NewTestMockClient(t),
+		QueryPlan:    true,
+	}
+	if err := tr.Transform(&g); err != nil {
+		t.Fatalf("Transform returned error: %s", err)
+	}
+
+	nodes := dag.SelectSeq[*nodePolicyEval](g.VerticesSeq()).Collect()
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 nodePolicyEval node, got %d", len(nodes))
+	}
+
+	// List block runs before policy.
+	testGraphHappensBefore(t, &g, listRes.Name(), "(evaluate policies)")
+
+	// Managed resource must NOT be a (transitive) ancestor of the policy node.
+	policyNode := nodes[0]
+	for _, anc := range g.Ancestors(policyNode) {
+		if dag.VertexName(anc) == managedRes.Name() {
+			t.Errorf("policy node should not depend on managed resource in query mode, but %q is an ancestor", managedRes.Name())
+		}
+	}
+}


### PR DESCRIPTION
Continues policy evaluation work from #38769, which collected per-resource
evaluation inputs during a list block walk. This PR wires those inputs into
the policy subgraph so they are scheduled and executed by the graph walker.

* Adds `nodeQueryResourcePolicy`, a new policy subgraph node that carries
  evaluation inputs for a single resource discovered during a list block walk.
  One node is injected into the policy subgraph per discovered resource during
  `listResourceExecute`. Policy evaluation is deferred entirely to the subgraph
  execution phase — no `evaluatePolicies` call occurs in the walk node.
  `Identity` and `ListBlockAddr` are carried on the struct for use in the
  `Execute` implementation in a following revision.
* Extends `policyEvalTransformer` with a `QueryPlan` mode that restricts
  upstream wiring to `addrs.ListResourceMode` nodes only. Wired at the
  `PlanGraphBuilder` callsite via `QueryPlan: b.queryPlan`.
* Extends `nodePolicyEval.DynamicExpand` and
  `nodePolicyEvalFinish.AllowUpstreamFailure` to handle `nodeQueryResourcePolicy`
  via type switches alongside the existing `nodeResourcePolicy` arm.
  `AllowUpstreamFailure` ensures policy evaluation proceeds even when some
  list blocks encounter errors.



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
