### PR TITLE
No policy evaluation should be done for pre-destroy refresh

### DIFF
--- a/internal/command/plan_policy_test.go
+++ b/internal/command/plan_policy_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/policy/proto"
+	"github.com/hashicorp/terraform/internal/states"
 )
 
 // Tests the output of a plan that includes a policy evaluation
@@ -785,6 +787,132 @@ func TestPlan_WithPolicySuccessInfoJSON(t *testing.T) {
 	}
 
 	checkGoldenReference(t, output, "plan-policy")
+}
+
+func TestPlan_Policy_Destroy(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("plan-policy"), td)
+	t.Chdir(td)
+
+	policyCode := `		resource_policy "resource_type" "policy_name" {
+		  enforce_attrs {
+		    key = attr.value == "foo"
+		  }
+		}
+	`
+	if err := os.WriteFile("policy.hcl", []byte(policyCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	policyObj := &policy.Policy{
+		Result:           policy.AllowResult,
+		PolicySetName:    "some_policy_set",
+		Address:          "provider_policy.example",
+		Directory:        "some/path/to",
+		Filename:         "provider_policy_file.tfpolicy.hcl",
+		EnforcementLevel: "mandatory",
+		Range: &hcl.Range{
+			Filename: "provider_policy_file.tfpolicy.hcl",
+			Start:    hcl.Pos{Line: 1, Column: 1},
+			End:      hcl.Pos{Line: 5, Column: 12},
+		},
+	}
+
+	originalState := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "foo",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"id":"bar"}`),
+				Status:    states.ObjectReady,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			},
+		)
+	})
+	statePath := testStateFile(t, originalState)
+
+	p := planFixtureProvider()
+	view, done := testView(t)
+	overrides := metaOverridesForProvider(p)
+	policyClient := policy.NewTestMockClient(t)
+	overrides.PolicyClient = policyClient
+
+	providerEvalCount := 0
+	policyClient.EvaluateProviderFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateProviderRequest_ProviderMetadata]) policy.EvaluationResponse {
+		providerEvalCount++
+		return policy.EvaluationResponse{
+			Overall:  policy.AllowResult,
+			Policies: []*policy.Policy{policyObj},
+			Enforcements: []policy.EnforcementResult{{
+				Result:  policy.AllowResult,
+				Message: "Destroy provider enforcement message",
+				Policy:  policyObj,
+			}},
+		}
+	}
+
+	c := &PlanCommand{
+		Meta: Meta{
+			testingOverrides:          overrides,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+		},
+	}
+
+	args := []string{"-destroy", "-state", statePath, "-policies", td, "-parallelism=1", "-no-color"}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, output.Stderr())
+	}
+
+	if providerEvalCount != 1 {
+		t.Fatalf("expected exactly 1 provider policy evaluation, got %d", providerEvalCount)
+	}
+
+	expectedStdout := `
+Warning: Deprecated flag: -state
+
+Use the "path" attribute within the "local" backend to specify a file for
+state storage
+data.test_data_source.a: Reading...
+data.test_data_source.a: Read complete after 0s [id=zzzzz]
+test_instance.foo: Refreshing state... [id=bar]
+
+Policy Info:
+in policy provider_policy.example
+"Destroy provider enforcement message"
+
+
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  - destroy
+
+Terraform will perform the following actions:
+
+  # test_instance.foo will be destroyed
+  - resource "test_instance" "foo" {
+      - id = "bar" -> null
+    }
+
+Plan: 0 to add, 0 to change, 1 to destroy.
+
+─────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.
+`
+	if diff := cmp.Diff(expectedStdout, output.Stdout()); diff != "" {
+		t.Fatalf("unexpected stdout output:\n%s", diff)
+	}
+
 }
 
 func TestPlan_WithPolicyClientStopAfterPlan(t *testing.T) {

--- a/internal/command/testdata/plan-policy/main.tf
+++ b/internal/command/testdata/plan-policy/main.tf
@@ -5,6 +5,7 @@ resource "test_instance" "foo" {
     device_index = 0
     description  = "Main network interface"
   }
+  depends_on = [data.test_data_source.a]
 }
 
 data "test_data_source" "a" {

--- a/internal/stacks/stackruntime/internal/stackeval/refresh_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/refresh_instance.go
@@ -74,10 +74,6 @@ func (r *RefreshInstance) Plan(ctx context.Context) (*plans.Plan, tfdiags.Diagno
 		// compatible with the destroy operation.
 		opts.PreDestroyRefresh = true
 
-		// In pre-destroy refresh, we want to prevent policy evaluation, so
-		// we disable the policy client
-		opts.PolicyClient = nil
-
 		plan, moreDiags := PlanComponentInstance(ctx, r.component.main, r.component.PlanPrevState(), opts, nil, r.component)
 		return plan, diags.Append(moreDiags)
 	})

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -7116,7 +7116,7 @@ func TestPlan_WithPolicyResultsOnRemovedComponent(t *testing.T) {
 		// Stacks runs a single call to the module runtime for planning a component destroy, a destroy plan.
 		// The plan emits modules and resources policy evaluations.
 		`component.simple_component["comp1"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation-removed"),
-		`component.simple_component["comp2"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation-removed"),
+		`component.simple_component["comp2"]`:                                  createExpectedComponentInstancePolicyEvaluationForResources("policy-evaluation-removed"),
 		`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation-removed"),
 		`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation-removed"),
 	}

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -777,6 +777,13 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 		return nil, nil, diags
 	}
 
+	if opts.PreDestroyRefresh {
+		// The pre-destroy refresh walk is an internal implementation detail used
+		// only to refresh state before producing the real destroy plan. Policy
+		// results should come only from the actual destroy plan walk.
+		opts.PolicyClient = nil
+	}
+
 	graph, walkOp, moreDiags := c.planGraph(config, prevRunState, opts)
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -306,15 +306,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&CloseProviderTransformer{},
 
 		// Request policy evaluation for resources.
-		&policyEvalTransformer{
-			PolicyClient: func() policy.Client {
-				// Skip policy evaluation during predestroy refresh.
-				if b.preDestroyRefresh {
-					return nil
-				}
-				return b.PolicyClient
-			}(),
-		},
+		&policyEvalTransformer{PolicyClient: b.PolicyClient},
 
 		// Close the root module
 		&CloseRootModuleTransformer{},


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This PR fixes a bug where provider policies were evaluated twice during `terraform plan -destroy` when local policies are enabled.

A destroy plan currently performs two internal passes:

1. a pre-destroy refresh plan
2. the actual destroy plan

`PreDestroyRefresh` already suppressed resource policy graph evaluation, but provider policy evaluation is inline in provider configuration nodes and was still receiving a non-nil policy client during the internal pre-destroy refresh walk, leading to duplicate provider policy results and duplicate policy info diagnostics in output.

Also, when we set the policy client appropriately in the module runtime, it should cascade to stack's `RefreshInstance`.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
