### PR TITLE
fix: warn when -backend-config file is an auto-loaded tfvars file (terraform.tfvars)

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260710-000000.yaml
+++ b/.changes/v1.16/BUG FIXES-20260710-000000.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'init: Warn when a backend configuration file uses a name reserved for automatically-loaded root module variable values.'
+time: 2026-07-10T00:00:00Z
+custom:
+  Issue: "38720"

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"sort"
@@ -825,6 +826,17 @@ func (c *InitCommand) backendConfigOverrideBody(flags arguments.FlagNameValueSli
 
 		if eq == -1 {
 			// The value is interpreted as a filename.
+			filename := filepath.Base(item.Value)
+			if filename == arguments.DefaultVarsFilename ||
+				filename == arguments.DefaultVarsFilename+".json" ||
+				strings.HasSuffix(filename, ".auto.tfvars") ||
+				strings.HasSuffix(filename, ".auto.tfvars.json") {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Warning,
+					"Unexpected backend configuration file",
+					fmt.Sprintf("The file %q is automatically loaded by Terraform as a root module variable values file. Using the same file for backend configuration may cause its contents to be interpreted unexpectedly.\n\nTo avoid this ambiguity, use the documented naming convention \"*.tfbackend\" for backend configuration files.", item.Value),
+				))
+			}
 			newBody, fileDiags := c.loadHCLFile(item.Value)
 			diags = diags.Append(fileDiags)
 			if fileDiags.HasErrors() {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -993,6 +993,90 @@ func TestInit_backendConfigFilePowershellConfusion(t *testing.T) {
 	}
 }
 
+func TestInit_backendConfigAutoLoadedVarFileWarning(t *testing.T) {
+	tests := map[string]struct {
+		filename    string
+		contents    string
+		wantWarning bool
+	}{
+		"terraform.tfvars": {
+			filename:    "terraform.tfvars",
+			contents:    `path = "hello"`,
+			wantWarning: true,
+		},
+		"terraform.tfvars.json": {
+			filename:    "terraform.tfvars.json",
+			contents:    `{"path":"hello"}`,
+			wantWarning: true,
+		},
+		"auto.tfvars": {
+			filename:    "example.auto.tfvars",
+			contents:    `path = "hello"`,
+			wantWarning: true,
+		},
+		"auto.tfvars.json": {
+			filename:    "example.auto.tfvars.json",
+			contents:    `{"path":"hello"}`,
+			wantWarning: true,
+		},
+		"regular.tfvars": {
+			filename: "backend.tfvars",
+			contents: `path = "hello"`,
+		},
+		"tfbackend": {
+			filename: "config.local.tfbackend",
+			contents: `path = "hello"`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			td := t.TempDir()
+			testCopyDir(t, testFixturePath("init-backend-config-file"), td)
+			t.Chdir(td)
+
+			if err := os.WriteFile(test.filename, []byte(test.contents), 0644); err != nil {
+				t.Fatalf("failed to write backend configuration file: %s", err)
+			}
+
+			ui := new(cli.MockUi)
+			view, done := testView(t)
+			c := &InitCommand{
+				Meta: Meta{
+					testingOverrides: metaOverridesForProvider(testProvider()),
+					Ui:               ui,
+					View:             view,
+				},
+			}
+
+			code := c.Run([]string{fmt.Sprintf("-backend-config=%s", test.filename)})
+			output := done(t)
+			if code != 0 {
+				t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, output.Stderr(), output.Stdout())
+			}
+
+			got := output.All()
+			const warningSummary = "Unexpected backend configuration file"
+			if !test.wantWarning {
+				if strings.Contains(got, warningSummary) {
+					t.Fatalf("unexpected warning in output:\n%s", got)
+				}
+				state := testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
+				if got, want := normalizeJSON(t, state.Backend.ConfigRaw), `{"path":"hello","workspace_dir":null}`; got != want {
+					t.Errorf("wrong config\ngot:  %s\nwant: %s", got, want)
+				}
+				return
+			}
+
+			for _, want := range []string{warningSummary, test.filename, "root module variable values file", "*.tfbackend"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("wrong output\ngot:\n%s\n\nwant: message containing %q", got, want)
+				}
+			}
+		})
+	}
+}
+
 func TestInit_backendReconfigure(t *testing.T) {
 	// Create a temporary working directory and copy in test fixtures
 	td := t.TempDir()


### PR DESCRIPTION
## Target Release

1.16.x

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None. This change only adds a warning diagnostic to `terraform init`; it does not alter authentication, authorization, state encryption, or any other security control.

## CHANGELOG entry

Added under `.changes/v1.16/` (changie): `init`: passing an auto-loaded variables file (`terraform.tfvars`, `terraform.tfvars.json`, `*.auto.tfvars`, `*.auto.tfvars.json`) to `-backend-config` now emits a warning, since that file is also loaded as root module variable values and its contents will not behave as backend configuration. The warning recommends the documented `*.tfbackend` naming convention.

The warning is raised in `(*InitCommand).backendConfigOverrideBody` (`internal/command/init.go`) in the file-path branch. A warning rather than an error preserves backward compatibility. `internal/command/init_test.go` covers the new diagnostic, modeled on `TestInit_backendConfigFilePowershellConfusion`.

Fixes #38720
