### PR TITLE
PSS: Add -json flag, but not JSON output, to `state migrate` command

### DIFF
--- a/internal/command/arguments/state_migrate.go
+++ b/internal/command/arguments/state_migrate.go
@@ -30,18 +30,17 @@ type StateMigrate struct {
 // representing the best effort interpretation of the arguments.
 func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	migrate := &StateMigrate{
-		ViewType: ViewHuman,
-	}
+	migrate := &StateMigrate{}
 
 	var srcLockFilePath, dstLockFilePath string
-	var upgrade, inputEnabled, forceCopy bool
+	var upgrade, inputEnabled, forceCopy, json bool
 	cmdFlags := defaultFlagSet("state migrate")
 	cmdFlags.StringVar(&srcLockFilePath, "source-provider-lock-file", "", "Path to a provider lock file for the source provider.")
 	cmdFlags.StringVar(&dstLockFilePath, "destination-provider-lock-file", "", "Path to a provider lock file for the destination provider.")
 	cmdFlags.BoolVar(&upgrade, "upgrade", false, "Trigger upgrade of the provider.")
 	cmdFlags.BoolVar(&inputEnabled, "input", true, "Enable input for interactive prompts.")
 	cmdFlags.BoolVar(&forceCopy, "force-copy", false, "Suppress and auto-approve prompts about copying state data. Enables state migrations when interactive prompts are disabled via -input=false.")
+	cmdFlags.BoolVar(&json, "json", false, "Enable JSON output.")
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -73,6 +72,14 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 			))
 		}
 
+		// JSON output is only to be used in automation, as input cannot be received
+		if json {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Conflicting command-line flags provided",
+				"-json cannot be used outside of automation (with -input=true)",
+			))
+		}
 	}
 
 	if srcLockFilePath == "" {
@@ -125,6 +132,12 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 		))
 	} else {
 		migrate.DestinationLockFilePath = dstLockFilePath
+	}
+
+	if json {
+		migrate.ViewType = ViewJSON
+	} else {
+		migrate.ViewType = ViewHuman
 	}
 
 	return migrate, diags

--- a/internal/command/arguments/state_migrate.go
+++ b/internal/command/arguments/state_migrate.go
@@ -72,9 +72,6 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 				"-destination-provider-lock-file cannot be used outside of automation (with -input=true)",
 			))
 		}
-		if len(diags) > 0 {
-			return migrate, diags
-		}
 
 	}
 

--- a/internal/command/arguments/state_migrate_test.go
+++ b/internal/command/arguments/state_migrate_test.go
@@ -47,6 +47,7 @@ func TestStateMigrateArgs_valid(t *testing.T) {
 				"-source-provider-lock-file", userLockFilePath,
 				"-destination-provider-lock-file", userLockFilePath,
 				"-upgrade",
+				"-json",
 				"-input=false",
 			},
 			expectedArgs: &StateMigrate{
@@ -54,7 +55,7 @@ func TestStateMigrateArgs_valid(t *testing.T) {
 				DestinationLockFilePath: userLockFilePath,
 				Upgrade:                 true,
 				InputEnabled:            false,
-				ViewType:                ViewHuman,
+				ViewType:                ViewJSON,
 			},
 		},
 	}
@@ -153,6 +154,25 @@ func TestStateMigrateArgs_invalid(t *testing.T) {
 					tfdiags.Error,
 					"Invalid destination-provider-lock-file",
 					"Expected lock file name to be .terraform.lock.hcl, got: invalid.lock.hcl",
+				),
+			},
+		},
+		{ // JSON output outside of automation
+			rawArgs: []string{
+				"-json",
+			},
+			expectedArgs: &StateMigrate{
+				SourceLockFilePath:      ".terraform.lock.hcl",
+				DestinationLockFilePath: ".terraform.lock.hcl",
+				Upgrade:                 false,
+				InputEnabled:            true,
+				ViewType:                ViewJSON,
+			},
+			expectedDiags: tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Conflicting command-line flags provided",
+					"-json cannot be used outside of automation (with -input=true)",
 				),
 			},
 		},

--- a/internal/command/arguments/state_migrate_test.go
+++ b/internal/command/arguments/state_migrate_test.go
@@ -127,11 +127,11 @@ func TestStateMigrateArgs_invalid(t *testing.T) {
 		},
 		{ // set lock file paths outside of automation
 			rawArgs: []string{
-				"-source-provider-lock-file", "/src/.terraform.lock.hcl",
-				"-destination-provider-lock-file", "/dst/.terraform.lock.hcl",
+				"-source-provider-lock-file", userLockFilePath,
+				"-destination-provider-lock-file", invalidLockFilePath,
 			},
 			expectedArgs: &StateMigrate{
-				SourceLockFilePath:      "",
+				SourceLockFilePath:      userLockFilePath,
 				DestinationLockFilePath: "",
 				Upgrade:                 false,
 				InputEnabled:            true,
@@ -147,6 +147,12 @@ func TestStateMigrateArgs_invalid(t *testing.T) {
 					tfdiags.Error,
 					"Conflicting command-line flags provided",
 					"-destination-provider-lock-file cannot be used outside of automation (with -input=true)",
+				),
+				// Diagnostic about invalid lock file regardless of this flag not being allow
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid destination-provider-lock-file",
+					"Expected lock file name to be .terraform.lock.hcl, got: invalid.lock.hcl",
 				),
 			},
 		},

--- a/internal/command/arguments/state_migrate_test.go
+++ b/internal/command/arguments/state_migrate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-func TestStateMigrateArgs(t *testing.T) {
+func TestStateMigrateArgs_valid(t *testing.T) {
 	t.Parallel()
 
 	// Create lock files to use in test, as validation will check for the existence of the
@@ -29,9 +29,8 @@ func TestStateMigrateArgs(t *testing.T) {
 	}
 
 	testCases := []struct {
-		rawArgs       []string
-		expectedArgs  *StateMigrate
-		expectedDiags tfdiags.Diagnostics
+		rawArgs      []string
+		expectedArgs *StateMigrate
 	}{
 		{
 			rawArgs: []string{""},
@@ -58,6 +57,40 @@ func TestStateMigrateArgs(t *testing.T) {
 				ViewType:                ViewHuman,
 			},
 		},
+	}
+
+	for i, tc := range testCases {
+		args, diags := ParseStateMigrate(tc.rawArgs)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if diff := cmp.Diff(tc.expectedArgs, args); diff != "" {
+			t.Fatalf("%d: supplied: %q, got unexpected arguments:\n%s", i, tc.rawArgs, diff)
+		}
+	}
+}
+
+func TestStateMigrateArgs_invalid(t *testing.T) {
+	t.Parallel()
+
+	// Create lock files to use in test, as validation will check for the existence of the
+	// file if a path is supplied via CLI flags.
+	td := t.TempDir()
+	userLockFilePath := filepath.Join(td, ".terraform.lock.hcl")
+	if err := os.WriteFile(userLockFilePath, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create test lock file: %s", err)
+	}
+
+	invalidLockFilePath := filepath.Join(td, "invalid.lock.hcl")
+	if err := os.WriteFile(invalidLockFilePath, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create test lock file: %s", err)
+	}
+
+	testCases := []struct {
+		rawArgs       []string
+		expectedArgs  *StateMigrate
+		expectedDiags tfdiags.Diagnostics
+	}{
 		{
 			rawArgs: []string{"-input=false", "-source-provider-lock-file", invalidLockFilePath},
 			expectedArgs: &StateMigrate{
@@ -121,7 +154,12 @@ func TestStateMigrateArgs(t *testing.T) {
 
 	for i, tc := range testCases {
 		args, diags := ParseStateMigrate(tc.rawArgs)
+
+		if !diags.HasErrors() {
+			t.Fatalf("expected diagnostics, but got none")
+		}
 		tfdiags.AssertDiagnosticsMatch(t, diags, tc.expectedDiags)
+
 		if diff := cmp.Diff(tc.expectedArgs, args); diff != "" {
 			t.Fatalf("%d: supplied: %q, got unexpected arguments:\n%s", i, tc.rawArgs, diff)
 		}


### PR DESCRIPTION
This PR doesn't add JSON output, as there are problems to navigate around how JSON logging is implemented in `init`. I'm laying the ground work for JSON output in `state migrate` across multiple PRs (namely: https://github.com/hashicorp/terraform/pull/38870, https://github.com/hashicorp/terraform/pull/38871 and the branch https://github.com/hashicorp/terraform/compare/pss/json-output-state-migrate...implement-state-migrate-json-output)

Instead **this PR** is limited to just adding support for the `-json` flag and making some other changes in argument parsing for `state migrate`:

* Parse -json flag as a boolean
* Stop returning early when an error is encountered during argument parsing, so we return a "best effort" representation alongside any errors. See: https://github.com/hashicorp/terraform/pull/38862#discussion_r3597085866



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing. **(experimental command)**
