### PR TITLE
feat: If the PSS provider is present in the locks used to control PSS provider download then don't prompt for approval.

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -546,7 +546,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 	}
 
 	// Return advice to the calling code about what to do regarding safe state store provider installation
-	safeInstallAction = c.determineSafeProviderInstallAction(rootModEarly.StateStore.ProviderAddr, providerLocations)
+	safeInstallAction = c.determineSafeProviderInstallAction(rootModEarly.StateStore.ProviderAddr, providerLocations, previousLocks)
 
 	return true, lock, safeInstallAction, stateStoreProviderAuthResult, diags
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4682,6 +4682,70 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		}
 	})
 
+	t.Run("not prompted to approve a state store provider downloaded via HTTP if the provider is in the dependency lock file.", func(t *testing.T) {
+		// This scenario is distinct from using the -state-store-provider-override flag, which is specific to non-interactive/automation mode.
+		// Here, we assert that users aren't prompted for approval if the provider hasn't been downloaded yet but it's described in the working directory's lock file.
+		// This will happen when a user git clones a Terraform project from version control, or a lock file is copied from elsewhere when starting a project.
+
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("state-store-unchanged/provider-managed-by-terraform"), td)
+		t.Chdir(td)
+
+		// The dependency lock file already exists.
+		lockFile := filepath.Join(td, depsfile.LockFilePath)
+		_, err := os.Stat(lockFile)
+		if os.IsNotExist(err) {
+			t.Fatal("expected dependency lock file to exist, but it doesn't")
+		}
+
+		// Set up mock provider source that mocks out downloading hashicorp/test v1.2.3 via HTTP.
+		// This stops Terraform auto-approving the provider installation.
+		source := newMockProviderSourceUsingTestHttpServer(t, map[string][]string{
+			"hashicorp/test": {"1.2.3"},
+		})
+
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProviderAddress := addrs.NewDefaultProvider("test")
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		meta := Meta{
+			Ui:                        ui,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+			testingOverrides: &testingOverrides{
+				Providers: map[addrs.Provider]providers.Factory{
+					mockProviderAddress: providers.FactoryFixed(mockProvider),
+				},
+			},
+			ProviderSource: source,
+		}
+		c := &InitCommand{
+			Meta: meta,
+		}
+
+		args := []string{
+			"-enable-pluggable-state-storage-experiment=true",
+		}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 0 {
+			t.Fatalf("expected code 0 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+
+		// Check output via view
+		output := testOutput.All()
+		expectedOutputs := []string{
+			`Initializing the state store "test_store"...`,
+			"Terraform has been successfully initialized!",
+		}
+		for _, expected := range expectedOutputs {
+			if !strings.Contains(output, expected) {
+				t.Fatalf("expected output to include %q, but got':\n %s", expected, output)
+			}
+		}
+	})
+
 	t.Run("approval prompt reports provider as unauthorized if no hashes returned from the HTTP mirror", func(t *testing.T) {
 		// Create a temporary, uninitialized working directory with configuration including a state store
 		td := t.TempDir()

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -5325,7 +5325,6 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		output := testOutput.All()
 		expectedOutputs := []string{
 			`Initializing the state store "test_store"...`,
-			"The state store provider was approved automatically",
 			"Terraform has been successfully initialized!",
 		}
 		for _, expected := range expectedOutputs {

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -3071,20 +3071,21 @@ const (
 
 // determineSafeProviderInstallAction returns a `SafeProviderInstallAction` rune that instructs calling code about what to do following download of the state store provider.
 // The `providerLocations` map parameter is expected to be created by the `FetchPackageBegin` callback, which is called during provider download.
-func (m *Meta) determineSafeProviderInstallAction(provider addrs.Provider, providerLocations map[addrs.Provider]getproviders.PackageLocation) SafeStateStoreProviderInstallAction {
+func (m *Meta) determineSafeProviderInstallAction(provider addrs.Provider, providerLocations map[addrs.Provider]getproviders.PackageLocation, previousLocks *depsfile.Locks) SafeStateStoreProviderInstallAction {
 	location, ok := providerLocations[provider]
-	if !ok {
-		// The provider was not processed in the FetchPackageBegin callback.
-		// A provider that wasn't downloaded during this init could be because:
-		// * It was already present from a previous installation.
-		// * If upgrading, no newer version was available that matched version constraints.
-		// * Or, the provider is unmanaged/reattached and so download was skipped.
-		log.Printf("[TRACE] init (getProvidersFromPSSConfig): the state storage provider %s (%q) will not be changed in the dependency lock file after provider installation. Either it was already present and/or there was no available upgrade version that matched version constraints.", provider.Type, provider)
+	if !ok || previousLocks.AllProviders()[provider] != nil {
+		// Either:
+		//  - the provider was already downloaded to the cache (ok == false, due to FetchPackageBegin callback not being invoked)
+		// or:
+		//  - the provider isn't already downloaded to the cache BUT installation is controlled by a lock file.
+		//
+		// In both cases trust is already established; skip requesting approval.
+		log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) was present in a dependency lock file during provider installation, so we consider it safe", provider.Type, provider)
 		return Proceed
 	} else {
-		// The provider was processed in the FetchPackageBegin callback, so either it's being downloaded for the first time, or upgraded.
+		// The provider wasn't in the dependency lock file so it's being download for the first time
+		// (we block upgrading the state store provider in this method).
 		log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) will be changed in the dependency lock file during provider installation.", provider.Type, provider)
-
 		switch location.(type) {
 		case getproviders.PackageLocalArchive, getproviders.PackageLocalDir:
 			// If the provider is downloaded from a local source we assume it's safe.

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -3110,6 +3110,12 @@ func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInst
 	switch action {
 	case Proceed:
 		// do nothing; provider is already trusted and there's no need to notify the user.
+
+		if flagLockfilePath != "" {
+			// If the user supplied a lock file path via CLI flag, we should notify them that it was used.
+			view.Output(views.StateStoreProviderAutomationApprovedMessage)
+			view.Spacer()
+		}
 	case RequireApproval:
 		if m.input {
 			// Prompt the user about trusting the provider used for state storage.
@@ -3172,9 +3178,6 @@ func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInst
 				))
 				return diags
 			}
-
-			view.Output(views.StateStoreProviderAutomationApprovedMessage)
-			view.Spacer()
 		}
 	default:
 		// Handle Invalid or unexpected action types


### PR DESCRIPTION
This PR's changes stops users of Terraform in interactive mode being unnecessarily prompted for provider approval in `state migrate` or `init` when using PSS. For example, when a user has git cloned a project from VCS for the first time and the repo contains a dependency lock file that file already demonstrates trust in a provider, so the user shouldn't be prompted for trust again.

This means that the main happy path (i.e. where  `determineSafeProviderInstallAction` returns a `Proceed` action) for provider download is equally applicable to these 3 different flavours of 'Terraform used a lock file to download a provider so that provider already has trust established':

1. User downloads a provider for the first time in automation using a CLI flag to provide a separate lock file
2. User runs init for the Nth time with a pre-existing lock file in the working directory and the provider already downloaded to the cache
3. User git clones a Terraform project where the dep lock file is in VCS and controls download of the state store provider.

This required some matching changes in  `handleSafeProviderInstallAction` because now [this old code](https://github.com/hashicorp/terraform/blob/56e9aea2f5978ea4ba8ec781fc041abd0e22183d/internal/command/meta_backend.go#L3175-L3176) has become unreachable. Instead, I've ensured that when a user is in scenario 1 from the list above they get some feedback about the CLI flag being used:

https://github.com/hashicorp/terraform/blob/ab9eb776fecb3b12962bf56e6cfa44ba2e66a70e/internal/command/meta_backend.go#L3114-L3118

In other scenarios the provider will just be downloaded normally under the control of the lock file, without excess terminal output.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
