### PR TITLE
views: Refactor how empty lines are logged in human-readable output

### DIFF
--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -98,7 +98,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		}
 		span.End()
 
-		view.Output(views.EmptyMessage)
+		view.Spacer()
 	}
 
 	// If our directory is empty, then we're done. We can't get or set up
@@ -242,7 +242,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		if configProvidersOutput {
 			// If we outputted information, then we need to output a newline
 			// so that our success message is nicely spaced out from prior text.
-			view.Output(views.EmptyMessage)
+			view.Spacer()
 		}
 
 		// Course of action depends on the SafeStateStoreProviderInstallAction returned from getProvidersFromPSSConfig
@@ -276,7 +276,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	if backendOutput {
 		// If we outputted information, then we need to output a newline
 		// so that our success message is nicely spaced out from prior text.
-		view.Output(views.EmptyMessage)
+		view.Spacer()
 	}
 
 	// Set up the policy client now that the backend is configured, so the
@@ -343,7 +343,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		if modsOutput {
 			// If we outputted information, then we need to output a newline
 			// so that our success message is nicely spaced out from prior text.
-			view.Output(views.EmptyMessage)
+			view.Spacer()
 		}
 	}
 
@@ -418,7 +418,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	if stateProvidersOutput {
 		// If we outputted information, then we need to output a newline
 		// so that our success message is nicely spaced out from prior text.
-		view.Output(views.EmptyMessage)
+		view.Spacer()
 	}
 
 	// Update the dependency lock file, if it has changed.
@@ -438,7 +438,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	if lockFileOutput {
 		// If we outputted information, then we need to output a newline
 		// so that our success message is nicely spaced out from prior text.
-		view.Output(views.EmptyMessage)
+		view.Spacer()
 	}
 
 	// If we accumulated any warnings along the way that weren't accompanied

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -3115,12 +3115,12 @@ func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInst
 			diags = diags.Append(m.promptStateStorageProviderApproval(provider, stateStoreProviderLock, stateStoreProviderAuthResult))
 			if diags.HasErrors() {
 				view.Output(views.StateStoreProviderInteractiveRejectedMessage)
-				view.Output(views.EmptyMessage)
+				view.Spacer()
 				return diags
 			}
 
 			view.Output(views.StateStoreProviderInteractiveApprovedMessage)
-			view.Output(views.EmptyMessage)
+			view.Spacer()
 		} else {
 			// Confirm that a lock was used to control download.
 			// Note: we have to wait and do that here because at this point we know the provider was downloaded from a source that requires additional info about trust.
@@ -3173,7 +3173,7 @@ func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInst
 			}
 
 			view.Output(views.StateStoreProviderAutomationApprovedMessage)
-			view.Output(views.EmptyMessage)
+			view.Spacer()
 		}
 	default:
 		// Handle Invalid or unexpected action types

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -310,7 +310,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			return 1
 		}
 		if output {
-			stateMigrate.LogInitMessage(views.EmptyMessage)
+			stateMigrate.Spacer()
 		}
 	}
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -138,11 +138,7 @@ func (v *InitJSON) PolicyResult(addr string, resp policy.EvaluationResponse) {
 }
 
 func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
-	// don't add empty messages to json output
 	preppedMessage := v.PrepareMessage(messageCode, params...)
-	if preppedMessage == "" {
-		return
-	}
 
 	// Logged data includes by default:
 	// @level as "info"
@@ -368,10 +364,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "Migrating from state store %q (%s) to %q (%s). Reason: %s.",
 		JSONValue:  "Migrating from state store %q (%s) to %q (%s). Reason: %s.",
 	},
-	"empty_message": {
-		HumanValue: "",
-		JSONValue:  "",
-	},
 }
 
 type InitMessageCode string
@@ -381,7 +373,6 @@ const (
 	// Keep docs/internals/machine-readable-ui.mdx up to date with
 	// this list when making changes here.
 	CopyingConfigurationMessage                  InitMessageCode = "copying_configuration_message"
-	EmptyMessage                                 InitMessageCode = "empty_message"
 	OutputInitEmptyMessage                       InitMessageCode = "output_init_empty_message"
 	OutputInitSuccessMessage                     InitMessageCode = "output_init_success_message"
 	OutputInitSuccessCloudMessage                InitMessageCode = "output_init_success_cloud_message"

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -22,6 +22,8 @@ type ProviderInstaller interface {
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Output(messageCode InitMessageCode, params ...any)
 	PrepareMessage(messageCode InitMessageCode, params ...any) string
+
+	Spacer // output from provider installation is spaced out from following human-readable output log lines
 }
 
 // The Init view is used for the init command.
@@ -33,6 +35,8 @@ type Init interface {
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
 	PrepareMessage(messageCode InitMessageCode, params ...any) string
+
+	Spacer // The `init` command logs empty lines to space-out different sections of human-readable output
 }
 
 // NewInit returns Init implementation for the given ViewType.
@@ -64,6 +68,10 @@ var (
 
 func (v *InitHuman) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)
+}
+
+func (v *InitHuman) Spacer() {
+	v.view.Spacer()
 }
 
 func (v *InitHuman) PolicyDiagnostics(diags policy.Diagnostics) {
@@ -115,6 +123,10 @@ var (
 
 func (v *InitJSON) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)
+}
+
+func (v *InitJSON) Spacer() {
+	v.view.Spacer()
 }
 
 func (v *InitJSON) PolicyDiagnostics(diags policy.Diagnostics) {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -103,8 +103,7 @@ func (v *InitHuman) PrepareMessage(messageCode InitMessageCode, params ...any) s
 	}
 
 	if message.HumanValue == "" {
-		// no need to apply colorization if the message is empty
-		return message.HumanValue
+		panic("unexpected empty message for init message code: " + string(messageCode))
 	}
 
 	return v.view.colorize.Color(strings.TrimSpace(fmt.Sprintf(message.HumanValue, params...)))
@@ -176,6 +175,10 @@ func (v *InitJSON) PrepareMessage(messageCode InitMessageCode, params ...any) st
 	if !ok {
 		// display the message code as fallback if not found in the message registry
 		return string(messageCode)
+	}
+
+	if message.JSONValue == "" {
+		panic("unexpected empty message for init message code: " + string(messageCode))
 	}
 
 	return strings.TrimSpace(fmt.Sprintf(message.JSONValue, params...))

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -228,3 +228,10 @@ func (v *JSONView) logPolicyDiagnostic(diag tfdiags.Diagnostic, extraArgs ...any
 		v.log.Error(fmt.Sprintf("Error: %s", diag.Description().Summary), args...)
 	}
 }
+
+var _ Spacer = (*JSONView)(nil)
+
+// Spacer is a no-op for JSON view, as empty lines are not needed to space-out logs in machine-readable output.
+func (v *JSONView) Spacer() {
+	// do nothing
+}

--- a/internal/command/views/spacer.go
+++ b/internal/command/views/spacer.go
@@ -1,0 +1,16 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+// Spacer is an interface that can be implemented by any view that needs to log
+// empty lines to output, to space out messages. This is only used in human-readable output
+// of commands that produce multiple logs during a long-running or multi-step operation.
+//
+// A clear example of this is the `terraform init` command, which uses empty lines to space
+// out messages related to distinct steps like backend initialisation, provider download etc.
+type Spacer interface {
+	// Spacer logs an empty line to output
+	// It should be a no-op for JSON views.
+	Spacer()
+}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -16,6 +16,7 @@ type StateMigrate interface {
 	Diagnostics(diags tfdiags.Diagnostics)
 
 	ProviderInstaller
+	Spacer // The `state migrate` command logs empty lines to space-out different sections of human-readable output
 }
 
 func NewStateMigrate(viewType arguments.ViewType, view *View) StateMigrate {
@@ -30,6 +31,7 @@ func NewStateMigrate(viewType arguments.ViewType, view *View) StateMigrate {
 var (
 	_ StateMigrate      = (*StateMigrateHuman)(nil)
 	_ ProviderInstaller = (*StateMigrateHuman)(nil)
+	_ Spacer            = (*StateMigrateHuman)(nil)
 )
 
 type StateMigrateHuman struct {
@@ -42,6 +44,11 @@ func (s *StateMigrateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 
 func (s *StateMigrateHuman) Log(message string, params ...any) {
 	s.view.streams.Println(fmt.Sprintf(message, params...))
+}
+
+// Implements Spacer
+func (s *StateMigrateHuman) Spacer() {
+	s.view.Spacer()
 }
 
 // Implements ProviderInstaller interface.

--- a/internal/command/views/view.go
+++ b/internal/command/views/view.go
@@ -190,6 +190,13 @@ func (v *View) PolicyResult(addr string, resp policy.EvaluationResponse) {
 	}
 }
 
+var _ Spacer = (*View)(nil)
+
+// Spacer logs an empty line to space-out human-readable output.
+func (v *View) Spacer() {
+	v.streams.Println()
+}
+
 // HelpPrompt is intended to be called from commands which fail to parse all
 // of their CLI arguments successfully. It refers users to the full help output
 // rather than rendering it directly, which can be overwhelming and confusing.


### PR DESCRIPTION
# Context

## Human-readable output has strategic empty lines logged, so the output is easier for humans to read and understand

The init command logs empty lines in its human-readable output, to space out sections of logs related to different events in the command. For example, an empty log line is created after backend initialisation so that the subsequent log lines related to module download or provider download are distinct:

<img width="682" height="364" alt="Screenshot 2026-07-10 at 19 39 40" src="https://github.com/user-attachments/assets/b83a799c-b6f8-4d58-9ff7-96a1b0e68a4e" />

The gap after backend initialisation corresponds to [this logging event in the code](https://github.com/hashicorp/terraform/blob/116d525a7242c2beb916f00ccb39ce070f4fac05/internal/command/init_run.go#L276-L280). Also,the gap between the info about the lock file being created and the final success message comes from [here](https://github.com/hashicorp/terraform/blob/116d525a7242c2beb916f00ccb39ce070f4fac05/internal/command/init_run.go#L438-L442).

## Machines don't have eyes, so those newlines aren't needed in JSON/machine-readable output

The use of those empty lines is irrelevant if we're making JSON output for the `init` command.

Currently our documentation for machine-readable output [reports that those empty lines are captured as JSON log entries](https://developer.hashicorp.com/terraform/internals/machine-readable-ui#empty_message):

> empty_message: describes an empty message; equivalent to a new line aiding formatting in terminal output

However if I perform the equivalent init operation as above with JSON output I don't see that empty_message log:

```json
{"@level":"info","@message":"Terraform 1.16.0-dev","@module":"terraform.ui","@timestamp":"2026-07-10T19:43:25.811096+01:00","terraform":"1.16.0-dev","type":"version","ui":"1.3"}
{"@level":"info","@message":"Initializing the backend...","@module":"terraform.ui","@timestamp":"2026-07-10T19:43:25.816181+01:00","message_code":"initializing_backend_message","type":"init_output"}
{"@level":"info","@message":"Initializing provider plugins...","@module":"terraform.ui","@timestamp":"2026-07-10T19:43:25.823704+01:00","message_code":"initializing_provider_plugin_message","type":"init_output"}
{"@level":"info","@message":"hashicorp/random: Finding latest version...","@module":"terraform.ui","@timestamp":"2026-07-10T19:43:25.823889+01:00","type":"log"}
{"@level":"info","@message":"Installing provider version: hashicorp/random v3.9.0...","@module":"terraform.ui","@timestamp":"2026-07-10T19:43:26.064879+01:00","type":"log"}
{"@level":"info","@message":"Installed provider version: hashicorp/random v3.9.0 (signed by HashiCorp)","@module":"terraform.ui","@timestamp":"2026-07-10T19:43:26.591183+01:00","type":"log"}
{"@level":"info","@message":"Terraform has created a lock file .terraform.lock.hcl to record the provider\nselections it made above. Include this file in your version control repository\nso that Terraform can guarantee to make the same selections by default when\nyou run \"terraform init\" in the future.","@module":"terraform.ui","@timestamp":"2026-07-10T19:43:26.591214+01:00","message_code":"lock_info","type":"init_output"}
{"@level":"info","@message":"Terraform has been successfully initialized!","@module":"terraform.ui","@timestamp":"2026-07-10T19:43:26.591865+01:00","message_code":"output_init_success_message","type":"init_output"}
{"@level":"info","@message":"You may now begin working with Terraform. Try running \"terraform plan\" to see\nany changes that are required for your infrastructure. All Terraform commands\nshould now work.\n\nIf you ever set or change modules or backend configuration for Terraform,\nrerun this command to reinitialize your working directory. If you forget, other\ncommands will detect it and remind you to do so if necessary.","@module":"terraform.ui","@timestamp":"2026-07-10T19:43:26.591873+01:00","message_code":"output_init_success_cli_message","type":"init_output"}
```

We would expect to see an `empty_message` log in between backend initialisation, provider download, lockfile creation, and the final success logs.

## Why it's missing

This log type was never produced! The views.EmptyMessage const was only used as input to the Output method of an init command's view, and the JSON view's Output method returns without logging anything if it encounters an empty message:

https://github.com/hashicorp/terraform/blob/d956ed4c42aedefa777b4bfde9d57a61fd132581/internal/command/views/init.go#L93-L98

Note that code is from https://github.com/hashicorp/terraform/commit/d956ed4c42aedefa777b4bfde9d57a61fd132581 , when JSON support was first added to `init`. 

 # This PR

In this PR I propose moving away from the message registry approach used for init when logging an empty message. Instead, add a method specific to the purpose of spacing-out log lines in human-readable output. This matches how task-specific methods are otherwise implemented on the View and JSONView structs ([examples](https://github.com/hashicorp/terraform/blob/116d525a7242c2beb916f00ccb39ce070f4fac05/internal/command/views/json_view.go#L92-L114)) and how they're wrapped by command-specific interfaces.

* The `Spacer` interface describes the action of spacing out logs.
* Human view implementations are expected to log an empty line via `Spacer` if they need to space-out human-readable output.
* JSON view implementations are expected to always perform a no-op for this method, as implementing a JSON object to decribe an empty log would be useless to consumers.


-----

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
