### PR TITLE
refactor(init/views): Stop using the `views` package to create an error diagnostic during `init`

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -1315,3 +1315,9 @@ The current .terraform.lock.hcl file only includes checksums for %s, so Terrafor
 To calculate additional checksums for another platform, run:
   terraform providers lock -platform=linux_amd64
 (where linux_amd64 is the platform to generate)`
+
+const errInitConfigError = `Terraform encountered problems during initialisation, including problems
+with the configuration, described below.
+
+The Terraform configuration must be valid before initialization so that
+Terraform can determine which modules and providers need to be installed.`

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -122,7 +122,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 	// be the first error displayed if that is an issue, but other operations are required
 	// before being able to check core version requirements.
 	if rootModEarly == nil {
-		diags = diags.Append(errors.New(view.PrepareMessage(views.InitConfigError)), earlyConfDiags)
+		diags = diags.Append(errors.New(errInitConfigError), earlyConfDiags)
 		view.Diagnostics(diags)
 
 		return 1
@@ -370,7 +370,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	diags = diags.Append(earlyConfDiags)
 	diags = diags.Append(backDiags)
 	if earlyConfDiags.HasErrors() {
-		diags = diags.Append(errors.New(view.PrepareMessage(views.InitConfigError)))
+		diags = diags.Append(errors.New(errInitConfigError))
 		view.Diagnostics(diags)
 		return 1
 	}
@@ -385,7 +385,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	// 3. Show any errors from loading the full configuration tree.
 	diags = diags.Append(confDiags)
 	if confDiags.HasErrors() {
-		diags = diags.Append(errors.New(view.PrepareMessage(views.InitConfigError)))
+		diags = diags.Append(errors.New(errInitConfigError))
 		view.Diagnostics(diags)
 		return 1
 	}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -8491,3 +8491,32 @@ func (s *aliasAssertingProviderSource) AvailableVersions(ctx context.Context, pr
 	}
 	return s.Source.AvailableVersions(ctx, provider)
 }
+
+// Test shows that the original and refactored ways of producing the error message previously achieved using
+// views.InitConfigError create the same diagnostics, therefore they'll be rendered in the terminal the same way.
+func TestEquivalentDiagnostics_errInitConfigError(t *testing.T) {
+	var refactoredDiags tfdiags.Diagnostics
+	refactoredDiags = refactoredDiags.Append(errors.New(errInitConfigError))
+	// Note that refactoredDiags is equivalent to the diagnostics made through Human and JSON views,
+	// therefore view type had no impact on the error diagnostic despite the human view's string input to
+	// errors.New including a "[reset]" formatting instruction.
+
+	t.Run("human", func(t *testing.T) {
+		var originalDiags tfdiags.Diagnostics
+
+		v, _ := testView(t)
+		view := views.NewInit(arguments.ViewHuman, v)
+		originalDiags = originalDiags.Append(errors.New(view.PrepareMessage(views.InitConfigError)))
+
+		tfdiags.AssertDiagnosticsMatch(t, originalDiags, refactoredDiags)
+	})
+	t.Run("json", func(t *testing.T) {
+		var originalDiags tfdiags.Diagnostics
+
+		v, _ := testView(t)
+		view := views.NewInit(arguments.ViewJSON, v)
+		originalDiags = originalDiags.Append(errors.New(view.PrepareMessage(views.InitConfigError)))
+
+		tfdiags.AssertDiagnosticsMatch(t, originalDiags, refactoredDiags)
+	})
+}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -8491,32 +8491,3 @@ func (s *aliasAssertingProviderSource) AvailableVersions(ctx context.Context, pr
 	}
 	return s.Source.AvailableVersions(ctx, provider)
 }
-
-// Test shows that the original and refactored ways of producing the error message previously achieved using
-// views.InitConfigError create the same diagnostics, therefore they'll be rendered in the terminal the same way.
-func TestEquivalentDiagnostics_errInitConfigError(t *testing.T) {
-	var refactoredDiags tfdiags.Diagnostics
-	refactoredDiags = refactoredDiags.Append(errors.New(errInitConfigError))
-	// Note that refactoredDiags is equivalent to the diagnostics made through Human and JSON views,
-	// therefore view type had no impact on the error diagnostic despite the human view's string input to
-	// errors.New including a "[reset]" formatting instruction.
-
-	t.Run("human", func(t *testing.T) {
-		var originalDiags tfdiags.Diagnostics
-
-		v, _ := testView(t)
-		view := views.NewInit(arguments.ViewHuman, v)
-		originalDiags = originalDiags.Append(errors.New(view.PrepareMessage(views.InitConfigError)))
-
-		tfdiags.AssertDiagnosticsMatch(t, originalDiags, refactoredDiags)
-	})
-	t.Run("json", func(t *testing.T) {
-		var originalDiags tfdiags.Diagnostics
-
-		v, _ := testView(t)
-		view := views.NewInit(arguments.ViewJSON, v)
-		originalDiags = originalDiags.Append(errors.New(view.PrepareMessage(views.InitConfigError)))
-
-		tfdiags.AssertDiagnosticsMatch(t, originalDiags, refactoredDiags)
-	})
-}

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -303,10 +303,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: partnerAndCommunityProvidersInfo,
 		JSONValue:  partnerAndCommunityProvidersInfo,
 	},
-	"init_config_error": {
-		HumanValue: errInitConfigError,
-		JSONValue:  errInitConfigErrorJSON,
-	},
 	"state_store_unset": {
 		HumanValue: "[reset][green]\n\nSuccessfully unset the state store %q. Terraform will now operate locally.",
 		JSONValue:  "Successfully unset the state store %q. Terraform will now operate locally.",
@@ -396,9 +392,6 @@ const (
 
 	//// Message codes below are ONLY used INTERNALLY (for now)
 
-	// InitConfigError indicates problems encountered during initialisation
-	// >>> Not used to create JSON output, can be removed.
-	InitConfigError InitMessageCode = "init_config_error"
 	// BackendConfiguredSuccessMessage indicates successful backend configuration
 	BackendConfiguredSuccessMessage InitMessageCode = "backend_configured_success"
 	// BackendConfiguredUnsetMessage indicates successful backend unsetting
@@ -533,22 +526,6 @@ version control system if they represent changes you intended to make.`
 const partnerAndCommunityProvidersInfo = "\nPartner and community providers are signed by their developers.\n" +
 	"If you'd like to know more about provider signing, you can read about it here:\n" +
 	"https://developer.hashicorp.com/terraform/cli/plugins/signing"
-
-const errInitConfigError = `
-[reset]Terraform encountered problems during initialisation, including problems
-with the configuration, described below.
-
-The Terraform configuration must be valid before initialization so that
-Terraform can determine which modules and providers need to be installed.
-`
-
-const errInitConfigErrorJSON = `
-Terraform encountered problems during initialisation, including problems
-with the configuration, described below.
-
-The Terraform configuration must be valid before initialization so that
-Terraform can determine which modules and providers need to be installed.
-`
 
 const backendConfiguredSuccessHuman = `[reset][green]
 Successfully configured the backend %q! Terraform will automatically

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -391,6 +391,7 @@ const (
 	//// Message codes below are ONLY used INTERNALLY (for now)
 
 	// InitConfigError indicates problems encountered during initialisation
+	// >>> Not used to create JSON output, can be removed.
 	InitConfigError InitMessageCode = "init_config_error"
 	// BackendConfiguredSuccessMessage indicates successful backend configuration
 	BackendConfiguredSuccessMessage InitMessageCode = "backend_configured_success"


### PR DESCRIPTION
Message codes for init are mostly used to make JSON log output, but not always. This PR removes use of an unnecessary message code linked to the init command.

## Context

Message codes that are used in the `init` command look like this example:

https://github.com/hashicorp/terraform/blob/116d525a7242c2beb916f00ccb39ce070f4fac05/internal/command/views/init.go#L376

Which corresponds to logs like this with a matching `message_code` field value:

```json
{"@level":"info","@message":"You may now begin working with Terraform. Try running \"terraform plan\" to see\nany changes that are required for your infrastructure. All Terraform commands\nshould now work.\n\nIf you ever set or change modules or backend configuration for Terraform,\nrerun this command to reinitialize your working directory. If you forget, other\ncommands will detect it and remind you to do so if necessary.","@module":"terraform.ui","@timestamp":"2025-08-11T13:09:42Z","message_code":"output_init_success_cli_message","type":"init_output"}
```

Which is [publicly documented in our machine-readable docs](https://developer.hashicorp.com/terraform/internals/machine-readable-ui#output_init_success_cli_message) and therefore we're unable to change it until a future major release.

Those JSON logs are produced via the Output or LogInitMessage methods on the init command's view implementations, e.g: 

https://github.com/hashicorp/terraform/blob/945ce80e51593b2aef5705e944f108cbdf532a68/internal/command/init.go#L359

However there are some places where the calling code accesses message strings directly just to obtain strings, not to produce a given log message.

An example of this is what I'm replacing in this PR:

```go
diags = diags.Append(errors.New(view.PrepareMessage(views.InitConfigError)))
```

## This PR

In this PR I move the `views.InitConfigError ` string out of the `views` package and let it be passed into errors.New directly. The views package doesn't need to be involved.

I've added a test that proves the resulting diagnostic is the same, despite how the original code used subtly different strings depending on the view type in use:


JSON has no "[reset]":

(https://github.com/hashicorp/terraform/blob/116d525a7242c2beb916f00ccb39ce070f4fac05/internal/command/views/init.go#L539

Human has "[reset]" at start:

https://github.com/hashicorp/terraform/blob/116d525a7242c2beb916f00ccb39ce070f4fac05/internal/command/views/init.go#L531

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
