### PR TITLE
fix: do not embed SSH private key material in cert-signer errors

### DIFF
--- a/internal/communicator/ssh/provisioner.go
+++ b/internal/communicator/ssh/provisioner.go
@@ -397,22 +397,22 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 func signCertWithPrivateKey(pk string, certificate string) (ssh.AuthMethod, error) {
 	rawPk, err := ssh.ParseRawPrivateKey([]byte(pk))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse private key %q: %s", pk, err)
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
 	}
 
 	pcert, _, _, _, err := ssh.ParseAuthorizedKey([]byte(certificate))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse certificate %q: %s", certificate, err)
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
 	}
 
 	usigner, err := ssh.NewSignerFromKey(rawPk)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create signer from raw private key %q: %s", rawPk, err)
+		return nil, fmt.Errorf("failed to create signer from raw private key: %w", err)
 	}
 
 	ucertSigner, err := ssh.NewCertSigner(pcert.(*ssh.Certificate), usigner)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cert signer %q: %s", usigner, err)
+		return nil, fmt.Errorf("failed to create cert signer: %w", err)
 	}
 
 	return ssh.PublicKeys(ucertSigner), nil


### PR DESCRIPTION
## Summary

`signCertWithPrivateKey` formatted parse/signer failures with `%q` on the raw private key PEM (and related key objects). Those strings can appear in Terraform logs and UI when certificate-based SSH provisioning fails.

## Change

Use `%w` / generic messages without embedding key material (same approach OpenTofu already uses for this helper).

Closes #38577

## Test plan

- [x] `go test ./internal/communicator/ssh/ -count=1`