### PR TITLE
refactor(views/init): Remove use of `PrepareMessage` method outside of the `views` package

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -1200,10 +1200,11 @@ func fetchPackageSuccessCallback(view views.ProviderInstaller) func(provider add
 			keyID = authResult.KeyID
 		}
 		if keyID != "" {
-			keyID = view.PrepareMessage(views.KeyID, keyID)
+			view.InstalledProviderVersionInfoWithKeyID(provider.ForDisplay(), version, authResult, keyID)
+			return
 		}
 
-		view.LogInitMessage(views.InstalledProviderVersionInfo, provider.ForDisplay(), version, authResult, keyID)
+		view.InstalledProviderVersionInfo(provider.ForDisplay(), version, authResult)
 	}
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -1200,11 +1200,11 @@ func fetchPackageSuccessCallback(view views.ProviderInstaller) func(provider add
 			keyID = authResult.KeyID
 		}
 		if keyID != "" {
-			view.InstalledProviderVersionInfoWithKeyID(provider, version, authResult, keyID)
+			view.LogProviderVersionSuccessWithKeyID(provider, version, authResult, keyID)
 			return
 		}
 
-		view.InstalledProviderVersionInfo(provider, version, authResult)
+		view.LogProviderVersionSuccess(provider, version, authResult)
 	}
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -1200,11 +1200,11 @@ func fetchPackageSuccessCallback(view views.ProviderInstaller) func(provider add
 			keyID = authResult.KeyID
 		}
 		if keyID != "" {
-			view.InstalledProviderVersionInfoWithKeyID(provider.ForDisplay(), version, authResult, keyID)
+			view.InstalledProviderVersionInfoWithKeyID(provider, version, authResult, keyID)
 			return
 		}
 
-		view.InstalledProviderVersionInfo(provider.ForDisplay(), version, authResult)
+		view.InstalledProviderVersionInfo(provider, version, authResult)
 	}
 }
 

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -8553,3 +8553,142 @@ func (s *aliasAssertingProviderSource) AvailableVersions(ctx context.Context, pr
 	}
 	return s.Source.AvailableVersions(ctx, provider)
 }
+
+// Test_fetchPackageSuccessCallback asserts how the fetchPackageSuccessCallback function behaves when called with different authentication results.
+// This test will be used to check that refactoring how output is made doesn't introduce any unexpected changes.
+func Test_fetchPackageSuccessCallback(t *testing.T) {
+	const verifiedChecksum = 0
+	const officialProvider = 1
+	const partnerProvider = 2
+	const noKey = ""
+
+	t.Run("no auth result", func(t *testing.T) {
+		viewH, doneH := testView(t)
+		viewJ, doneJ := testView(t)
+		initViewHuman := views.NewInit(arguments.ViewHuman, viewH)
+		initViewJSON := views.NewInit(arguments.ViewJSON, viewJ)
+
+		cbHuman := fetchPackageSuccessCallback(initViewHuman)
+		cbJSON := fetchPackageSuccessCallback(initViewJSON)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		localDir := "."
+
+		var authResult *getproviders.PackageAuthenticationResult = nil
+
+		// Use callback to log output
+		cbHuman(p, ver, localDir, authResult)
+		cbJSON(p, ver, localDir, authResult)
+
+		// Assert output - human
+		output := doneH(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (unauthenticated)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+		// Assert output - json
+		output = doneJ(t)
+		expectedOutput = `{"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (unauthenticated)","@module":"terraform.ui","@timestamp":` // Stop comparison before timestamp
+		if !strings.Contains(output.Stdout(), expectedOutput) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("verified checksum auth result", func(t *testing.T) {
+		viewH, doneH := testView(t)
+		viewJ, doneJ := testView(t)
+		initViewHuman := views.NewInit(arguments.ViewHuman, viewH)
+		initViewJSON := views.NewInit(arguments.ViewJSON, viewJ)
+
+		cbHuman := fetchPackageSuccessCallback(initViewHuman)
+		cbJSON := fetchPackageSuccessCallback(initViewJSON)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		localDir := "."
+
+		authResult := getproviders.NewPackageAuthenticationResult(verifiedChecksum, noKey)
+
+		// Use callback to log output
+		cbHuman(p, ver, localDir, authResult)
+		cbJSON(p, ver, localDir, authResult)
+
+		// Assert output - human
+		output := doneH(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (verified checksum)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+		// Assert output - json
+		output = doneJ(t)
+		expectedOutput = `{"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (verified checksum)","@module":"terraform.ui","@timestamp":` // Stop comparison before timestamp
+		if !strings.Contains(output.Stdout(), expectedOutput) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("official provider auth result", func(t *testing.T) {
+		viewH, doneH := testView(t)
+		viewJ, doneJ := testView(t)
+		initViewHuman := views.NewInit(arguments.ViewHuman, viewH)
+		initViewJSON := views.NewInit(arguments.ViewJSON, viewJ)
+
+		cbHuman := fetchPackageSuccessCallback(initViewHuman)
+		cbJSON := fetchPackageSuccessCallback(initViewJSON)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		localDir := "."
+
+		authResult := getproviders.NewPackageAuthenticationResult(officialProvider, noKey)
+
+		// Use callback to log output
+		cbHuman(p, ver, localDir, authResult)
+		cbJSON(p, ver, localDir, authResult)
+
+		// Assert output - human
+		output := doneH(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (signed by HashiCorp)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+		// Assert output - json
+		output = doneJ(t)
+		expectedOutput = `{"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (signed by HashiCorp)","@module":"terraform.ui","@timestamp":` // Stop comparison before timestamp
+		if !strings.Contains(output.Stdout(), expectedOutput) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("third party signed partner provider with key id", func(t *testing.T) {
+		viewH, doneH := testView(t)
+		viewJ, doneJ := testView(t)
+		initViewHuman := views.NewInit(arguments.ViewHuman, viewH)
+		initViewJSON := views.NewInit(arguments.ViewJSON, viewJ)
+
+		cbHuman := fetchPackageSuccessCallback(initViewHuman)
+		cbJSON := fetchPackageSuccessCallback(initViewJSON)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		localDir := "."
+
+		key := "key-id-123"
+		authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, key)
+
+		// Use callback to log output
+		cbHuman(p, ver, localDir, authResult)
+		cbJSON(p, ver, localDir, authResult)
+
+		// Assert output - human
+		output := doneH(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (signed by a HashiCorp partner, key ID key-id-123)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+		// Assert output - json
+		output = doneJ(t)
+		expectedOutput = `{"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (signed by a HashiCorp partnerkey_id: key-id-123)","@module":"terraform.ui","@timestamp":` // Stop comparison before timestamp
+		if !strings.Contains(output.Stdout(), expectedOutput) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", expectedOutput, output.Stdout())
+		}
+	})
+}

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -21,10 +21,11 @@ import (
 type ProviderInstaller interface {
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Output(messageCode InitMessageCode, params ...any)
-	PrepareMessage(messageCode InitMessageCode, params ...any) string
 
 	InstalledProviderVersionInfo(params ...any)
 	InstalledProviderVersionInfoWithKeyID(params ...any)
+
+	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines
 }
@@ -37,10 +38,11 @@ type Init interface {
 	Output(messageCode InitMessageCode, params ...any)
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
-	PrepareMessage(messageCode InitMessageCode, params ...any) string
 
 	InstalledProviderVersionInfo(params ...any)
 	InstalledProviderVersionInfoWithKeyID(params ...any)
+
+	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // The `init` command logs empty lines to space-out different sections of human-readable output
 }
@@ -89,16 +91,16 @@ func (v *InitHuman) PolicyResult(addr string, resp policy.EvaluationResponse) {
 }
 
 func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
-	v.view.streams.Println(v.PrepareMessage(messageCode, params...))
+	v.view.streams.Println(v.prepareMessage(messageCode, params...))
 }
 
 func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
-	v.view.streams.Println(v.PrepareMessage(messageCode, params...))
+	v.view.streams.Println(v.prepareMessage(messageCode, params...))
 }
 
 func (v *InitHuman) InstalledProviderVersionInfo(params ...any) {
 	params = append(params, "") // add empty key id to the end
-	v.view.streams.Println(v.PrepareMessage(InstalledProviderVersionInfo, params...))
+	v.view.streams.Println(v.prepareMessage(InstalledProviderVersionInfo, params...))
 }
 
 func (v *InitHuman) InstalledProviderVersionInfoWithKeyID(params ...any) {
@@ -109,7 +111,7 @@ func (v *InitHuman) InstalledProviderVersionInfoWithKeyID(params ...any) {
 	if key != "" {
 		params = append(params, fmt.Sprintf(", key ID [reset][bold]%s[reset]", key))
 	}
-	v.view.streams.Println(v.PrepareMessage(InstalledProviderVersionInfo, params...))
+	v.view.streams.Println(v.prepareMessage(InstalledProviderVersionInfo, params...))
 }
 
 // this implements log method for use by interfaces that need to log generic string messages, e.g used for logging in hook_module_install.go
@@ -117,7 +119,7 @@ func (v *InitHuman) Log(message string, params ...any) {
 	v.view.streams.Println(strings.TrimSpace(fmt.Sprintf(message, params...)))
 }
 
-func (v *InitHuman) PrepareMessage(messageCode InitMessageCode, params ...any) string {
+func (v *InitHuman) prepareMessage(messageCode InitMessageCode, params ...any) string {
 	message, ok := MessageRegistry[messageCode]
 	if !ok {
 		// display the message code as fallback if not found in the message registry
@@ -159,7 +161,7 @@ func (v *InitJSON) PolicyResult(addr string, resp policy.EvaluationResponse) {
 }
 
 func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
-	preppedMessage := v.PrepareMessage(messageCode, params...)
+	preppedMessage := v.prepareMessage(messageCode, params...)
 
 	// Logged data includes by default:
 	// @level as "info"
@@ -183,7 +185,7 @@ func (v *InitJSON) LogInitMessage(messageCode InitMessageCode, params ...any) {
 }
 
 func (v *InitJSON) logInitMessage(messageCode InitMessageCode, params ...any) {
-	preppedMessage := v.PrepareMessage(messageCode, params...)
+	preppedMessage := v.prepareMessage(messageCode, params...)
 	if preppedMessage == "" {
 		return
 	}
@@ -217,7 +219,7 @@ func (v *InitJSON) InstalledProviderVersionInfoWithKeyID(params ...any) {
 	v.logInitMessage(InstalledProviderVersionInfo, params...)
 }
 
-func (v *InitJSON) PrepareMessage(messageCode InitMessageCode, params ...any) string {
+func (v *InitJSON) prepareMessage(messageCode InitMessageCode, params ...any) string {
 	message, ok := MessageRegistry[messageCode]
 	if !ok {
 		// display the message code as fallback if not found in the message registry

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -22,8 +24,8 @@ type ProviderInstaller interface {
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Output(messageCode InitMessageCode, params ...any)
 
-	InstalledProviderVersionInfo(params ...any)
-	InstalledProviderVersionInfoWithKeyID(params ...any)
+	InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
+	InstalledProviderVersionInfoWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
 
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
@@ -39,8 +41,8 @@ type Init interface {
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
 
-	InstalledProviderVersionInfo(params ...any)
-	InstalledProviderVersionInfoWithKeyID(params ...any)
+	InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
+	InstalledProviderVersionInfoWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
 
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
@@ -98,19 +100,14 @@ func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	v.view.streams.Println(v.prepareMessage(messageCode, params...))
 }
 
-func (v *InitHuman) InstalledProviderVersionInfo(params ...any) {
-	params = append(params, "") // add empty key id to the end
+func (v *InitHuman) InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	v.view.streams.Println(v.prepareMessage(InstalledProviderVersionInfo, params...))
 }
 
-func (v *InitHuman) InstalledProviderVersionInfoWithKeyID(params ...any) {
-	key := params[len(params)-1]
-	params = params[:len(params)-1]
-
-	// add key id to the end of the message if it is not empty
-	if key != "" {
-		params = append(params, fmt.Sprintf(", key ID [reset][bold]%s[reset]", key))
-	}
+func (v *InitHuman) InstalledProviderVersionInfoWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+	keyDetails := fmt.Sprintf(", key ID [reset][bold]%s[reset]", keyID) // key id needs to be formatted for human output
+	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 	v.view.streams.Println(v.prepareMessage(InstalledProviderVersionInfo, params...))
 }
 
@@ -198,21 +195,17 @@ func (v *InitJSON) Log(message string, params ...any) {
 	v.view.Log(strings.TrimSpace(fmt.Sprintf(message, params...)))
 }
 
-func (v *InitJSON) InstalledProviderVersionInfo(params ...any) {
-	params = append(params, "") // add empty key id to the end
+func (v *InitJSON) InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	v.logInitMessage(InstalledProviderVersionInfo, params...)
 }
 
-func (v *InitJSON) InstalledProviderVersionInfoWithKeyID(params ...any) {
-	key := params[len(params)-1]
-
-	// replace key id param with formatted version to the end of the message if it is not empty
-	if key != "" {
-		params[len(params)-1] = fmt.Sprintf("key_id: %s", key)
-	}
+func (v *InitJSON) InstalledProviderVersionInfoWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+	keyDetails := fmt.Sprintf("key_id: %s", keyID) // key id needs to be formatted for JSON output
+	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -333,10 +333,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "- Installing %s v%s...",
 		JSONValue:  "Installing provider version: %s v%s...",
 	},
-	"key_id": {
-		HumanValue: ", key ID [reset][bold]%s[reset]",
-		JSONValue:  "key_id: %s",
-	},
 	"installed_provider_version_info": {
 		HumanValue: "- Installed %s v%s (%s%s)",
 		JSONValue:  "Installed provider version: %s v%s (%s%s)",
@@ -470,8 +466,6 @@ const (
 	BuiltInProviderAvailableMessage InitMessageCode = "built_in_provider_available_message"
 	// ProviderAlreadyInstalledMessage indicates a provider that is already installed during installation
 	ProviderAlreadyInstalledMessage InitMessageCode = "provider_already_installed_message"
-	// KeyID indicates the key ID used to sign of a successfully installed provider
-	KeyID InitMessageCode = "key_id"
 	// InstallingProviderMessage indicates that a provider is being installed (from a remote location)
 	InstallingProviderMessage InitMessageCode = "installing_provider_message"
 	// FindingLatestVersionMessage indicates that Terraform is looking for the latest version of a provider during installation (no constraint was supplied)

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -24,8 +24,11 @@ type ProviderInstaller interface {
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Output(messageCode InitMessageCode, params ...any)
 
-	InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
-	InstalledProviderVersionInfoWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
+	// Log details about a successfully fetched provider package.
+	LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
+
+	// Log details about a successfully fetched provider package, including details about the key used to sign it.
+	LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
 
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
@@ -41,8 +44,8 @@ type Init interface {
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
 
-	InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
-	InstalledProviderVersionInfoWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
+	LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
+	LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
 
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
@@ -100,12 +103,12 @@ func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	v.view.streams.Println(v.prepareMessage(messageCode, params...))
 }
 
-func (v *InitHuman) InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+func (v *InitHuman) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	v.view.streams.Println(v.prepareMessage(InstalledProviderVersionInfo, params...))
 }
 
-func (v *InitHuman) InstalledProviderVersionInfoWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+func (v *InitHuman) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
 	keyDetails := fmt.Sprintf(", key ID [reset][bold]%s[reset]", keyID) // key id needs to be formatted for human output
 	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 	v.view.streams.Println(v.prepareMessage(InstalledProviderVersionInfo, params...))
@@ -195,7 +198,7 @@ func (v *InitJSON) Log(message string, params ...any) {
 	v.view.Log(strings.TrimSpace(fmt.Sprintf(message, params...)))
 }
 
-func (v *InitJSON) InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+func (v *InitJSON) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
@@ -203,7 +206,7 @@ func (v *InitJSON) InstalledProviderVersionInfo(providerAddr addrs.Provider, ver
 	v.logInitMessage(InstalledProviderVersionInfo, params...)
 }
 
-func (v *InitJSON) InstalledProviderVersionInfoWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+func (v *InitJSON) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
 	keyDetails := fmt.Sprintf("key_id: %s", keyID) // key id needs to be formatted for JSON output
 	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -23,6 +23,9 @@ type ProviderInstaller interface {
 	Output(messageCode InitMessageCode, params ...any)
 	PrepareMessage(messageCode InitMessageCode, params ...any) string
 
+	InstalledProviderVersionInfo(params ...any)
+	InstalledProviderVersionInfoWithKeyID(params ...any)
+
 	Spacer // output from provider installation is spaced out from following human-readable output log lines
 }
 
@@ -35,6 +38,9 @@ type Init interface {
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
 	PrepareMessage(messageCode InitMessageCode, params ...any) string
+
+	InstalledProviderVersionInfo(params ...any)
+	InstalledProviderVersionInfoWithKeyID(params ...any)
 
 	Spacer // The `init` command logs empty lines to space-out different sections of human-readable output
 }
@@ -88,6 +94,22 @@ func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
 
 func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	v.view.streams.Println(v.PrepareMessage(messageCode, params...))
+}
+
+func (v *InitHuman) InstalledProviderVersionInfo(params ...any) {
+	params = append(params, "") // add empty key id to the end
+	v.view.streams.Println(v.PrepareMessage(InstalledProviderVersionInfo, params...))
+}
+
+func (v *InitHuman) InstalledProviderVersionInfoWithKeyID(params ...any) {
+	key := params[len(params)-1]
+	params = params[:len(params)-1]
+
+	// add key id to the end of the message if it is not empty
+	if key != "" {
+		params = append(params, fmt.Sprintf(", key ID [reset][bold]%s[reset]", key))
+	}
+	v.view.streams.Println(v.PrepareMessage(InstalledProviderVersionInfo, params...))
 }
 
 // this implements log method for use by interfaces that need to log generic string messages, e.g used for logging in hook_module_install.go
@@ -157,6 +179,10 @@ func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
 }
 
 func (v *InitJSON) LogInitMessage(messageCode InitMessageCode, params ...any) {
+	v.logInitMessage(messageCode, params...)
+}
+
+func (v *InitJSON) logInitMessage(messageCode InitMessageCode, params ...any) {
 	preppedMessage := v.PrepareMessage(messageCode, params...)
 	if preppedMessage == "" {
 		return
@@ -168,6 +194,27 @@ func (v *InitJSON) LogInitMessage(messageCode InitMessageCode, params ...any) {
 // this implements log method for use by services that need to log generic string messages, e.g usage logging in hook_module_install.go
 func (v *InitJSON) Log(message string, params ...any) {
 	v.view.Log(strings.TrimSpace(fmt.Sprintf(message, params...)))
+}
+
+func (v *InitJSON) InstalledProviderVersionInfo(params ...any) {
+	params = append(params, "") // add empty key id to the end
+
+	// This was previously logged via LogInitMessage, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.logInitMessage(InstalledProviderVersionInfo, params...)
+}
+
+func (v *InitJSON) InstalledProviderVersionInfoWithKeyID(params ...any) {
+	key := params[len(params)-1]
+
+	// replace key id param with formatted version to the end of the message if it is not empty
+	if key != "" {
+		params[len(params)-1] = fmt.Sprintf("key_id: %s", key)
+	}
+
+	// This was previously logged via LogInitMessage, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.logInitMessage(InstalledProviderVersionInfo, params...)
 }
 
 func (v *InitJSON) PrepareMessage(messageCode InitMessageCode, params ...any) string {

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -408,7 +408,7 @@ func TestNewInit_jsonViewPrepareMessage(t *testing.T) {
 
 		want := "Initializing modules..."
 
-		actual := newInit.PrepareMessage(InitializingModulesMessage)
+		actual := newInit.prepareMessage(InitializingModulesMessage)
 		if !cmp.Equal(want, actual) {
 			t.Errorf("unexpected output: %s", cmp.Diff(want, actual))
 		}

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -473,7 +473,7 @@ func TestNewInit_humanViewOutput(t *testing.T) {
 }
 
 // Assert message content
-func TestNewInit_InstalledProviderVersionInfo(t *testing.T) {
+func TestNewInit_LogProviderVersionSuccess(t *testing.T) {
 	const verifiedChecksum = 0
 	const officialProvider = 1
 	const noKey = ""
@@ -487,7 +487,7 @@ func TestNewInit_InstalledProviderVersionInfo(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		var authResult *getproviders.PackageAuthenticationResult = nil
 
-		initView.InstalledProviderVersionInfo(p, ver, authResult)
+		initView.LogProviderVersionSuccess(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -505,7 +505,7 @@ func TestNewInit_InstalledProviderVersionInfo(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		var authResult *getproviders.PackageAuthenticationResult = nil
 
-		initView.InstalledProviderVersionInfo(p, ver, authResult)
+		initView.LogProviderVersionSuccess(p, ver, authResult)
 
 		// Assert output - human
 		output := done(t)
@@ -523,7 +523,7 @@ func TestNewInit_InstalledProviderVersionInfo(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		authResult := getproviders.NewPackageAuthenticationResult(verifiedChecksum, noKey)
 
-		initView.InstalledProviderVersionInfo(p, ver, authResult)
+		initView.LogProviderVersionSuccess(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -541,7 +541,7 @@ func TestNewInit_InstalledProviderVersionInfo(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		authResult := getproviders.NewPackageAuthenticationResult(verifiedChecksum, noKey)
 
-		initView.InstalledProviderVersionInfo(p, ver, authResult)
+		initView.LogProviderVersionSuccess(p, ver, authResult)
 
 		// Assert output - human
 		output := done(t)
@@ -560,7 +560,7 @@ func TestNewInit_InstalledProviderVersionInfo(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(officialProvider, key)
 
-		initView.InstalledProviderVersionInfo(p, ver, authResult)
+		initView.LogProviderVersionSuccess(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -579,7 +579,7 @@ func TestNewInit_InstalledProviderVersionInfo(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(officialProvider, key)
 
-		initView.InstalledProviderVersionInfo(p, ver, authResult)
+		initView.LogProviderVersionSuccess(p, ver, authResult)
 
 		// Assert output - human
 		output := done(t)
@@ -591,7 +591,7 @@ func TestNewInit_InstalledProviderVersionInfo(t *testing.T) {
 }
 
 // Assert message content
-func TestNewInit_InstalledProviderVersionInfoWithKeyID(t *testing.T) {
+func TestNewInit_LogProviderVersionSuccessWithKeyID(t *testing.T) {
 	const partnerProvider = 2
 
 	t.Run("partner provider auth result - human view", func(t *testing.T) {
@@ -604,7 +604,7 @@ func TestNewInit_InstalledProviderVersionInfoWithKeyID(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, key)
 
-		initView.InstalledProviderVersionInfoWithKeyID(p, ver, authResult, key)
+		initView.LogProviderVersionSuccessWithKeyID(p, ver, authResult, key)
 
 		// Assert output - human
 		output := done(t)
@@ -623,7 +623,7 @@ func TestNewInit_InstalledProviderVersionInfoWithKeyID(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, key)
 
-		initView.InstalledProviderVersionInfoWithKeyID(p, ver, authResult, key)
+		initView.LogProviderVersionSuccessWithKeyID(p, ver, authResult, key)
 
 		// Assert output - human
 		output := done(t)
@@ -635,7 +635,7 @@ func TestNewInit_InstalledProviderVersionInfoWithKeyID(t *testing.T) {
 }
 
 // Assert JSON log content, including log type and additional fields
-func TestNewInit_InstalledProviderVersionInfo_json(t *testing.T) {
+func TestNewInit_LogProviderVersionSuccess_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
 	initView := NewInit(arguments.ViewJSON, view)
@@ -644,7 +644,7 @@ func TestNewInit_InstalledProviderVersionInfo_json(t *testing.T) {
 	v := versions.MustParseVersion("1.0.0")
 	officialProvider := 1
 	authResult := getproviders.NewPackageAuthenticationResult(officialProvider, "key-id-123")
-	initView.InstalledProviderVersionInfo(p, v, authResult)
+	initView.LogProviderVersionSuccess(p, v, authResult)
 
 	// Assert output
 	output := done(t)
@@ -664,7 +664,7 @@ func TestNewInit_InstalledProviderVersionInfo_json(t *testing.T) {
 // Assert JSON log content, including log type and additional fields
 //
 // Note - in calling code this is only ever used for partner providers
-func TestNewInit_InstalledProviderVersionInfoWithKeyID_json(t *testing.T) {
+func TestNewInit_LogProviderVersionSuccessWithKeyID_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
 	initView := NewInit(arguments.ViewJSON, view)
@@ -674,7 +674,7 @@ func TestNewInit_InstalledProviderVersionInfoWithKeyID_json(t *testing.T) {
 	partnerProvider := 2
 	keyID := "key-id-123"
 	authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, keyID)
-	initView.InstalledProviderVersionInfoWithKeyID(p, v, authResult, keyID)
+	initView.LogProviderVersionSuccessWithKeyID(p, v, authResult, keyID)
 
 	// Assert output
 	output := done(t)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -8,11 +8,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apparentlymart/go-versions/versions"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	viewjson "github.com/hashicorp/terraform/internal/command/views/json"
+	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -338,7 +340,7 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 			t.Fatalf("unexpected return type %t", newInit)
 		}
 
-		var packageName, packageVersion = "hashicorp/aws", "3.0.0"
+		packageName, packageVersion := "hashicorp/aws", "3.0.0"
 		newInit.Output(ProviderAlreadyInstalledMessage, packageName, packageVersion)
 
 		version := tfversion.String()
@@ -459,7 +461,7 @@ func TestNewInit_humanViewOutput(t *testing.T) {
 			t.Fatalf("unexpected return type %t", newInit)
 		}
 
-		var packageName, packageVersion = "hashicorp/aws", "3.0.0"
+		packageName, packageVersion := "hashicorp/aws", "3.0.0"
 		newInit.Output(ProviderAlreadyInstalledMessage, packageName, packageVersion)
 
 		actual := done(t).All()
@@ -469,3 +471,223 @@ func TestNewInit_humanViewOutput(t *testing.T) {
 		}
 	})
 }
+
+// Assert message content
+func TestNewInit_InstalledProviderVersionInfo(t *testing.T) {
+	const verifiedChecksum = 0
+	const officialProvider = 1
+	const noKey = ""
+
+	t.Run("no auth result - human view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		initView := NewInit(arguments.ViewHuman, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		var authResult *getproviders.PackageAuthenticationResult = nil
+
+		initView.InstalledProviderVersionInfo(p, ver, authResult)
+
+		// Assert output
+		output := done(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (unauthenticated)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("no auth result - json view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		initView := NewInit(arguments.ViewJSON, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		var authResult *getproviders.PackageAuthenticationResult = nil
+
+		initView.InstalledProviderVersionInfo(p, ver, authResult)
+
+		// Assert output - human
+		output := done(t)
+		expectedOutput := `"@message":"Installed provider version: hashicorp/test v1.2.3 (unauthenticated)"`
+		if !strings.Contains(output.Stdout(), expectedOutput) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("verified checksum auth result - human view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		initView := NewInit(arguments.ViewHuman, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		authResult := getproviders.NewPackageAuthenticationResult(verifiedChecksum, noKey)
+
+		initView.InstalledProviderVersionInfo(p, ver, authResult)
+
+		// Assert output
+		output := done(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (verified checksum)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("verified checksum auth result - json view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		initView := NewInit(arguments.ViewJSON, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		authResult := getproviders.NewPackageAuthenticationResult(verifiedChecksum, noKey)
+
+		initView.InstalledProviderVersionInfo(p, ver, authResult)
+
+		// Assert output - human
+		output := done(t)
+		expectedOutput := `"@message":"Installed provider version: hashicorp/test v1.2.3 (verified checksum)"`
+		if !strings.Contains(output.Stdout(), expectedOutput) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("official provider auth result - human view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		initView := NewInit(arguments.ViewHuman, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		key := "key-id-123"
+		authResult := getproviders.NewPackageAuthenticationResult(officialProvider, key)
+
+		initView.InstalledProviderVersionInfo(p, ver, authResult)
+
+		// Assert output
+		output := done(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (signed by HashiCorp)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("official provider auth result - json view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		initView := NewInit(arguments.ViewJSON, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		key := "key-id-123"
+		authResult := getproviders.NewPackageAuthenticationResult(officialProvider, key)
+
+		initView.InstalledProviderVersionInfo(p, ver, authResult)
+
+		// Assert output - human
+		output := done(t)
+		expectedOutput := `"@message":"Installed provider version: hashicorp/test v1.2.3 (signed by HashiCorp)"`
+		if !strings.Contains(output.Stdout(), expectedOutput) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", expectedOutput, output.Stdout())
+		}
+	})
+}
+
+// Assert message content
+func TestNewInit_InstalledProviderVersionInfoWithKeyID(t *testing.T) {
+	const partnerProvider = 2
+
+	t.Run("partner provider auth result - human view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		initView := NewInit(arguments.ViewHuman, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		key := "key-id-123"
+		authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, key)
+
+		initView.InstalledProviderVersionInfoWithKeyID(p, ver, authResult, key)
+
+		// Assert output - human
+		output := done(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (signed by a HashiCorp partner, key ID key-id-123)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("partner provider auth result -json view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		initView := NewInit(arguments.ViewJSON, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		key := "key-id-123"
+		authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, key)
+
+		initView.InstalledProviderVersionInfoWithKeyID(p, ver, authResult, key)
+
+		// Assert output - human
+		output := done(t)
+		expectedOutput := `{"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (signed by a HashiCorp partnerkey_id: key-id-123)","@module":"terraform.ui","@timestamp":` // Stop comparison before timestamp
+		if !strings.Contains(output.Stdout(), expectedOutput) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", expectedOutput, output.Stdout())
+		}
+	})
+}
+
+// Assert JSON log content, including log type and additional fields
+func TestNewInit_InstalledProviderVersionInfo_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	v := versions.MustParseVersion("1.0.0")
+	officialProvider := 1
+	authResult := getproviders.NewPackageAuthenticationResult(officialProvider, "key-id-123")
+	initView.InstalledProviderVersionInfo(p, v, authResult)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Installed provider version: hashicorp/test v1.0.0 (signed by HashiCorp)"`,
+		`"@module":"terraform.ui"`,
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+// Assert JSON log content, including log type and additional fields
+//
+// Note - in calling code this is only ever used for partner providers
+func TestNewInit_InstalledProviderVersionInfoWithKeyID_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	v := versions.MustParseVersion("1.0.0")
+	partnerProvider := 2
+	keyID := "key-id-123"
+	authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, keyID)
+	initView.InstalledProviderVersionInfoWithKeyID(p, v, authResult, keyID)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Installed provider version: hashicorp/test v1.0.0 (signed by a HashiCorp partnerkey_id: key-id-123)"`,
+		`"@module":"terraform.ui"`,
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -691,3 +691,20 @@ func TestNewInit_InstalledProviderVersionInfoWithKeyID_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_Spacer_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.Spacer()
+
+	// Assert output
+	output := done(t)
+
+	// We cannot simply assert no output as the JSON view logs the version message on initialization
+	// Splitting on \n when there's only the version log will get an array of the log and an empty string.
+	// If there are more logs there'll be >2 elements.
+	if x := strings.Split(output.Stdout(), "\n"); len(x) != 2 {
+		t.Fatalf("expected no additional output after version message, got: %s", output.Stdout())
+	}
+}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -76,7 +76,11 @@ func (s *StateMigrateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 }
 
 func (s *StateMigrateHuman) Log(message string, params ...any) {
-	msg := s.view.colorize.Color(strings.TrimSpace(fmt.Sprintf(message, params...)))
+	s.log(fmt.Sprintf(message, params...))
+}
+
+func (s *StateMigrateHuman) log(preparedMessage string) {
+	msg := s.view.colorize.Color(strings.TrimSpace(preparedMessage))
 	s.view.streams.Println(msg)
 }
 
@@ -107,7 +111,7 @@ func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 func (s *StateMigrateHuman) InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)
-	s.Log(msg)
+	s.log(msg)
 }
 
 // Implements ProviderInstaller interface.
@@ -116,7 +120,7 @@ func (s *StateMigrateHuman) InstalledProviderVersionInfoWithKeyID(providerAddr a
 	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 
 	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)
-	s.Log(msg)
+	s.log(msg)
 }
 
 // Implements ProviderInstaller interface.

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -102,20 +104,16 @@ func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 }
 
 // Implements ProviderInstaller interface.
-func (s *StateMigrateHuman) InstalledProviderVersionInfo(params ...any) {
-	params = append(params, "") // add empty key id to the end
+func (s *StateMigrateHuman) InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)
 	s.Log(msg)
 }
 
 // Implements ProviderInstaller interface.
-func (s *StateMigrateHuman) InstalledProviderVersionInfoWithKeyID(params ...any) {
-	key := params[len(params)-1]
-
-	// replace key id param with formatted version to the end of the message if it is not empty
-	if key != "" {
-		params[len(params)-1] = fmt.Sprintf("key_id: %s", key)
-	}
+func (s *StateMigrateHuman) InstalledProviderVersionInfoWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+	keyDetails := fmt.Sprintf(", key ID [reset][bold]%s[reset]", keyID) // key id needs to be formatted for human output
+	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 
 	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)
 	s.Log(msg)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -104,7 +104,7 @@ func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 // Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) InstalledProviderVersionInfo(params ...any) {
 	params = append(params, "") // add empty key id to the end
-	msg := s.PrepareMessage(InstalledProviderVersionInfo, params...)
+	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)
 	s.Log(msg)
 }
 
@@ -117,12 +117,12 @@ func (s *StateMigrateHuman) InstalledProviderVersionInfoWithKeyID(params ...any)
 		params[len(params)-1] = fmt.Sprintf("key_id: %s", key)
 	}
 
-	msg := s.PrepareMessage(InstalledProviderVersionInfo, params...)
+	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)
 	s.Log(msg)
 }
 
 // Implements ProviderInstaller interface.
-func (s *StateMigrateHuman) PrepareMessage(code InitMessageCode, params ...any) string {
+func (s *StateMigrateHuman) prepareMessage(code InitMessageCode, params ...any) string {
 	message, ok := MessageRegistry[code]
 	if !ok {
 		// display the message code as fallback if not found in the message registry

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -108,14 +108,14 @@ func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 }
 
 // Implements ProviderInstaller interface.
-func (s *StateMigrateHuman) InstalledProviderVersionInfo(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+func (s *StateMigrateHuman) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)
 	s.log(msg)
 }
 
 // Implements ProviderInstaller interface.
-func (s *StateMigrateHuman) InstalledProviderVersionInfoWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+func (s *StateMigrateHuman) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
 	keyDetails := fmt.Sprintf(", key ID [reset][bold]%s[reset]", keyID) // key id needs to be formatted for human output
 	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -102,6 +102,26 @@ func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 }
 
 // Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) InstalledProviderVersionInfo(params ...any) {
+	params = append(params, "") // add empty key id to the end
+	msg := s.PrepareMessage(InstalledProviderVersionInfo, params...)
+	s.Log(msg)
+}
+
+// Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) InstalledProviderVersionInfoWithKeyID(params ...any) {
+	key := params[len(params)-1]
+
+	// replace key id param with formatted version to the end of the message if it is not empty
+	if key != "" {
+		params[len(params)-1] = fmt.Sprintf("key_id: %s", key)
+	}
+
+	msg := s.PrepareMessage(InstalledProviderVersionInfo, params...)
+	s.Log(msg)
+}
+
+// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) PrepareMessage(code InitMessageCode, params ...any) string {
 	message, ok := MessageRegistry[code]
 	if !ok {

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/terminal"
 )
 
-func TestNewStateMigrate_InstalledProviderVersionInfo(t *testing.T) {
+func TestNewStateMigrate_LogProviderVersionSuccess(t *testing.T) {
 	const verifiedChecksum = 0
 	const officialProvider = 1
 	const noKey = ""
@@ -26,7 +26,7 @@ func TestNewStateMigrate_InstalledProviderVersionInfo(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		var authResult *getproviders.PackageAuthenticationResult = nil
 
-		smView.InstalledProviderVersionInfo(p, ver, authResult)
+		smView.LogProviderVersionSuccess(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -44,7 +44,7 @@ func TestNewStateMigrate_InstalledProviderVersionInfo(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		authResult := getproviders.NewPackageAuthenticationResult(verifiedChecksum, noKey)
 
-		smView.InstalledProviderVersionInfo(p, ver, authResult)
+		smView.LogProviderVersionSuccess(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -63,7 +63,7 @@ func TestNewStateMigrate_InstalledProviderVersionInfo(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(officialProvider, key)
 
-		smView.InstalledProviderVersionInfo(p, ver, authResult)
+		smView.LogProviderVersionSuccess(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -74,7 +74,7 @@ func TestNewStateMigrate_InstalledProviderVersionInfo(t *testing.T) {
 	})
 }
 
-func TestNewStateMigrate_InstalledProviderVersionInfoWithKeyID(t *testing.T) {
+func TestNewStateMigrate_LogProviderVersionSuccessWithKeyID(t *testing.T) {
 	const partnerProvider = 2
 
 	t.Run("partner provider auth result - human view", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestNewStateMigrate_InstalledProviderVersionInfoWithKeyID(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, key)
 
-		smView.InstalledProviderVersionInfoWithKeyID(p, ver, authResult, key)
+		smView.LogProviderVersionSuccessWithKeyID(p, ver, authResult, key)
 
 		// Assert output - human
 		output := done(t)

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -1,0 +1,99 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/hashicorp/terraform/internal/terminal"
+)
+
+func TestNewStateMigrate_InstalledProviderVersionInfo(t *testing.T) {
+	const verifiedChecksum = 0
+	const officialProvider = 1
+	const noKey = ""
+
+	t.Run("no auth result - human view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := NewStateMigrate(arguments.ViewHuman, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		var authResult *getproviders.PackageAuthenticationResult = nil
+
+		smView.InstalledProviderVersionInfo(p, ver, authResult)
+
+		// Assert output
+		output := done(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (unauthenticated)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("verified checksum auth result - human view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := NewStateMigrate(arguments.ViewHuman, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		authResult := getproviders.NewPackageAuthenticationResult(verifiedChecksum, noKey)
+
+		smView.InstalledProviderVersionInfo(p, ver, authResult)
+
+		// Assert output
+		output := done(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (verified checksum)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+	})
+	t.Run("official provider auth result - human view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := NewStateMigrate(arguments.ViewHuman, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		key := "key-id-123"
+		authResult := getproviders.NewPackageAuthenticationResult(officialProvider, key)
+
+		smView.InstalledProviderVersionInfo(p, ver, authResult)
+
+		// Assert output
+		output := done(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (signed by HashiCorp)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+	})
+}
+
+func TestNewStateMigrate_InstalledProviderVersionInfoWithKeyID(t *testing.T) {
+	const partnerProvider = 2
+
+	t.Run("partner provider auth result - human view", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := NewStateMigrate(arguments.ViewHuman, view)
+
+		p := addrs.MustParseProviderSourceString("hashicorp/test")
+		ver := getproviders.MustParseVersion("1.2.3")
+		key := "key-id-123"
+		authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, key)
+
+		smView.InstalledProviderVersionInfoWithKeyID(p, ver, authResult, key)
+
+		// Assert output - human
+		output := done(t)
+		expectedOutput := "- Installed hashicorp/test v1.2.3 (signed by a HashiCorp partner, key ID key-id-123)\n"
+		if output.Stdout() != expectedOutput {
+			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
+		}
+	})
+}


### PR DESCRIPTION
This PR does 2 related things.

**Firstly**, it removes use of `PrepareMessage` methods outside of the `views` package. This feels like implementation details leaking out of that package. After achieving this I've stopped PrepareMessage being exported from the `views` package.

**Secondly**, it achieves the above by beginning to change `init`-related logging to adopt the strategy used for JSON output elsewhere in this repo (See the [Operation interface](https://github.com/hashicorp/terraform/blob/d419453b418ead10cd04e8c588dd80832906da6f/internal/command/views/operation.go#L25), and the [message types recorded here](https://github.com/hashicorp/terraform/blob/main/internal/command/views/json/message_types.go).). Instead of calling code passing different arguments to a single method to achieve a range of message types, calling code will instead call the specific method for the event it's currently trying to log.

i.e instead of:

```go

...command logic handling Foobar event...

// coupling with views package; calling code doesn't know the required number of params
view.Output(views.FoobarIsHappeningMessage, param1, param2, param3)
```

we use:

```go
var p addrs.Provider
var v versions.Version

...command logic handling Foobar event...

 // Calling code knows what data is expected to create output due to the method signature
view.Foobar(p, v)
```


There are a bunch of benefits to moving in this direction and I'm happy to discuss and/or write things up more if needed.

# Look at https://github.com/hashicorp/terraform/pull/38871 so see what next steps would look like.



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
