### PR TITLE
refactor(views/init): Add methods to `views.ProviderInstaller` interface for all message types related to provider download. Refactor code to used those methods, thereby replacing the `LogInitMessage` method.

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -922,7 +922,7 @@ func (c *InitCommand) Synopsis() string {
 // Returns a reused callback function for the ProviderAlreadyInstalled event in a providercache.InstallerEvents struct.
 func providerAlreadyInstalledCallback(view views.ProviderInstaller) func(provider addrs.Provider, selectedVersion getproviders.Version) {
 	return func(provider addrs.Provider, selectedVersion getproviders.Version) {
-		view.LogInitMessage(views.ProviderAlreadyInstalledMessage, provider.ForDisplay(), selectedVersion)
+		view.LogProviderAlreadyInstalled(provider, selectedVersion)
 	}
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -929,7 +929,7 @@ func providerAlreadyInstalledCallback(view views.ProviderInstaller) func(provide
 // Returns a reused callback function for the BuiltInProviderAvailable event in a providercache.InstallerEvents struct.
 func builtInProviderAvailableCallback(view views.ProviderInstaller) func(provider addrs.Provider) {
 	return func(provider addrs.Provider) {
-		view.LogInitMessage(views.BuiltInProviderAvailableMessage, provider.ForDisplay())
+		view.LogBuiltInProviderAvailable(provider)
 	}
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -481,7 +481,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 				view.LogReusingPreviousProviderVersion(provider)
 			} else {
 				if len(versionConstraints) > 0 {
-					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
+					view.LogFindingMatchingVersion(provider, versionConstraints)
 				} else {
 					view.LogInitMessage(views.FindingLatestVersionMessage, provider.ForDisplay())
 				}
@@ -635,7 +635,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 				view.LogReusingPreviousProviderVersion(provider)
 			} else {
 				if len(versionConstraints) > 0 {
-					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
+					view.LogFindingMatchingVersion(provider, versionConstraints)
 				} else {
 					view.LogInitMessage(views.FindingLatestVersionMessage, provider.ForDisplay())
 				}

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -471,7 +471,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 	var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
 	evts := &providercache.InstallerEvents{
 		PendingProviders: func(reqs map[addrs.Provider]getproviders.VersionConstraints) {
-			view.Output(views.InitializingStateStoreProviderPluginMessage, rootModEarly.StateStore.Type)
+			view.LogInitializingStateStoreProviderPlugin(rootModEarly.StateStore.Type)
 		},
 		ProviderAlreadyInstalled: providerAlreadyInstalledCallback(view),
 		BuiltInProviderAvailable: builtInProviderAvailableCallback(view),

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -954,7 +954,7 @@ func linkFromCacheBeginCallback(view views.ProviderInstaller) func(provider addr
 // Returns a reused callback function for the FetchPackageBegin event in a providercache.InstallerEvents struct.
 func fetchPackageBeginCallback(view views.ProviderInstaller) func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
 	return func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
-		view.LogInitMessage(views.InstallingProviderMessage, provider.ForDisplay(), version)
+		view.LogInstallingProvider(provider, version)
 	}
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -947,7 +947,7 @@ func builtInProviderFailureCallback(diags *tfdiags.Diagnostics) func(provider ad
 // Returns a reused callback function for the LinkFromCacheBegin event in a providercache.InstallerEvents struct.
 func linkFromCacheBeginCallback(view views.ProviderInstaller) func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
 	return func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
-		view.LogInitMessage(views.UsingProviderFromCacheDirInfo, provider.ForDisplay(), version)
+		view.LogUsingProviderFromCacheDir(provider, version)
 	}
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -922,7 +922,7 @@ func (c *InitCommand) Synopsis() string {
 // Returns a reused callback function for the ProviderAlreadyInstalled event in a providercache.InstallerEvents struct.
 func providerAlreadyInstalledCallback(view views.ProviderInstaller) func(provider addrs.Provider, selectedVersion getproviders.Version) {
 	return func(provider addrs.Provider, selectedVersion getproviders.Version) {
-		view.LogProviderAlreadyInstalled(provider, selectedVersion)
+		view.LogProviderVersionAlreadyInstalled(provider, selectedVersion)
 	}
 }
 
@@ -947,14 +947,14 @@ func builtInProviderFailureCallback(diags *tfdiags.Diagnostics) func(provider ad
 // Returns a reused callback function for the LinkFromCacheBegin event in a providercache.InstallerEvents struct.
 func linkFromCacheBeginCallback(view views.ProviderInstaller) func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
 	return func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
-		view.LogUsingProviderFromCacheDir(provider, version)
+		view.LogUsingProviderVersionFromCacheDir(provider, version)
 	}
 }
 
 // Returns a reused callback function for the FetchPackageBegin event in a providercache.InstallerEvents struct.
 func fetchPackageBeginCallback(view views.ProviderInstaller) func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
 	return func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
-		view.LogInstallingProvider(provider, version)
+		view.LogInstallingProviderVersion(provider, version)
 	}
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -1258,7 +1258,7 @@ func providersFetchedCallback(view views.ProviderInstaller) func(authResults map
 			}
 		}
 		if thirdPartySigned {
-			view.LogInitMessage(views.PartnerAndCommunityProvidersMessage)
+			view.LogPartnerAndCommunityProviders()
 		}
 	}
 }

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -483,7 +483,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 				if len(versionConstraints) > 0 {
 					view.LogFindingMatchingVersion(provider, versionConstraints)
 				} else {
-					view.LogInitMessage(views.FindingLatestVersionMessage, provider.ForDisplay())
+					view.LogFindingLatestVersion(provider)
 				}
 			}
 		},
@@ -637,7 +637,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 				if len(versionConstraints) > 0 {
 					view.LogFindingMatchingVersion(provider, versionConstraints)
 				} else {
-					view.LogInitMessage(views.FindingLatestVersionMessage, provider.ForDisplay())
+					view.LogFindingLatestVersion(provider)
 				}
 			}
 		},

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -478,7 +478,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 		BuiltInProviderFailure:   builtInProviderFailureCallback(&diags),
 		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
 			if locked {
-				view.LogInitMessage(views.ReusingPreviousVersionInfo, provider.ForDisplay())
+				view.LogReusingPreviousProviderVersion(provider)
 			} else {
 				if len(versionConstraints) > 0 {
 					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
@@ -632,7 +632,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		BuiltInProviderFailure:   builtInProviderFailureCallback(&diags),
 		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
 			if locked {
-				view.LogInitMessage(views.ReusingPreviousVersionInfo, provider.ForDisplay())
+				view.LogReusingPreviousProviderVersion(provider)
 			} else {
 				if len(versionConstraints) > 0 {
 					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -501,7 +501,7 @@ func (c *StateMigrateCommand) getSingleProvider(ctx context.Context, storeName s
 				if len(versionConstraints) > 0 {
 					view.LogFindingMatchingVersion(provider, versionConstraints)
 				} else {
-					view.LogInitMessage(views.FindingLatestVersionMessage, provider.ForDisplay())
+					view.LogFindingLatestVersion(provider)
 				}
 			}
 		},

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -489,7 +489,7 @@ func (c *StateMigrateCommand) getSingleProvider(ctx context.Context, storeName s
 	// are shimming our vt100 output to the legacy console API on Windows.
 	evts := &providercache.InstallerEvents{
 		PendingProviders: func(reqs map[addrs.Provider]getproviders.VersionConstraints) {
-			view.LogInitMessage(views.InitializingStateStoreProviderPluginMessage, storeName)
+			view.LogInitializingStateStoreProviderPlugin(storeName)
 		},
 		ProviderAlreadyInstalled: providerAlreadyInstalledCallback(view),
 		BuiltInProviderAvailable: builtInProviderAvailableCallback(view),

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -499,7 +499,7 @@ func (c *StateMigrateCommand) getSingleProvider(ctx context.Context, storeName s
 				view.LogReusingPreviousProviderVersion(provider)
 			} else {
 				if len(versionConstraints) > 0 {
-					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
+					view.LogFindingMatchingVersion(provider, versionConstraints)
 				} else {
 					view.LogInitMessage(views.FindingLatestVersionMessage, provider.ForDisplay())
 				}

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -496,7 +496,7 @@ func (c *StateMigrateCommand) getSingleProvider(ctx context.Context, storeName s
 		BuiltInProviderFailure:   builtInProviderFailureCallback(&diags),
 		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
 			if locked {
-				view.LogInitMessage(views.ReusingPreviousVersionInfo, provider.ForDisplay())
+				view.LogReusingPreviousProviderVersion(provider)
 			} else {
 				if len(versionConstraints) > 0 {
 					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -81,6 +81,11 @@ func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	v.view.streams.Println(v.prepareMessage(messageCode, params...))
 }
 
+func (v *InitHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+	v.view.streams.Println(v.prepareMessage(ProviderAlreadyInstalledMessage, params...))
+}
+
 func (v *InitHuman) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	v.view.streams.Println(v.prepareMessage(InstalledProviderVersionInfo, params...))
@@ -174,6 +179,14 @@ func (v *InitJSON) logInitMessage(messageCode InitMessageCode, params ...any) {
 // this implements log method for use by services that need to log generic string messages, e.g usage logging in hook_module_install.go
 func (v *InitJSON) Log(message string, params ...any) {
 	v.view.Log(strings.TrimSpace(fmt.Sprintf(message, params...)))
+}
+
+func (v *InitJSON) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+
+	// This was previously logged via LogInitMessage, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.logInitMessage(ProviderAlreadyInstalledMessage, params...)
 }
 
 func (v *InitJSON) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -127,6 +127,10 @@ func (v *InitHuman) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provid
 	v.view.streams.Println(v.prepareMessage(InstalledProviderVersionInfo, params...))
 }
 
+func (v *InitHuman) LogPartnerAndCommunityProviders() {
+	v.view.streams.Println(v.prepareMessage(PartnerAndCommunityProvidersMessage))
+}
+
 // this implements log method for use by interfaces that need to log generic string messages, e.g used for logging in hook_module_install.go
 func (v *InitHuman) Log(message string, params ...any) {
 	v.view.streams.Println(strings.TrimSpace(fmt.Sprintf(message, params...)))
@@ -282,6 +286,12 @@ func (v *InitJSON) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provide
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	v.logInitMessage(InstalledProviderVersionInfo, params...)
+}
+
+func (v *InitJSON) LogPartnerAndCommunityProviders() {
+	// This was previously logged via LogInitMessage, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.logInitMessage(PartnerAndCommunityProvidersMessage)
 }
 
 func (v *InitJSON) prepareMessage(messageCode InitMessageCode, params ...any) string {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -96,6 +96,11 @@ func (v *InitHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, ver
 	v.view.streams.Println(v.prepareMessage(ProviderAlreadyInstalledMessage, params...))
 }
 
+func (v *InitHuman) LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+	v.view.streams.Println(v.prepareMessage(InstallingProviderMessage, params...))
+}
+
 func (v *InitHuman) LogReusingPreviousProviderVersion(providerAddr addrs.Provider) {
 	params := []any{providerAddr.ForDisplay()}
 	v.view.streams.Println(v.prepareMessage(ReusingPreviousVersionInfo, params...))
@@ -218,6 +223,14 @@ func (v *InitJSON) LogProviderAlreadyInstalled(providerAddr addrs.Provider, vers
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	v.logInitMessage(ProviderAlreadyInstalledMessage, params...)
+}
+
+func (v *InitJSON) LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+
+	// This was previously logged via LogInitMessage, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.logInitMessage(InstallingProviderMessage, params...)
 }
 
 func (v *InitJSON) LogReusingPreviousProviderVersion(providerAddr addrs.Provider) {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -81,6 +81,11 @@ func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	v.view.streams.Println(v.prepareMessage(messageCode, params...))
 }
 
+func (v *InitHuman) LogInitializingStateStoreProviderPlugin(storeType string) {
+	params := []any{storeType}
+	v.view.streams.Println(v.prepareMessage(InitializingStateStoreProviderPluginMessage, params...))
+}
+
 func (v *InitHuman) LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints) {
 	params := []any{providerAddr.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints)}
 	v.view.streams.Println(v.prepareMessage(FindingMatchingVersionMessage, params...))
@@ -213,6 +218,14 @@ func (v *InitJSON) logInitMessage(messageCode InitMessageCode, params ...any) {
 // this implements log method for use by services that need to log generic string messages, e.g usage logging in hook_module_install.go
 func (v *InitJSON) Log(message string, params ...any) {
 	v.view.Log(strings.TrimSpace(fmt.Sprintf(message, params...)))
+}
+
+func (v *InitJSON) LogInitializingStateStoreProviderPlugin(storeType string) {
+	params := []any{storeType}
+
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.Output(InitializingStateStoreProviderPluginMessage, params...)
 }
 
 func (v *InitJSON) LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints) {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -86,6 +86,11 @@ func (v *InitHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, ver
 	v.view.streams.Println(v.prepareMessage(ProviderAlreadyInstalledMessage, params...))
 }
 
+func (v *InitHuman) LogReusingPreviousProviderVersion(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+	v.view.streams.Println(v.prepareMessage(ReusingPreviousVersionInfo, params...))
+}
+
 func (v *InitHuman) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	v.view.streams.Println(v.prepareMessage(InstalledProviderVersionInfo, params...))
@@ -187,6 +192,14 @@ func (v *InitJSON) LogProviderAlreadyInstalled(providerAddr addrs.Provider, vers
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	v.logInitMessage(ProviderAlreadyInstalledMessage, params...)
+}
+
+func (v *InitJSON) LogReusingPreviousProviderVersion(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+
+	// This was previously logged via LogInitMessage, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.logInitMessage(ReusingPreviousVersionInfo, params...)
 }
 
 func (v *InitJSON) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -96,6 +96,11 @@ func (v *InitHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, ver
 	v.view.streams.Println(v.prepareMessage(ProviderAlreadyInstalledMessage, params...))
 }
 
+func (v *InitHuman) LogUsingProviderFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+	v.view.streams.Println(v.prepareMessage(UsingProviderFromCacheDirInfo, params...))
+}
+
 func (v *InitHuman) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
 	params := []any{providerAddr.ForDisplay()}
 	v.view.streams.Println(v.prepareMessage(BuiltInProviderAvailableMessage, params...))
@@ -228,6 +233,14 @@ func (v *InitJSON) LogProviderAlreadyInstalled(providerAddr addrs.Provider, vers
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	v.logInitMessage(ProviderAlreadyInstalledMessage, params...)
+}
+
+func (v *InitJSON) LogUsingProviderFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+
+	// This was previously logged via LogInitMessage, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.logInitMessage(UsingProviderFromCacheDirInfo, params...)
 }
 
 func (v *InitJSON) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -20,7 +20,6 @@ type Init interface {
 	PolicyResult(addr string, resp policy.EvaluationResponse)
 	PolicyDiagnostics(diags policy.Diagnostics)
 	Output(messageCode InitMessageCode, params ...any)
-	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
 
 	ProviderInstaller
@@ -74,10 +73,6 @@ func (v *InitHuman) PolicyResult(addr string, resp policy.EvaluationResponse) {
 }
 
 func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
-	v.view.streams.Println(v.prepareMessage(messageCode, params...))
-}
-
-func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	v.view.streams.Println(v.prepareMessage(messageCode, params...))
 }
 
@@ -202,10 +197,17 @@ func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
 	)
 }
 
-func (v *InitJSON) LogInitMessage(messageCode InitMessageCode, params ...any) {
-	v.logInitMessage(messageCode, params...)
-}
-
+// logInitMessage is an internalised version of an old method `LogInitMessage`.
+// New methods have since been added that replace the old `LogInitMessage` method,
+// but to ensure that the same JSON output is produced we keep `logInitMessage` to
+// be reused by the newer methods.
+//
+// Logs produced via this method are not annotated with any extra data.
+// By default they contain:
+// * @level as "info"
+// * @module as "terraform.ui" (See NewJSONView)
+// * @timestamp formatted in the default way
+// * @message set as the string constructed from this method's arguments
 func (v *InitJSON) logInitMessage(messageCode InitMessageCode, params ...any) {
 	preppedMessage := v.prepareMessage(messageCode, params...)
 	if preppedMessage == "" {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -14,27 +14,6 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// ProviderInstaller is an interface that describes the methods required by a view that's used
-// with provider installation methods.
-//
-// The method names here are constrained by the Init view interface, which is coupled to the
-// provider installation process. In a future major version of Terraform this could be improved.
-// See: https://github.com/hashicorp/terraform/issues/38763
-type ProviderInstaller interface {
-	LogInitMessage(messageCode InitMessageCode, params ...any)
-	Output(messageCode InitMessageCode, params ...any)
-
-	// Log details about a successfully fetched provider package.
-	LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
-
-	// Log details about a successfully fetched provider package, including details about the key used to sign it.
-	LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
-
-	prepareMessage(messageCode InitMessageCode, params ...any) string
-
-	Spacer // output from provider installation is spaced out from following human-readable output log lines
-}
-
 // The Init view is used for the init command.
 type Init interface {
 	Diagnostics(diags tfdiags.Diagnostics)
@@ -44,8 +23,7 @@ type Init interface {
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
 
-	LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
-	LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
+	ProviderInstaller
 
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -91,12 +91,12 @@ func (v *InitHuman) LogFindingLatestVersion(providerAddr addrs.Provider) {
 	v.view.streams.Println(v.prepareMessage(FindingLatestVersionMessage, params...))
 }
 
-func (v *InitHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
+func (v *InitHuman) LogProviderVersionAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	v.view.streams.Println(v.prepareMessage(ProviderAlreadyInstalledMessage, params...))
 }
 
-func (v *InitHuman) LogUsingProviderFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
+func (v *InitHuman) LogUsingProviderVersionFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	v.view.streams.Println(v.prepareMessage(UsingProviderFromCacheDirInfo, params...))
 }
@@ -106,7 +106,7 @@ func (v *InitHuman) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
 	v.view.streams.Println(v.prepareMessage(BuiltInProviderAvailableMessage, params...))
 }
 
-func (v *InitHuman) LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version) {
+func (v *InitHuman) LogInstallingProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	v.view.streams.Println(v.prepareMessage(InstallingProviderMessage, params...))
 }
@@ -246,7 +246,7 @@ func (v *InitJSON) LogFindingLatestVersion(providerAddr addrs.Provider) {
 	v.logInitMessage(FindingLatestVersionMessage, params...)
 }
 
-func (v *InitJSON) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
+func (v *InitJSON) LogProviderVersionAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
@@ -254,7 +254,7 @@ func (v *InitJSON) LogProviderAlreadyInstalled(providerAddr addrs.Provider, vers
 	v.logInitMessage(ProviderAlreadyInstalledMessage, params...)
 }
 
-func (v *InitJSON) LogUsingProviderFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
+func (v *InitJSON) LogUsingProviderVersionFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
@@ -270,7 +270,7 @@ func (v *InitJSON) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
 	v.logInitMessage(BuiltInProviderAvailableMessage, params...)
 }
 
-func (v *InitJSON) LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version) {
+func (v *InitJSON) LogInstallingProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -86,6 +86,11 @@ func (v *InitHuman) LogFindingMatchingVersion(providerAddr addrs.Provider, versi
 	v.view.streams.Println(v.prepareMessage(FindingMatchingVersionMessage, params...))
 }
 
+func (v *InitHuman) LogFindingLatestVersion(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+	v.view.streams.Println(v.prepareMessage(FindingLatestVersionMessage, params...))
+}
+
 func (v *InitHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	v.view.streams.Println(v.prepareMessage(ProviderAlreadyInstalledMessage, params...))
@@ -197,6 +202,14 @@ func (v *InitJSON) LogFindingMatchingVersion(providerAddr addrs.Provider, versio
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	v.logInitMessage(FindingMatchingVersionMessage, params...)
+}
+
+func (v *InitJSON) LogFindingLatestVersion(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+
+	// This was previously logged via LogInitMessage, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.logInitMessage(FindingLatestVersionMessage, params...)
 }
 
 func (v *InitJSON) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -81,6 +81,11 @@ func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	v.view.streams.Println(v.prepareMessage(messageCode, params...))
 }
 
+func (v *InitHuman) LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints) {
+	params := []any{providerAddr.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints)}
+	v.view.streams.Println(v.prepareMessage(FindingMatchingVersionMessage, params...))
+}
+
 func (v *InitHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	v.view.streams.Println(v.prepareMessage(ProviderAlreadyInstalledMessage, params...))
@@ -184,6 +189,14 @@ func (v *InitJSON) logInitMessage(messageCode InitMessageCode, params ...any) {
 // this implements log method for use by services that need to log generic string messages, e.g usage logging in hook_module_install.go
 func (v *InitJSON) Log(message string, params ...any) {
 	v.view.Log(strings.TrimSpace(fmt.Sprintf(message, params...)))
+}
+
+func (v *InitJSON) LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints) {
+	params := []any{providerAddr.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints)}
+
+	// This was previously logged via LogInitMessage, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.logInitMessage(FindingMatchingVersionMessage, params...)
 }
 
 func (v *InitJSON) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -96,6 +96,11 @@ func (v *InitHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, ver
 	v.view.streams.Println(v.prepareMessage(ProviderAlreadyInstalledMessage, params...))
 }
 
+func (v *InitHuman) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+	v.view.streams.Println(v.prepareMessage(BuiltInProviderAvailableMessage, params...))
+}
+
 func (v *InitHuman) LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	v.view.streams.Println(v.prepareMessage(InstallingProviderMessage, params...))
@@ -223,6 +228,14 @@ func (v *InitJSON) LogProviderAlreadyInstalled(providerAddr addrs.Provider, vers
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	v.logInitMessage(ProviderAlreadyInstalledMessage, params...)
+}
+
+func (v *InitJSON) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+
+	// This was previously logged via LogInitMessage, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.logInitMessage(BuiltInProviderAvailableMessage, params...)
 }
 
 func (v *InitJSON) LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version) {

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -715,6 +715,29 @@ func TestNewInit_LogProviderVersionSuccessWithKeyID_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogReusingPreviousProviderVersion_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	initView.LogReusingPreviousProviderVersion(p)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"hashicorp/test: Reusing previous version from the dependency lock file"`,
+		`"@module":"terraform.ui"`,
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -738,6 +738,30 @@ func TestNewInit_LogReusingPreviousProviderVersion_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogFindingMatchingVersion_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	constraint, _ := getproviders.ParseVersionConstraints("1.0.0")
+	initView.LogFindingMatchingVersion(p, constraint)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Finding matching versions for provider: hashicorp/test, version_constraint: \"1.0.0\""`,
+		`"@module":"terraform.ui"`,
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -856,6 +856,28 @@ func TestNewInit_LogUsingProviderFromCacheDir_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogPartnerAndCommunityProviders_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogPartnerAndCommunityProviders()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Partner and community providers are signed by their developers.\nIf you'd like to know more about provider signing, you can read about it here:\nhttps://developer.hashicorp.com/terraform/cli/plugins/signing"`,
+		`"@module":"terraform.ui"`,
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -878,6 +878,31 @@ func TestNewInit_LogPartnerAndCommunityProviders_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogInitializingStateStoreProviderPlugin_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	storeType := "test_store"
+	initView.LogInitializingStateStoreProviderPlugin(storeType)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Initializing provider plugin for state store \"test_store\"..."`,
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"message_code":"initializing_state_store_provider_plugin_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -662,14 +662,14 @@ func TestNewInit_LogProviderVersionSuccess_json(t *testing.T) {
 	}
 }
 
-func TestNewInit_ProviderAlreadyInstalled_json(t *testing.T) {
+func TestNewInit_LogProviderVersionAlreadyInstalled_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
 	initView := NewInit(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	v := versions.MustParseVersion("1.0.0")
-	initView.LogProviderAlreadyInstalled(p, v)
+	initView.LogProviderVersionAlreadyInstalled(p, v)
 
 	// Assert output
 	output := done(t)
@@ -786,14 +786,14 @@ func TestNewInit_LogFindingLatestVersion_json(t *testing.T) {
 	}
 }
 
-func TestNewInit_LogInstallingProvider_json(t *testing.T) {
+func TestNewInit_LogInstallingProviderVersion_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
 	initView := NewInit(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	v := versions.MustParseVersion("1.0.0")
-	initView.LogInstallingProvider(p, v)
+	initView.LogInstallingProviderVersion(p, v)
 
 	// Assert output
 	output := done(t)
@@ -833,14 +833,14 @@ func TestNewInit_LogBuiltInProviderAvailable_json(t *testing.T) {
 	}
 }
 
-func TestNewInit_LogUsingProviderFromCacheDir_json(t *testing.T) {
+func TestNewInit_LogUsingProviderVersionFromCacheDir_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
 	initView := NewInit(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	v := versions.MustParseVersion("1.0.0")
-	initView.LogUsingProviderFromCacheDir(p, v)
+	initView.LogUsingProviderVersionFromCacheDir(p, v)
 
 	// Assert output
 	output := done(t)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -762,6 +762,29 @@ func TestNewInit_LogFindingMatchingVersion_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogFindingLatestVersion_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	initView.LogFindingLatestVersion(p)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"hashicorp/test: Finding latest version..."`,
+		`"@module":"terraform.ui"`,
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -832,6 +832,30 @@ func TestNewInit_LogBuiltInProviderAvailable_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogUsingProviderFromCacheDir_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	v := versions.MustParseVersion("1.0.0")
+	initView.LogUsingProviderFromCacheDir(p, v)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"hashicorp/test v1.0.0: Using from the shared cache directory"`,
+		`"@module":"terraform.ui"`,
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -661,6 +661,30 @@ func TestNewInit_LogProviderVersionSuccess_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_ProviderAlreadyInstalled_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	v := versions.MustParseVersion("1.0.0")
+	initView.LogProviderAlreadyInstalled(p, v)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"hashicorp/test v1.0.0: Using previously-installed provider version"`,
+		`"@module":"terraform.ui"`,
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 // Assert JSON log content, including log type and additional fields
 //
 // Note - in calling code this is only ever used for partner providers

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -809,6 +809,29 @@ func TestNewInit_LogInstallingProvider_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogBuiltInProviderAvailable_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	initView.LogBuiltInProviderAvailable(p)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"hashicorp/test is built in to Terraform"`,
+		`"@module":"terraform.ui"`,
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -785,6 +785,30 @@ func TestNewInit_LogFindingLatestVersion_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogInstallingProvider_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	v := versions.MustParseVersion("1.0.0")
+	initView.LogInstallingProvider(p, v)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Installing provider version: hashicorp/test v1.0.0..."`,
+		`"@module":"terraform.ui"`,
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -375,7 +375,7 @@ func TestNewInit_jsonViewLog(t *testing.T) {
 		t.Fatalf("unexpected return type %t", newInit)
 	}
 
-	newInit.LogInitMessage(InitializingProviderPluginMessage)
+	newInit.Output(InitializingProviderPluginMessage)
 
 	version := tfversion.String()
 	want := []map[string]interface{}{
@@ -388,10 +388,11 @@ func TestNewInit_jsonViewLog(t *testing.T) {
 			"ui":        JSON_UI_VERSION,
 		},
 		{
-			"@level":   "info",
-			"@message": "Initializing provider plugins...",
-			"@module":  "terraform.ui",
-			"type":     "log",
+			"@level":       "info",
+			"@message":     "Initializing provider plugins...",
+			"@module":      "terraform.ui",
+			"message_code": "initializing_provider_plugin_message",
+			"type":         "init_output",
 		},
 	}
 

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -24,6 +24,9 @@ type ProviderInstaller interface {
 	// Log details about a successfully fetched provider package, including details about the key used to sign it.
 	LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
 
+	// Log details about a successfully fetched provider package
+	LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version)
+
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -45,6 +45,9 @@ type ProviderInstaller interface {
 	// Log that the provider version in use is being used from a local cache instead of being downloaded from an external source.
 	LogUsingProviderFromCacheDir(providerAddr addrs.Provider, version getproviders.Version)
 
+	// Log that a provider successfully fetched in this operation is maintained by third-parties.
+	LogPartnerAndCommunityProviders()
+
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/getproviders"
+)
+
+// ProviderInstaller is an interface that describes the methods required by a view that's used
+// with provider installation methods.
+//
+// The method names here are constrained by the Init view interface, which is coupled to the
+// provider installation process. In a future major version of Terraform this could be improved.
+// See: https://github.com/hashicorp/terraform/issues/38763
+type ProviderInstaller interface {
+	LogInitMessage(messageCode InitMessageCode, params ...any)
+	Output(messageCode InitMessageCode, params ...any)
+
+	// Log details about a successfully fetched provider package.
+	LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
+
+	// Log details about a successfully fetched provider package, including details about the key used to sign it.
+	LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
+
+	prepareMessage(messageCode InitMessageCode, params ...any) string
+
+	Spacer // output from provider installation is spaced out from following human-readable output log lines
+}

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -15,7 +15,6 @@ import (
 // provider installation process. In a future major version of Terraform this could be improved.
 // See: https://github.com/hashicorp/terraform/issues/38763
 type ProviderInstaller interface {
-	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Output(messageCode InitMessageCode, params ...any)
 
 	// Log details about a successfully fetched provider package.

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -33,6 +33,9 @@ type ProviderInstaller interface {
 	// Log details about a provider installation being controlled by a version constraint.
 	LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints)
 
+	// Log details about a provider installation not being controlled by a version constraint nor a dependency lock file; latest available version is used.
+	LogFindingLatestVersion(providerAddr addrs.Provider)
+
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -11,43 +11,41 @@ import (
 // ProviderInstaller is an interface that describes the methods required by a view that's used
 // with provider installation methods.
 //
-// The method names here are constrained by the Init view interface, which is coupled to the
-// provider installation process. In a future major version of Terraform this could be improved.
-// See: https://github.com/hashicorp/terraform/issues/38763
+// The `Output` method is a constraint from the Init view interface, which will be refactored away soon.
 type ProviderInstaller interface {
 	Output(messageCode InitMessageCode, params ...any)
 
-	// Log details about a successfully fetched provider package.
+	// LogProviderVersionSuccess describes a successfully installed provider along with its version
 	LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
 
-	// Log details about a successfully fetched provider package, including details about the key used to sign it.
+	// LogProviderVersionSuccessWithKeyID describes a successfully installed provider along with its version and the key ID used to verify the provider's authenticity
 	LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
 
-	// Log details about a successfully fetched provider package
+	// LogProviderAlreadyInstalled indicates a provider that is already installed during installation
 	LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version)
 
-	// Log details about a provider being controlled by a pre-existing lock in a dependency lock file.
+	// LogReusingPreviousProviderVersion indicates a provider is locked to a specific version during installation
 	LogReusingPreviousProviderVersion(providerAddr addrs.Provider)
 
-	// Log details about a provider installation being controlled by a version constraint.
+	// LogFindingMatchingVersion indicates that Terraform is looking for a provider version that matches the constraint during installation.
 	LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints)
 
-	// Log details about a provider installation not being controlled by a version constraint nor a dependency lock file; latest available version is used.
+	// FindingLatestVersion indicates that Terraform is looking for the latest version of a provider during installation (no constraint nor prior lock was supplied)
 	LogFindingLatestVersion(providerAddr addrs.Provider)
 
-	// Log details about a provider installation process that's starting.
+	// LogInstallingProvider indicates that a provider is being installed (from a remote location)
 	LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version)
 
-	// Log that the built-in provider is available in the current Terraform core binary
+	// LogBuiltInProviderAvailable indicates a built-in provider is available in the current Terraform core binary and is in use during installation
 	LogBuiltInProviderAvailable(providerAddr addrs.Provider)
 
-	// Log that the provider version in use is being used from a local cache instead of being downloaded from an external source.
+	// LogUsingProviderFromCacheDir indicates that a provider is being linked from a system-wide cache, instead of being downloaded from an external source.
 	LogUsingProviderFromCacheDir(providerAddr addrs.Provider, version getproviders.Version)
 
-	// Log that a provider successfully fetched in this operation is maintained by third-parties.
+	// Log that a provider successfully fetched in this operation is maintained by third-parties and describe how these are signed
 	LogPartnerAndCommunityProviders()
 
-	// Log that the command is begging installation and initialisation of a provider(s) for the purposes of managing resource state.
+	// LogInitializingStateStoreProviderPlugin indicates progress during installation of a state store provider plugin
 	LogInitializingStateStoreProviderPlugin(storeType string)
 
 	prepareMessage(messageCode InitMessageCode, params ...any) string

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -48,6 +48,9 @@ type ProviderInstaller interface {
 	// Log that a provider successfully fetched in this operation is maintained by third-parties.
 	LogPartnerAndCommunityProviders()
 
+	// Log that the command is begging installation and initialisation of a provider(s) for the purposes of managing resource state.
+	LogInitializingStateStoreProviderPlugin(storeType string)
+
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -42,6 +42,9 @@ type ProviderInstaller interface {
 	// Log that the built-in provider is available in the current Terraform core binary
 	LogBuiltInProviderAvailable(providerAddr addrs.Provider)
 
+	// Log that the provider version in use is being used from a local cache instead of being downloaded from an external source.
+	LogUsingProviderFromCacheDir(providerAddr addrs.Provider, version getproviders.Version)
+
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -30,6 +30,9 @@ type ProviderInstaller interface {
 	// Log details about a provider being controlled by a pre-existing lock in a dependency lock file.
 	LogReusingPreviousProviderVersion(providerAddr addrs.Provider)
 
+	// Log details about a provider installation being controlled by a version constraint.
+	LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints)
+
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -36,6 +36,9 @@ type ProviderInstaller interface {
 	// Log details about a provider installation not being controlled by a version constraint nor a dependency lock file; latest available version is used.
 	LogFindingLatestVersion(providerAddr addrs.Provider)
 
+	// Log details about a provider installation process that's starting.
+	LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version)
+
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -21,8 +21,8 @@ type ProviderInstaller interface {
 	// LogProviderVersionSuccessWithKeyID describes a successfully installed provider along with its version and the key ID used to verify the provider's authenticity
 	LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
 
-	// LogProviderAlreadyInstalled indicates a provider that is already installed during installation
-	LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version)
+	// LogProviderVersionAlreadyInstalled indicates a provider that is already installed during installation
+	LogProviderVersionAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version)
 
 	// LogReusingPreviousProviderVersion indicates a provider is locked to a specific version during installation
 	LogReusingPreviousProviderVersion(providerAddr addrs.Provider)
@@ -33,14 +33,14 @@ type ProviderInstaller interface {
 	// FindingLatestVersion indicates that Terraform is looking for the latest version of a provider during installation (no constraint nor prior lock was supplied)
 	LogFindingLatestVersion(providerAddr addrs.Provider)
 
-	// LogInstallingProvider indicates that a provider is being installed (from a remote location)
-	LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version)
+	// LogInstallingProviderVersion indicates that a provider is being installed (from a remote location)
+	LogInstallingProviderVersion(providerAddr addrs.Provider, version getproviders.Version)
 
 	// LogBuiltInProviderAvailable indicates a built-in provider is available in the current Terraform core binary and is in use during installation
 	LogBuiltInProviderAvailable(providerAddr addrs.Provider)
 
-	// LogUsingProviderFromCacheDir indicates that a provider is being linked from a system-wide cache, instead of being downloaded from an external source.
-	LogUsingProviderFromCacheDir(providerAddr addrs.Provider, version getproviders.Version)
+	// LogUsingProviderVersionFromCacheDir indicates that a provider is being linked from a system-wide cache, instead of being downloaded from an external source.
+	LogUsingProviderVersionFromCacheDir(providerAddr addrs.Provider, version getproviders.Version)
 
 	// Log that a provider successfully fetched in this operation is maintained by third-parties and describe how these are signed
 	LogPartnerAndCommunityProviders()

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -27,6 +27,9 @@ type ProviderInstaller interface {
 	// Log details about a successfully fetched provider package
 	LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version)
 
+	// Log details about a provider being controlled by a pre-existing lock in a dependency lock file.
+	LogReusingPreviousProviderVersion(providerAddr addrs.Provider)
+
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines

--- a/internal/command/views/provider_installer.go
+++ b/internal/command/views/provider_installer.go
@@ -39,6 +39,9 @@ type ProviderInstaller interface {
 	// Log details about a provider installation process that's starting.
 	LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version)
 
+	// Log that the built-in provider is available in the current Terraform core binary
+	LogBuiltInProviderAvailable(providerAddr addrs.Provider)
+
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -108,6 +108,13 @@ func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 }
 
 // Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+	msg := s.prepareMessage(ProviderAlreadyInstalledMessage, params...)
+	s.log(msg)
+}
+
+// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -115,6 +115,13 @@ func (s *StateMigrateHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provi
 }
 
 // Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) LogReusingPreviousProviderVersion(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+	msg := s.prepareMessage(ReusingPreviousVersionInfo, params...)
+	s.log(msg)
+}
+
+// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -129,6 +129,13 @@ func (s *StateMigrateHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provi
 }
 
 // Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+	msg := s.prepareMessage(BuiltInProviderAvailableMessage, params...)
+	s.log(msg)
+}
+
+// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	msg := s.prepareMessage(InstallingProviderMessage, params...)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -115,6 +115,13 @@ func (s *StateMigrateHuman) LogFindingMatchingVersion(providerAddr addrs.Provide
 }
 
 // Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) LogFindingLatestVersion(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+	msg := s.prepareMessage(FindingLatestVersionMessage, params...)
+	s.log(msg)
+}
+
+// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	msg := s.prepareMessage(ProviderAlreadyInstalledMessage, params...)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -120,14 +120,14 @@ func (s *StateMigrateHuman) LogFindingLatestVersion(providerAddr addrs.Provider)
 }
 
 // Implements ProviderInstaller interface.
-func (s *StateMigrateHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
+func (s *StateMigrateHuman) LogProviderVersionAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	msg := s.prepareMessage(ProviderAlreadyInstalledMessage, params...)
 	s.log(msg)
 }
 
 // Implements ProviderInstaller interface.
-func (s *StateMigrateHuman) LogUsingProviderFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
+func (s *StateMigrateHuman) LogUsingProviderVersionFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	msg := s.prepareMessage(UsingProviderFromCacheDirInfo, params...)
 	s.log(msg)
@@ -141,7 +141,7 @@ func (s *StateMigrateHuman) LogBuiltInProviderAvailable(providerAddr addrs.Provi
 }
 
 // Implements ProviderInstaller interface.
-func (s *StateMigrateHuman) LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version) {
+func (s *StateMigrateHuman) LogInstallingProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	msg := s.prepareMessage(InstallingProviderMessage, params...)
 	s.log(msg)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -173,6 +173,12 @@ func (s *StateMigrateHuman) LogProviderVersionSuccessWithKeyID(providerAddr addr
 }
 
 // Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) LogPartnerAndCommunityProviders() {
+	msg := s.prepareMessage(PartnerAndCommunityProvidersMessage)
+	s.log(msg)
+}
+
+// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) prepareMessage(code InitMessageCode, params ...any) string {
 	message, ok := MessageRegistry[code]
 	if !ok {

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -129,6 +129,13 @@ func (s *StateMigrateHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provi
 }
 
 // Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) LogInstallingProvider(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+	msg := s.prepareMessage(InstallingProviderMessage, params...)
+	s.log(msg)
+}
+
+// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) LogReusingPreviousProviderVersion(providerAddr addrs.Provider) {
 	params := []any{providerAddr.ForDisplay()}
 	msg := s.prepareMessage(ReusingPreviousVersionInfo, params...)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -90,15 +90,6 @@ func (s *StateMigrateHuman) Spacer() {
 }
 
 // Implements ProviderInstaller interface.
-func (s *StateMigrateHuman) LogInitMessage(code InitMessageCode, params ...any) {
-	msg, ok := MessageRegistry[code]
-	if !ok {
-		panic("missing message for InstallingProviderMessage init message code")
-	}
-	s.Log(msg.HumanValue, params...)
-}
-
-// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 	msg, ok := MessageRegistry[code]
 	if !ok {

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -108,6 +108,13 @@ func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 }
 
 // Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints) {
+	params := []any{providerAddr.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints)}
+	msg := s.prepareMessage(FindingMatchingVersionMessage, params...)
+	s.log(msg)
+}
+
+// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	msg := s.prepareMessage(ProviderAlreadyInstalledMessage, params...)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -108,6 +108,13 @@ func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 }
 
 // Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) LogInitializingStateStoreProviderPlugin(storeType string) {
+	params := []any{storeType}
+	msg := s.prepareMessage(InitializingStateStoreProviderPluginMessage, params...)
+	s.log(msg)
+}
+
+// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints) {
 	params := []any{providerAddr.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints)}
 	msg := s.prepareMessage(FindingMatchingVersionMessage, params...)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -129,6 +129,13 @@ func (s *StateMigrateHuman) LogProviderAlreadyInstalled(providerAddr addrs.Provi
 }
 
 // Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) LogUsingProviderFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+	msg := s.prepareMessage(UsingProviderFromCacheDirInfo, params...)
+	s.log(msg)
+}
+
+// Implements ProviderInstaller interface.
 func (s *StateMigrateHuman) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
 	params := []any{providerAddr.ForDisplay()}
 	msg := s.prepareMessage(BuiltInProviderAvailableMessage, params...)


### PR DESCRIPTION
Next step following https://github.com/hashicorp/terraform/pull/38870

This PR has made a method for each type of log message related to the provider installation process. In the process this has replaced the `LogInitMessage` method and helped make the `views.ProviderInstaller` interface a lot more meaningful/cleaner.

My planned next steps after this PR in the medium-long term are to:
* Do the same task for the remaining message types logged via the init view's generic `Output` method
* Replace use of the MessageRegistry used for the init view (and state migrate view, which had to adopt its use to reuse code).
    * We only need message codes for the JSON messages that log those message codes, and that can be moved to the views/json package. Currently they're used for both human and json output only because we have been limited to generic methods for logging output.

In the short term though, the intention of this PR is to enable good-quality JSON output to be produced by the `state migrate` command, which also implements the affected view interface.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
