### PR TITLE
docs: fix typo in CONTRIBUTING.md (seperate -> separate)

### DIFF
--- a/.changes/v1.16/NOTES-20260714-183931.yaml
+++ b/.changes/v1.16/NOTES-20260714-183931.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: 'CONTRIBUTING.md: Fix typo (seperate → separate)'
+time: 2026-07-14T18:39:31.164222+08:00
+custom:
+    Issue: "38873"

--- a/terraform/.changes/v1.16/NOTES-20260714-183931.yaml
+++ b/terraform/.changes/v1.16/NOTES-20260714-183931.yaml
@@ -1,0 +1,3 @@
+kind: NOTES
+body: 'CONTRIBUTING.md: Fix typo (seperate → separate)'
+time: 2026-07-14T18:39:31.164222+08:00


### PR DESCRIPTION
This PR fixes a spelling error in the CONTRIBUTING.md file.

## Change:
- Fixed "**seperate**" → "separate" in the AI Usage section (line 328)

## Target Release

1.16.x

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.

## CHANGELOG entry

- [x] This change is not user-facing.