### PR TITLE
docs: Fix typo in CONTRIBUTING.md (seperate → separate)

### DIFF
--- a/terraform/.changes/v1.16/NOTES-20260714-183931.yaml
+++ b/terraform/.changes/v1.16/NOTES-20260714-183931.yaml
@@ -1,0 +1,3 @@
+kind: NOTES
+body: 'CONTRIBUTING.md: Fix typo (seperate → separate)'
+time: 2026-07-14T18:39:31.164222+08:00


### PR DESCRIPTION
This PR fixes a typo in the CONTRIBUTING.md documentation file.

**Change:**
- Fixed spelling: `seperate` → `separate`

**Changelog:**
- Added changelog entry file: `.changes/v1.16/NOTES-20260714-183931.yaml`

This is a minor documentation fix to correct the spelling error in the contributing guidelines.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
