### PR TITLE
refactor: Rename some vars and update some TRACE logs in `init` to reflect that provider download is no longer split into config/state groups

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -508,7 +508,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 		FetchPackageSuccess: func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {
 			// 1. Capture auth result if this provider is used for state storage.
 			if rootModEarly.StateStore != nil && provider.Equals(rootModEarly.StateStore.ProviderAddr) {
-				log.Printf("[TRACE] getProvidersFromConfig: state storage provider %s (%q) auth result: %q", rootModEarly.StateStore.ProviderAddr.Type, rootModEarly.StateStore.ProviderAddr.ForDisplay(), stateStoreProviderAuthResult.String())
+				log.Printf("[TRACE] getProvidersFromPSSConfig: state storage provider %s (%q) auth result: %q", rootModEarly.StateStore.ProviderAddr.Type, rootModEarly.StateStore.ProviderAddr.ForDisplay(), stateStoreProviderAuthResult.String())
 				stateStoreProviderAuthResult = authResult
 			}
 

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -229,17 +229,17 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 			}
 		}
 
-		var configProvidersOutput bool
+		var getPSSProviderOutput bool
 		var safeInstallAction SafeStateStoreProviderInstallAction
 		var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
-		var configProviderDiags tfdiags.Diagnostics
-		configProvidersOutput, pssLock, safeInstallAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
-		diags = diags.Append(configProviderDiags)
-		if configProviderDiags.HasErrors() {
+		var getPSSProviderDiags tfdiags.Diagnostics
+		getPSSProviderOutput, pssLock, safeInstallAction, stateStoreProviderAuthResult, getPSSProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
+		diags = diags.Append(getPSSProviderDiags)
+		if getPSSProviderDiags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1
 		}
-		if configProvidersOutput {
+		if getPSSProviderOutput {
 			// If we outputted information, then we need to output a newline
 			// so that our success message is nicely spaced out from prior text.
 			view.Spacer()
@@ -409,13 +409,13 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		// `getProviders`, else that method could download the PSS provider a second time, or download a different version.
 		previousLocksWithPSSOverride = c.mergeLockedDependencies(pssLock, previousLocksWithPSSOverride)
 	}
-	stateProvidersOutput, finalLocks, stateProvidersDiags := c.getProviders(ctx, config, state, initArgs.Upgrade, previousLocksWithPSSOverride, initArgs.PluginPath, view, providerHook)
-	diags = diags.Append(stateProvidersDiags)
-	if stateProvidersDiags.HasErrors() {
+	getProvidersOutput, finalLocks, getProvidersDiags := c.getProviders(ctx, config, state, initArgs.Upgrade, previousLocksWithPSSOverride, initArgs.PluginPath, view, providerHook)
+	diags = diags.Append(getProvidersDiags)
+	if getProvidersDiags.HasErrors() {
 		view.Diagnostics(diags)
 		return 1
 	}
-	if stateProvidersOutput {
+	if getProvidersOutput {
 		// If we outputted information, then we need to output a newline
 		// so that our success message is nicely spaced out from prior text.
 		view.Spacer()

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -3080,23 +3080,23 @@ func (m *Meta) determineSafeProviderInstallAction(provider addrs.Provider, provi
 		//  - the provider isn't already downloaded to the cache BUT installation is controlled by a lock file.
 		//
 		// In both cases trust is already established; skip requesting approval.
-		log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) was present in a dependency lock file during provider installation, so we consider it safe", provider.Type, provider)
+		log.Printf("[TRACE] init (determineSafeProviderInstallAction): the state storage provider %s (%q) was present in a dependency lock file during provider installation, so we consider it safe", provider.Type, provider)
 		return Proceed
 	} else {
 		// The provider wasn't in the dependency lock file so it's being download for the first time
 		// (we block upgrading the state store provider in this method).
-		log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) will be changed in the dependency lock file during provider installation.", provider.Type, provider)
+		log.Printf("[TRACE] init (determineSafeProviderInstallAction): the state storage provider %s (%q) will be changed in the dependency lock file during provider installation.", provider.Type, provider)
 		switch location.(type) {
 		case getproviders.PackageLocalArchive, getproviders.PackageLocalDir:
 			// If the provider is downloaded from a local source we assume it's safe.
 			// We don't require presence of the -safe-init flag, or require input from the user to approve its usage.
-			log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded from a local source, so we consider it safe.", provider.Type, provider)
+			log.Printf("[TRACE] init (determineSafeProviderInstallAction): the state storage provider %s (%q) is downloaded from a local source, so we consider it safe.", provider.Type, provider)
 			return Proceed
 		case getproviders.PackageHTTPURL:
-			log.Printf("[DEBUG] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded via HTTP, so we consider it potentially unsafe.", provider.Type, provider)
+			log.Printf("[DEBUG] init (determineSafeProviderInstallAction): the state storage provider %s (%q) is downloaded via HTTP, so we consider it potentially unsafe.", provider.Type, provider)
 			return RequireApproval
 		default:
-			panic(fmt.Sprintf("init (getProvidersFromConfig): unexpected provider location type for state storage provider %q: %T", provider, location))
+			panic(fmt.Sprintf("init (determineSafeProviderInstallAction): unexpected provider location type for state storage provider %q: %T", provider, location))
 		}
 	}
 }


### PR DESCRIPTION
We no longer split provider download into 'providers from config' and 'providers only in state', so these var names need to be updated to avoid confusion.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
