### PR TITLE
Suppress GO-2026-5932

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -16,6 +16,11 @@ binary {
   triage {
     suppress {
       vulnerabilities = [
+        // golang.org/x/crypto/openpgp is deprecated/unmaintained with no fixed
+        // version. The built terraform binary does not use this package
+        // (confirmed via `go mod why golang.org/x/crypto/openpgp`).
+        // It is only used in the copywrite tool.
+        "GO-2026-5932",
         // These vulnerabilities all point to the same issue.
         // https://test.osv.dev/vulnerability/GO-2026-4762
         "GHSA-p77j-4mvh-x3m3",


### PR DESCRIPTION
Suppresses OSV advisory GO-2026-5932 in the CRT security scanner. The advisory deprecates `golang.org/x/crypto/openpgp`; it has no fixed version, so bumping x/crypto cannot clear it.

The `copywrite` tool imports this, but the built terraform binary does not use this package.
```
❯ go mod why golang.org/x/crypto/openpgp
# golang.org/x/crypto/openpgp
github.com/hashicorp/copywrite
github.com/hashicorp/copywrite/cmd
github.com/google/go-github/v45/github
golang.org/x/crypto/openpgp
```

I'm backporting this to 1.15 in case we're doing another patch release.

Related:
* https://github.com/hashicorp/terraform-provider-azurerm/pull/32786
* https://github.com/hashicorp/terraform-provider-aws/pull/48838

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
