### PR TITLE
policy: validate policies against provider schemas before the walk

### DIFF
--- a/.changes/v1.16/NOTES-20260715-114855.yaml
+++ b/.changes/v1.16/NOTES-20260715-114855.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: 'policy (experimental): loaded policies are now validated against the run''s provider schemas before plan/apply, so a policy referencing an attribute a provider does not have fails early instead of partway through a run'
+time: 2026-07-15T11:48:55.000000-04:00
+custom:
+    Issue: "38877"

--- a/internal/policy/client.go
+++ b/internal/policy/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -270,6 +271,81 @@ func (c *client) Setup(ctx context.Context, req SetupRequest) SetupResponse {
 		serverCapabilities: response.ServerCapabilities,
 		Diagnostics:        DiagsFromProto(response.Diagnostics, nil),
 	}
+}
+
+// ValidateProviderSchemas validates the loaded policies against the run's
+// provider schemas. It serialises each provider's config/resource/data-source
+// object types as cty JSON type encodings, calls the plugin, and returns the
+// diagnostics — errors when a policy references something a provider lacks.
+func (c *client) ValidateProviderSchemas(ctx context.Context, req ValidateProviderSchemasRequest) ValidateProviderSchemasResponse {
+	ctx, span := tracer().Start(ctx, "policy.client.validate_provider_schemas",
+		trace.WithAttributes(attribute.Int("policy.provider_schemas.count", len(req.ProviderSchemas))),
+	)
+	defer span.End()
+
+	protoReq := &proto.ValidateProviderSchemasRequest{}
+	for _, ps := range req.ProviderSchemas {
+		protoPS, err := providerSchemaToProto(ps)
+		if err != nil {
+			return ValidateProviderSchemasResponse{Diagnostics: Diagnostics{
+				NewErrorDiagnostic("Failed to encode provider schema",
+					fmt.Sprintf("Failed to encode the schema for provider %q: %v.", ps.Type, err),
+					SetupErrorResult,
+				),
+			}}
+		}
+		protoReq.ProviderSchemas = append(protoReq.ProviderSchemas, protoPS)
+	}
+
+	response, err := c.client.ValidateProviderSchemas(ctx, protoReq)
+	if err != nil {
+		return ValidateProviderSchemasResponse{Diagnostics: Diagnostics{
+			NewErrorDiagnostic("Failed to validate policies against provider schemas",
+				fmt.Sprintf("Failed to validate policies against provider schemas: %v.", err),
+				SetupErrorResult,
+			),
+		}}
+	}
+	return ValidateProviderSchemasResponse{Diagnostics: DiagsFromProto(response.Diagnostics, nil)}
+}
+
+// providerSchemaToProto encodes a provider schema's cty object types as cty JSON
+// type encodings for the wire.
+func providerSchemaToProto(ps ProviderSchema) (*proto.ProviderSchema, error) {
+	config, err := ctyjson.MarshalType(ps.Config)
+	if err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	resources, err := marshalTypeMap(ps.Resources)
+	if err != nil {
+		return nil, fmt.Errorf("resources: %w", err)
+	}
+	dataSources, err := marshalTypeMap(ps.DataSources)
+	if err != nil {
+		return nil, fmt.Errorf("data sources: %w", err)
+	}
+	return &proto.ProviderSchema{
+		Type:        ps.Type,
+		LocalNames:  ps.LocalNames,
+		Config:      config,
+		Resources:   resources,
+		DataSources: dataSources,
+	}, nil
+}
+
+func marshalTypeMap(in map[string]cty.Type) (map[string][]byte, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make(map[string][]byte, len(in))
+	for name, ty := range in {
+		raw, err := ctyjson.MarshalType(ty)
+		if err != nil {
+			return nil, fmt.Errorf("%q: %w", name, err)
+		}
+		out[name] = raw
+	}
+	return out, nil
 }
 
 func (c *client) EvaluateResource(ctx context.Context, req EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) EvaluationResponse {

--- a/internal/policy/client.go
+++ b/internal/policy/client.go
@@ -312,7 +312,7 @@ func (c *client) ValidateProviderSchemas(ctx context.Context, req ValidateProvid
 // providerSchemaToProto encodes a provider schema's cty object types as cty JSON
 // type encodings for the wire.
 func providerSchemaToProto(ps ProviderSchema) (*proto.ProviderSchema, error) {
-	config, err := ctyjson.MarshalType(ps.Config)
+	config, err := marshalType(ps.Config)
 	if err != nil {
 		return nil, fmt.Errorf("config: %w", err)
 	}
@@ -326,7 +326,6 @@ func providerSchemaToProto(ps ProviderSchema) (*proto.ProviderSchema, error) {
 	}
 	return &proto.ProviderSchema{
 		Type:        ps.Type,
-		LocalNames:  ps.LocalNames,
 		Config:      config,
 		Resources:   resources,
 		DataSources: dataSources,
@@ -339,13 +338,20 @@ func marshalTypeMap(in map[string]cty.Type) (map[string][]byte, error) {
 	}
 	out := make(map[string][]byte, len(in))
 	for name, ty := range in {
-		raw, err := ctyjson.MarshalType(ty)
+		raw, err := marshalType(ty)
 		if err != nil {
 			return nil, fmt.Errorf("%q: %w", name, err)
 		}
 		out[name] = raw
 	}
 	return out, nil
+}
+
+func marshalType(ty cty.Type) ([]byte, error) {
+	if ty == cty.NilType {
+		ty = cty.EmptyObject
+	}
+	return ctyjson.MarshalType(ty)
 }
 
 func (c *client) EvaluateResource(ctx context.Context, req EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) EvaluationResponse {

--- a/internal/policy/client_test.go
+++ b/internal/policy/client_test.go
@@ -5,12 +5,15 @@ package policy
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 	"google.golang.org/grpc"
 	gproto "google.golang.org/protobuf/proto"
 
@@ -25,6 +28,7 @@ type stubPolicyClient struct {
 	evaluateResourceFn func(*proto.PolicyEvaluateResourceRequest) (*proto.PolicyEvaluateResourceResponse, error)
 	evaluateProviderFn func(*proto.PolicyEvaluateProviderRequest) (*proto.PolicyEvaluateProviderResponse, error)
 	evaluateModuleFn   func(*proto.PolicyEvaluateModuleRequest) (*proto.PolicyEvaluateModuleResponse, error)
+	validateSchemasFn  func(context.Context, *proto.ValidateProviderSchemasRequest) (*proto.ValidateProviderSchemasResponse, error)
 }
 
 func (s *stubPolicyClient) Setup(ctx context.Context, req *proto.PolicySetupRequest, _ ...grpc.CallOption) (*proto.PolicySetupResponse, error) {
@@ -41,6 +45,58 @@ func (s *stubPolicyClient) EvaluateProvider(ctx context.Context, req *proto.Poli
 
 func (s *stubPolicyClient) EvaluateModule(ctx context.Context, req *proto.PolicyEvaluateModuleRequest, _ ...grpc.CallOption) (*proto.PolicyEvaluateModuleResponse, error) {
 	return s.evaluateModuleFn(req)
+}
+
+func (s *stubPolicyClient) ValidateProviderSchemas(ctx context.Context, req *proto.ValidateProviderSchemasRequest, _ ...grpc.CallOption) (*proto.ValidateProviderSchemasResponse, error) {
+	return s.validateSchemasFn(ctx, req)
+}
+
+func TestProviderSchemaToProto(t *testing.T) {
+	got, err := providerSchemaToProto(ProviderSchema{
+		Type:        "test",
+		Config:      cty.NilType,
+		Resources:   map[string]cty.Type{"test_empty": cty.NilType},
+		DataSources: map[string]cty.Type{"test_data": cty.EmptyObject},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error encoding absent schema bodies: %s", err)
+	}
+	if len(got.LocalNames) != 0 {
+		t.Fatalf("Terraform must not send configuration local names as policy aliases: %v", got.LocalNames)
+	}
+
+	for name, raw := range map[string][]byte{
+		"config":     got.Config,
+		"test_empty": got.Resources["test_empty"],
+		"test_data":  got.DataSources["test_data"],
+	} {
+		typ, err := ctyjson.UnmarshalType(raw)
+		if err != nil {
+			t.Fatalf("%s did not contain a valid cty type: %s", name, err)
+		}
+		if !typ.Equals(cty.EmptyObject) {
+			t.Errorf("%s encoded %s, want empty object", name, typ.FriendlyName())
+		}
+	}
+}
+
+func TestClientValidateProviderSchemasRPCError(t *testing.T) {
+	c := &client{client: &stubPolicyClient{
+		validateSchemasFn: func(ctx context.Context, req *proto.ValidateProviderSchemasRequest) (*proto.ValidateProviderSchemasResponse, error) {
+			return nil, errors.New("transport unavailable")
+		},
+	}}
+
+	resp := c.ValidateProviderSchemas(t.Context(), ValidateProviderSchemasRequest{
+		ProviderSchemas: []ProviderSchema{{Type: "test", Config: cty.EmptyObject}},
+	})
+	if !resp.Diagnostics.HasErrors() {
+		t.Fatal("expected the RPC error to become a diagnostic")
+	}
+	detail := resp.Diagnostics[0].Description().Detail
+	if !strings.Contains(detail, "transport unavailable") || !strings.Contains(detail, "provider schemas") {
+		t.Fatalf("RPC diagnostic is not actionable: %q", detail)
+	}
 }
 
 func TestClientEvaluate(t *testing.T) {

--- a/internal/policy/mock.go
+++ b/internal/policy/mock.go
@@ -41,6 +41,12 @@ type MockClient struct {
 	EvaluateModuleRequest  EvaluationRequest[*proto.PolicyEvaluateModuleRequest_ModuleMetadata]
 	EvaluateModuleFn       func(context.Context, EvaluationRequest[*proto.PolicyEvaluateModuleRequest_ModuleMetadata]) EvaluationResponse
 
+	// ValidateProviderSchemas method tracking
+	ValidateProviderSchemasCalled   bool
+	ValidateProviderSchemasResponse *ValidateProviderSchemasResponse
+	ValidateProviderSchemasRequest  ValidateProviderSchemasRequest
+	ValidateProviderSchemasFn       func(context.Context, ValidateProviderSchemasRequest) ValidateProviderSchemasResponse
+
 	// Stop method tracking
 	StopCalled bool
 	StopFn     func()
@@ -110,6 +116,22 @@ func (p *MockClient) EvaluateModule(ctx context.Context, r EvaluationRequest[*pr
 
 	if p.EvaluateModuleResponse != nil {
 		return *p.EvaluateModuleResponse
+	}
+
+	return resp
+}
+
+func (p *MockClient) ValidateProviderSchemas(ctx context.Context, req ValidateProviderSchemasRequest) (resp ValidateProviderSchemasResponse) {
+	defer p.beginWrite()()
+
+	p.ValidateProviderSchemasCalled = true
+	p.ValidateProviderSchemasRequest = req
+	if p.ValidateProviderSchemasFn != nil {
+		return p.ValidateProviderSchemasFn(ctx, req)
+	}
+
+	if p.ValidateProviderSchemasResponse != nil {
+		return *p.ValidateProviderSchemasResponse
 	}
 
 	return resp

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -21,6 +21,10 @@ type Client interface {
 	EvaluateResource(context.Context, EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) EvaluationResponse
 	EvaluateProvider(context.Context, EvaluationRequest[*proto.PolicyEvaluateProviderRequest_ProviderMetadata]) EvaluationResponse
 	EvaluateModule(context.Context, EvaluationRequest[*proto.PolicyEvaluateModuleRequest_ModuleMetadata]) EvaluationResponse
+	// ValidateProviderSchemas validates the loaded policies against the run's
+	// provider schemas, so a policy that references an attribute a provider does
+	// not have fails early. Called after Setup, once schemas are resolved.
+	ValidateProviderSchemas(context.Context, ValidateProviderSchemasRequest) ValidateProviderSchemasResponse
 	Stop()
 }
 
@@ -28,6 +32,31 @@ type Client interface {
 type CallbackService interface {
 	RegisterCallbackService(context.Context) (*callback.Server, Diagnostics)
 }
+
+type (
+	// ValidateProviderSchemasRequest carries the provider schemas to validate the
+	// loaded policies against.
+	ValidateProviderSchemasRequest struct {
+		ProviderSchemas []ProviderSchema
+	}
+
+	// ProviderSchema is one provider's schema as cty object types: its
+	// configuration and the object type of each resource and data source it
+	// offers, plus the local names it is known by in configuration.
+	ProviderSchema struct {
+		Type        string
+		LocalNames  []string
+		Config      cty.Type
+		Resources   map[string]cty.Type
+		DataSources map[string]cty.Type
+	}
+
+	// ValidateProviderSchemasResponse carries the diagnostics from validating the
+	// loaded policies against the schemas.
+	ValidateProviderSchemasResponse struct {
+		Diagnostics Diagnostics
+	}
+)
 
 type (
 	SetupResponse struct {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -42,10 +42,10 @@ type (
 
 	// ProviderSchema is one provider's schema as cty object types: its
 	// configuration and the object type of each resource and data source it
-	// offers, plus the local names it is known by in configuration.
+	// offers. Policy-language aliases are resolved by the policy plugin from the
+	// policy configuration; Terraform configuration local names are unrelated.
 	ProviderSchema struct {
 		Type        string
-		LocalNames  []string
 		Config      cty.Type
 		Resources   map[string]cty.Type
 		DataSources map[string]cty.Type

--- a/internal/policy/proto/policy.pb.go
+++ b/internal/policy/proto/policy.pb.go
@@ -752,6 +752,186 @@ func (x *PolicyEvaluateModuleResponse) GetPolicyDetails() []*PolicyEvaluationDet
 	return nil
 }
 
+// ValidateProviderSchemasRequest carries the provider schemas to validate the
+// already-loaded policies against.
+type ValidateProviderSchemasRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ProviderSchemas []*ProviderSchema      `protobuf:"bytes,1,rep,name=provider_schemas,json=providerSchemas,proto3" json:"provider_schemas,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ValidateProviderSchemasRequest) Reset() {
+	*x = ValidateProviderSchemasRequest{}
+	mi := &file_policy_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ValidateProviderSchemasRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ValidateProviderSchemasRequest) ProtoMessage() {}
+
+func (x *ValidateProviderSchemasRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_policy_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ValidateProviderSchemasRequest.ProtoReflect.Descriptor instead.
+func (*ValidateProviderSchemasRequest) Descriptor() ([]byte, []int) {
+	return file_policy_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *ValidateProviderSchemasRequest) GetProviderSchemas() []*ProviderSchema {
+	if x != nil {
+		return x.ProviderSchemas
+	}
+	return nil
+}
+
+// ValidateProviderSchemasResponse returns the diagnostics from validating the
+// loaded policies against the provider schemas — an error for each reference to
+// something a provider does not offer.
+type ValidateProviderSchemasResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Diagnostics   []*Diagnostic          `protobuf:"bytes,1,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ValidateProviderSchemasResponse) Reset() {
+	*x = ValidateProviderSchemasResponse{}
+	mi := &file_policy_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ValidateProviderSchemasResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ValidateProviderSchemasResponse) ProtoMessage() {}
+
+func (x *ValidateProviderSchemasResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_policy_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ValidateProviderSchemasResponse.ProtoReflect.Descriptor instead.
+func (*ValidateProviderSchemasResponse) Descriptor() ([]byte, []int) {
+	return file_policy_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ValidateProviderSchemasResponse) GetDiagnostics() []*Diagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
+// ProviderSchema is one provider's schema: its configuration and the object
+// type of each resource and data source it offers. It lets the plugin check
+// policies structurally without any plan data. Object types are encoded with
+// cty's JSON type encoding (cty/json.MarshalType); an empty encoding means an
+// empty object type.
+type ProviderSchema struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// type is the provider type, e.g. "aws".
+	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	// local_names are the required_providers local names (aliases) that also
+	// refer to this provider, so a provider policy labelled by an alias resolves.
+	LocalNames []string `protobuf:"bytes,2,rep,name=local_names,json=localNames,proto3" json:"local_names,omitempty"`
+	// config is the cty JSON encoding of the provider configuration object type.
+	Config []byte `protobuf:"bytes,3,opt,name=config,proto3" json:"config,omitempty"`
+	// resources maps a resource type to the cty JSON encoding of its object type.
+	Resources map[string][]byte `protobuf:"bytes,4,rep,name=resources,proto3" json:"resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// data_sources maps a data-source type to the cty JSON encoding of its object type.
+	DataSources   map[string][]byte `protobuf:"bytes,5,rep,name=data_sources,json=dataSources,proto3" json:"data_sources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProviderSchema) Reset() {
+	*x = ProviderSchema{}
+	mi := &file_policy_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProviderSchema) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProviderSchema) ProtoMessage() {}
+
+func (x *ProviderSchema) ProtoReflect() protoreflect.Message {
+	mi := &file_policy_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProviderSchema.ProtoReflect.Descriptor instead.
+func (*ProviderSchema) Descriptor() ([]byte, []int) {
+	return file_policy_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ProviderSchema) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *ProviderSchema) GetLocalNames() []string {
+	if x != nil {
+		return x.LocalNames
+	}
+	return nil
+}
+
+func (x *ProviderSchema) GetConfig() []byte {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+func (x *ProviderSchema) GetResources() map[string][]byte {
+	if x != nil {
+		return x.Resources
+	}
+	return nil
+}
+
+func (x *ProviderSchema) GetDataSources() map[string][]byte {
+	if x != nil {
+		return x.DataSources
+	}
+	return nil
+}
+
 // ClientCapabilities are the set of capabilities the client supports.
 // At launch, this is empty as we don't have any backwards or forwards
 // compatibility concerns to worry about.
@@ -763,7 +943,7 @@ type PolicySetupRequest_ClientCapabilities struct {
 
 func (x *PolicySetupRequest_ClientCapabilities) Reset() {
 	*x = PolicySetupRequest_ClientCapabilities{}
-	mi := &file_policy_proto_msgTypes[10]
+	mi := &file_policy_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -775,7 +955,7 @@ func (x *PolicySetupRequest_ClientCapabilities) String() string {
 func (*PolicySetupRequest_ClientCapabilities) ProtoMessage() {}
 
 func (x *PolicySetupRequest_ClientCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[10]
+	mi := &file_policy_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -804,7 +984,7 @@ type PolicySetupRequest_Entitlement struct {
 
 func (x *PolicySetupRequest_Entitlement) Reset() {
 	*x = PolicySetupRequest_Entitlement{}
-	mi := &file_policy_proto_msgTypes[11]
+	mi := &file_policy_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -816,7 +996,7 @@ func (x *PolicySetupRequest_Entitlement) String() string {
 func (*PolicySetupRequest_Entitlement) ProtoMessage() {}
 
 func (x *PolicySetupRequest_Entitlement) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[11]
+	mi := &file_policy_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -863,7 +1043,7 @@ type PolicySetupResponse_TerraformConfiguration struct {
 
 func (x *PolicySetupResponse_TerraformConfiguration) Reset() {
 	*x = PolicySetupResponse_TerraformConfiguration{}
-	mi := &file_policy_proto_msgTypes[12]
+	mi := &file_policy_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -875,7 +1055,7 @@ func (x *PolicySetupResponse_TerraformConfiguration) String() string {
 func (*PolicySetupResponse_TerraformConfiguration) ProtoMessage() {}
 
 func (x *PolicySetupResponse_TerraformConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[12]
+	mi := &file_policy_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -909,7 +1089,7 @@ type PolicySetupResponse_ServerCapabilities struct {
 
 func (x *PolicySetupResponse_ServerCapabilities) Reset() {
 	*x = PolicySetupResponse_ServerCapabilities{}
-	mi := &file_policy_proto_msgTypes[13]
+	mi := &file_policy_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -921,7 +1101,7 @@ func (x *PolicySetupResponse_ServerCapabilities) String() string {
 func (*PolicySetupResponse_ServerCapabilities) ProtoMessage() {}
 
 func (x *PolicySetupResponse_ServerCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[13]
+	mi := &file_policy_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -955,7 +1135,7 @@ type PolicyEvaluateResourceRequest_ResourceMetadata struct {
 
 func (x *PolicyEvaluateResourceRequest_ResourceMetadata) Reset() {
 	*x = PolicyEvaluateResourceRequest_ResourceMetadata{}
-	mi := &file_policy_proto_msgTypes[15]
+	mi := &file_policy_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -967,7 +1147,7 @@ func (x *PolicyEvaluateResourceRequest_ResourceMetadata) String() string {
 func (*PolicyEvaluateResourceRequest_ResourceMetadata) ProtoMessage() {}
 
 func (x *PolicyEvaluateResourceRequest_ResourceMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[15]
+	mi := &file_policy_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1017,7 +1197,7 @@ type PolicyEvaluateProviderRequest_ProviderMetadata struct {
 
 func (x *PolicyEvaluateProviderRequest_ProviderMetadata) Reset() {
 	*x = PolicyEvaluateProviderRequest_ProviderMetadata{}
-	mi := &file_policy_proto_msgTypes[16]
+	mi := &file_policy_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1029,7 +1209,7 @@ func (x *PolicyEvaluateProviderRequest_ProviderMetadata) String() string {
 func (*PolicyEvaluateProviderRequest_ProviderMetadata) ProtoMessage() {}
 
 func (x *PolicyEvaluateProviderRequest_ProviderMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[16]
+	mi := &file_policy_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1090,7 +1270,7 @@ type PolicyEvaluateModuleRequest_ModuleMetadata struct {
 
 func (x *PolicyEvaluateModuleRequest_ModuleMetadata) Reset() {
 	*x = PolicyEvaluateModuleRequest_ModuleMetadata{}
-	mi := &file_policy_proto_msgTypes[17]
+	mi := &file_policy_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1102,7 +1282,7 @@ func (x *PolicyEvaluateModuleRequest_ModuleMetadata) String() string {
 func (*PolicyEvaluateModuleRequest_ModuleMetadata) ProtoMessage() {}
 
 func (x *PolicyEvaluateModuleRequest_ModuleMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[17]
+	mi := &file_policy_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1212,12 +1392,30 @@ const file_policy_proto_rawDesc = "" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\"\x93\x01\n" +
 	"\x1cPolicyEvaluateModuleResponse\x12-\n" +
 	"\x06result\x18\x01 \x01(\x0e2\x15.proto.EvaluateResultR\x06result\x12D\n" +
-	"\x0epolicy_details\x18\x02 \x03(\v2\x1d.proto.PolicyEvaluationDetailR\rpolicyDetails2\xed\x02\n" +
+	"\x0epolicy_details\x18\x02 \x03(\v2\x1d.proto.PolicyEvaluationDetailR\rpolicyDetails\"b\n" +
+	"\x1eValidateProviderSchemasRequest\x12@\n" +
+	"\x10provider_schemas\x18\x01 \x03(\v2\x15.proto.ProviderSchemaR\x0fproviderSchemas\"V\n" +
+	"\x1fValidateProviderSchemasResponse\x123\n" +
+	"\vdiagnostics\x18\x01 \x03(\v2\x11.proto.DiagnosticR\vdiagnostics\"\xea\x02\n" +
+	"\x0eProviderSchema\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1f\n" +
+	"\vlocal_names\x18\x02 \x03(\tR\n" +
+	"localNames\x12\x16\n" +
+	"\x06config\x18\x03 \x01(\fR\x06config\x12B\n" +
+	"\tresources\x18\x04 \x03(\v2$.proto.ProviderSchema.ResourcesEntryR\tresources\x12I\n" +
+	"\fdata_sources\x18\x05 \x03(\v2&.proto.ProviderSchema.DataSourcesEntryR\vdataSources\x1a<\n" +
+	"\x0eResourcesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\x1a>\n" +
+	"\x10DataSourcesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x012\xd9\x03\n" +
 	"\x06Policy\x12@\n" +
 	"\x05Setup\x12\x19.proto.PolicySetupRequest\x1a\x1a.proto.PolicySetupResponse\"\x00\x12a\n" +
 	"\x10EvaluateResource\x12$.proto.PolicyEvaluateResourceRequest\x1a%.proto.PolicyEvaluateResourceResponse\"\x00\x12a\n" +
 	"\x10EvaluateProvider\x12$.proto.PolicyEvaluateProviderRequest\x1a%.proto.PolicyEvaluateProviderResponse\"\x00\x12[\n" +
-	"\x0eEvaluateModule\x12\".proto.PolicyEvaluateModuleRequest\x1a#.proto.PolicyEvaluateModuleResponse\"\x00B4Z2github.com/hashicorp/terraform-policy-plugin/protob\x06proto3"
+	"\x0eEvaluateModule\x12\".proto.PolicyEvaluateModuleRequest\x1a#.proto.PolicyEvaluateModuleResponse\"\x00\x12j\n" +
+	"\x17ValidateProviderSchemas\x12%.proto.ValidateProviderSchemasRequest\x1a&.proto.ValidateProviderSchemasResponse\"\x00B4Z2github.com/hashicorp/terraform-policy-plugin/protob\x06proto3"
 
 var (
 	file_policy_proto_rawDescOnce sync.Once
@@ -1231,7 +1429,7 @@ func file_policy_proto_rawDescGZIP() []byte {
 	return file_policy_proto_rawDescData
 }
 
-var file_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_policy_proto_goTypes = []any{
 	(*PolicySetupRequest)(nil),                         // 0: proto.PolicySetupRequest
 	(*PolicySetupResponse)(nil),                        // 1: proto.PolicySetupResponse
@@ -1243,63 +1441,74 @@ var file_policy_proto_goTypes = []any{
 	(*PolicyEvaluateProviderResponse)(nil),             // 7: proto.PolicyEvaluateProviderResponse
 	(*PolicyEvaluateModuleRequest)(nil),                // 8: proto.PolicyEvaluateModuleRequest
 	(*PolicyEvaluateModuleResponse)(nil),               // 9: proto.PolicyEvaluateModuleResponse
-	(*PolicySetupRequest_ClientCapabilities)(nil),      // 10: proto.PolicySetupRequest.ClientCapabilities
-	(*PolicySetupRequest_Entitlement)(nil),             // 11: proto.PolicySetupRequest.Entitlement
-	(*PolicySetupResponse_TerraformConfiguration)(nil), // 12: proto.PolicySetupResponse.TerraformConfiguration
-	(*PolicySetupResponse_ServerCapabilities)(nil),     // 13: proto.PolicySetupResponse.ServerCapabilities
-	nil, // 14: proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry
-	(*PolicyEvaluateResourceRequest_ResourceMetadata)(nil), // 15: proto.PolicyEvaluateResourceRequest.ResourceMetadata
-	(*PolicyEvaluateProviderRequest_ProviderMetadata)(nil), // 16: proto.PolicyEvaluateProviderRequest.ProviderMetadata
-	(*PolicyEvaluateModuleRequest_ModuleMetadata)(nil),     // 17: proto.PolicyEvaluateModuleRequest.ModuleMetadata
-	(*Diagnostic)(nil),         // 18: proto.Diagnostic
-	(*ResourceAttributes)(nil), // 19: proto.ResourceAttributes
-	(EvaluateResult)(0),        // 20: proto.EvaluateResult
-	(*Range)(nil),              // 21: proto.Range
-	(*Snippet)(nil),            // 22: proto.Snippet
-	(Operation)(0),             // 23: proto.Operation
+	(*ValidateProviderSchemasRequest)(nil),             // 10: proto.ValidateProviderSchemasRequest
+	(*ValidateProviderSchemasResponse)(nil),            // 11: proto.ValidateProviderSchemasResponse
+	(*ProviderSchema)(nil),                             // 12: proto.ProviderSchema
+	(*PolicySetupRequest_ClientCapabilities)(nil),      // 13: proto.PolicySetupRequest.ClientCapabilities
+	(*PolicySetupRequest_Entitlement)(nil),             // 14: proto.PolicySetupRequest.Entitlement
+	(*PolicySetupResponse_TerraformConfiguration)(nil), // 15: proto.PolicySetupResponse.TerraformConfiguration
+	(*PolicySetupResponse_ServerCapabilities)(nil),     // 16: proto.PolicySetupResponse.ServerCapabilities
+	nil, // 17: proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry
+	(*PolicyEvaluateResourceRequest_ResourceMetadata)(nil), // 18: proto.PolicyEvaluateResourceRequest.ResourceMetadata
+	(*PolicyEvaluateProviderRequest_ProviderMetadata)(nil), // 19: proto.PolicyEvaluateProviderRequest.ProviderMetadata
+	(*PolicyEvaluateModuleRequest_ModuleMetadata)(nil),     // 20: proto.PolicyEvaluateModuleRequest.ModuleMetadata
+	nil,                        // 21: proto.ProviderSchema.ResourcesEntry
+	nil,                        // 22: proto.ProviderSchema.DataSourcesEntry
+	(*Diagnostic)(nil),         // 23: proto.Diagnostic
+	(*ResourceAttributes)(nil), // 24: proto.ResourceAttributes
+	(EvaluateResult)(0),        // 25: proto.EvaluateResult
+	(*Range)(nil),              // 26: proto.Range
+	(*Snippet)(nil),            // 27: proto.Snippet
+	(Operation)(0),             // 28: proto.Operation
 }
 var file_policy_proto_depIdxs = []int32{
-	10, // 0: proto.PolicySetupRequest.client_capabilities:type_name -> proto.PolicySetupRequest.ClientCapabilities
-	11, // 1: proto.PolicySetupRequest.entitlement:type_name -> proto.PolicySetupRequest.Entitlement
-	13, // 2: proto.PolicySetupResponse.server_capabilities:type_name -> proto.PolicySetupResponse.ServerCapabilities
-	18, // 3: proto.PolicySetupResponse.diagnostics:type_name -> proto.Diagnostic
-	19, // 4: proto.PolicyEvaluateResourceRequest.attrs:type_name -> proto.ResourceAttributes
-	15, // 5: proto.PolicyEvaluateResourceRequest.metadata:type_name -> proto.PolicyEvaluateResourceRequest.ResourceMetadata
-	19, // 6: proto.PolicyEvaluateResourceRequest.prior_attrs:type_name -> proto.ResourceAttributes
-	20, // 7: proto.PolicyEvaluationDetail.result:type_name -> proto.EvaluateResult
-	21, // 8: proto.PolicyEvaluationDetail.def_range:type_name -> proto.Range
+	13, // 0: proto.PolicySetupRequest.client_capabilities:type_name -> proto.PolicySetupRequest.ClientCapabilities
+	14, // 1: proto.PolicySetupRequest.entitlement:type_name -> proto.PolicySetupRequest.Entitlement
+	16, // 2: proto.PolicySetupResponse.server_capabilities:type_name -> proto.PolicySetupResponse.ServerCapabilities
+	23, // 3: proto.PolicySetupResponse.diagnostics:type_name -> proto.Diagnostic
+	24, // 4: proto.PolicyEvaluateResourceRequest.attrs:type_name -> proto.ResourceAttributes
+	18, // 5: proto.PolicyEvaluateResourceRequest.metadata:type_name -> proto.PolicyEvaluateResourceRequest.ResourceMetadata
+	24, // 6: proto.PolicyEvaluateResourceRequest.prior_attrs:type_name -> proto.ResourceAttributes
+	25, // 7: proto.PolicyEvaluationDetail.result:type_name -> proto.EvaluateResult
+	26, // 8: proto.PolicyEvaluationDetail.def_range:type_name -> proto.Range
 	4,  // 9: proto.PolicyEvaluationDetail.enforce_results:type_name -> proto.EnforceBlockResult
-	18, // 10: proto.PolicyEvaluationDetail.diagnostics:type_name -> proto.Diagnostic
-	20, // 11: proto.EnforceBlockResult.result:type_name -> proto.EvaluateResult
-	21, // 12: proto.EnforceBlockResult.range:type_name -> proto.Range
-	18, // 13: proto.EnforceBlockResult.diagnostics:type_name -> proto.Diagnostic
-	22, // 14: proto.EnforceBlockResult.snippet:type_name -> proto.Snippet
-	20, // 15: proto.PolicyEvaluateResourceResponse.result:type_name -> proto.EvaluateResult
+	23, // 10: proto.PolicyEvaluationDetail.diagnostics:type_name -> proto.Diagnostic
+	25, // 11: proto.EnforceBlockResult.result:type_name -> proto.EvaluateResult
+	26, // 12: proto.EnforceBlockResult.range:type_name -> proto.Range
+	23, // 13: proto.EnforceBlockResult.diagnostics:type_name -> proto.Diagnostic
+	27, // 14: proto.EnforceBlockResult.snippet:type_name -> proto.Snippet
+	25, // 15: proto.PolicyEvaluateResourceResponse.result:type_name -> proto.EvaluateResult
 	3,  // 16: proto.PolicyEvaluateResourceResponse.policy_details:type_name -> proto.PolicyEvaluationDetail
-	19, // 17: proto.PolicyEvaluateProviderRequest.attrs:type_name -> proto.ResourceAttributes
-	16, // 18: proto.PolicyEvaluateProviderRequest.metadata:type_name -> proto.PolicyEvaluateProviderRequest.ProviderMetadata
-	20, // 19: proto.PolicyEvaluateProviderResponse.result:type_name -> proto.EvaluateResult
+	24, // 17: proto.PolicyEvaluateProviderRequest.attrs:type_name -> proto.ResourceAttributes
+	19, // 18: proto.PolicyEvaluateProviderRequest.metadata:type_name -> proto.PolicyEvaluateProviderRequest.ProviderMetadata
+	25, // 19: proto.PolicyEvaluateProviderResponse.result:type_name -> proto.EvaluateResult
 	3,  // 20: proto.PolicyEvaluateProviderResponse.policy_details:type_name -> proto.PolicyEvaluationDetail
-	19, // 21: proto.PolicyEvaluateModuleRequest.attrs:type_name -> proto.ResourceAttributes
-	17, // 22: proto.PolicyEvaluateModuleRequest.metadata:type_name -> proto.PolicyEvaluateModuleRequest.ModuleMetadata
-	20, // 23: proto.PolicyEvaluateModuleResponse.result:type_name -> proto.EvaluateResult
+	24, // 21: proto.PolicyEvaluateModuleRequest.attrs:type_name -> proto.ResourceAttributes
+	20, // 22: proto.PolicyEvaluateModuleRequest.metadata:type_name -> proto.PolicyEvaluateModuleRequest.ModuleMetadata
+	25, // 23: proto.PolicyEvaluateModuleResponse.result:type_name -> proto.EvaluateResult
 	3,  // 24: proto.PolicyEvaluateModuleResponse.policy_details:type_name -> proto.PolicyEvaluationDetail
-	14, // 25: proto.PolicySetupResponse.ServerCapabilities.configurations:type_name -> proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry
-	12, // 26: proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry.value:type_name -> proto.PolicySetupResponse.TerraformConfiguration
-	23, // 27: proto.PolicyEvaluateResourceRequest.ResourceMetadata.operation:type_name -> proto.Operation
-	0,  // 28: proto.Policy.Setup:input_type -> proto.PolicySetupRequest
-	2,  // 29: proto.Policy.EvaluateResource:input_type -> proto.PolicyEvaluateResourceRequest
-	6,  // 30: proto.Policy.EvaluateProvider:input_type -> proto.PolicyEvaluateProviderRequest
-	8,  // 31: proto.Policy.EvaluateModule:input_type -> proto.PolicyEvaluateModuleRequest
-	1,  // 32: proto.Policy.Setup:output_type -> proto.PolicySetupResponse
-	5,  // 33: proto.Policy.EvaluateResource:output_type -> proto.PolicyEvaluateResourceResponse
-	7,  // 34: proto.Policy.EvaluateProvider:output_type -> proto.PolicyEvaluateProviderResponse
-	9,  // 35: proto.Policy.EvaluateModule:output_type -> proto.PolicyEvaluateModuleResponse
-	32, // [32:36] is the sub-list for method output_type
-	28, // [28:32] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	12, // 25: proto.ValidateProviderSchemasRequest.provider_schemas:type_name -> proto.ProviderSchema
+	23, // 26: proto.ValidateProviderSchemasResponse.diagnostics:type_name -> proto.Diagnostic
+	21, // 27: proto.ProviderSchema.resources:type_name -> proto.ProviderSchema.ResourcesEntry
+	22, // 28: proto.ProviderSchema.data_sources:type_name -> proto.ProviderSchema.DataSourcesEntry
+	17, // 29: proto.PolicySetupResponse.ServerCapabilities.configurations:type_name -> proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry
+	15, // 30: proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry.value:type_name -> proto.PolicySetupResponse.TerraformConfiguration
+	28, // 31: proto.PolicyEvaluateResourceRequest.ResourceMetadata.operation:type_name -> proto.Operation
+	0,  // 32: proto.Policy.Setup:input_type -> proto.PolicySetupRequest
+	2,  // 33: proto.Policy.EvaluateResource:input_type -> proto.PolicyEvaluateResourceRequest
+	6,  // 34: proto.Policy.EvaluateProvider:input_type -> proto.PolicyEvaluateProviderRequest
+	8,  // 35: proto.Policy.EvaluateModule:input_type -> proto.PolicyEvaluateModuleRequest
+	10, // 36: proto.Policy.ValidateProviderSchemas:input_type -> proto.ValidateProviderSchemasRequest
+	1,  // 37: proto.Policy.Setup:output_type -> proto.PolicySetupResponse
+	5,  // 38: proto.Policy.EvaluateResource:output_type -> proto.PolicyEvaluateResourceResponse
+	7,  // 39: proto.Policy.EvaluateProvider:output_type -> proto.PolicyEvaluateProviderResponse
+	9,  // 40: proto.Policy.EvaluateModule:output_type -> proto.PolicyEvaluateModuleResponse
+	11, // 41: proto.Policy.ValidateProviderSchemas:output_type -> proto.ValidateProviderSchemasResponse
+	37, // [37:42] is the sub-list for method output_type
+	32, // [32:37] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_policy_proto_init() }
@@ -1315,7 +1524,7 @@ func file_policy_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_policy_proto_rawDesc), len(file_policy_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   18,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/policy/proto/policy.proto
+++ b/internal/policy/proto/policy.proto
@@ -27,6 +27,12 @@ service Policy {
   // EvaluateModule evaluates a module configuration against the store modules.
   // This method is specifically designed for module-level policy evaluation.
   rpc EvaluateModule(PolicyEvaluateModuleRequest) returns (PolicyEvaluateModuleResponse) {}
+  // ValidateProviderSchemas validates the loaded policies against the given
+  // provider schemas and returns any structural errors. The client calls this
+  // after Setup, once it has resolved the provider schemas for the run, so a
+  // policy referencing an attribute a provider does not have fails early rather
+  // than partway through evaluation.
+  rpc ValidateProviderSchemas(ValidateProviderSchemasRequest) returns (ValidateProviderSchemasResponse) {}
 }
 
 // SetupRequest is the message body for the Setup RPC.
@@ -233,4 +239,40 @@ message PolicyEvaluateModuleResponse {
 
   // PolicyDetails contains detailed information about each policy evaluation
   repeated PolicyEvaluationDetail policy_details = 2;
+}
+
+// ValidateProviderSchemasRequest carries the provider schemas to validate the
+// already-loaded policies against.
+message ValidateProviderSchemasRequest {
+  repeated ProviderSchema provider_schemas = 1;
+}
+
+// ValidateProviderSchemasResponse returns the diagnostics from validating the
+// loaded policies against the provider schemas — an error for each reference to
+// something a provider does not offer.
+message ValidateProviderSchemasResponse {
+  repeated Diagnostic diagnostics = 1;
+}
+
+// ProviderSchema is one provider's schema: its configuration and the object
+// type of each resource and data source it offers. It lets the plugin check
+// policies structurally without any plan data. Object types are encoded with
+// cty's JSON type encoding (cty/json.MarshalType); an empty encoding means an
+// empty object type.
+message ProviderSchema {
+  // type is the provider type, e.g. "aws".
+  string type = 1;
+
+  // local_names are the required_providers local names (aliases) that also
+  // refer to this provider, so a provider policy labelled by an alias resolves.
+  repeated string local_names = 2;
+
+  // config is the cty JSON encoding of the provider configuration object type.
+  bytes config = 3;
+
+  // resources maps a resource type to the cty JSON encoding of its object type.
+  map<string, bytes> resources = 4;
+
+  // data_sources maps a data-source type to the cty JSON encoding of its object type.
+  map<string, bytes> data_sources = 5;
 }

--- a/internal/policy/proto/policy_grpc.pb.go
+++ b/internal/policy/proto/policy_grpc.pb.go
@@ -22,10 +22,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Policy_Setup_FullMethodName            = "/proto.Policy/Setup"
-	Policy_EvaluateResource_FullMethodName = "/proto.Policy/EvaluateResource"
-	Policy_EvaluateProvider_FullMethodName = "/proto.Policy/EvaluateProvider"
-	Policy_EvaluateModule_FullMethodName   = "/proto.Policy/EvaluateModule"
+	Policy_Setup_FullMethodName                   = "/proto.Policy/Setup"
+	Policy_EvaluateResource_FullMethodName        = "/proto.Policy/EvaluateResource"
+	Policy_EvaluateProvider_FullMethodName        = "/proto.Policy/EvaluateProvider"
+	Policy_EvaluateModule_FullMethodName          = "/proto.Policy/EvaluateModule"
+	Policy_ValidateProviderSchemas_FullMethodName = "/proto.Policy/ValidateProviderSchemas"
 )
 
 // PolicyClient is the client API for Policy service.
@@ -49,6 +50,12 @@ type PolicyClient interface {
 	// EvaluateModule evaluates a module configuration against the store modules.
 	// This method is specifically designed for module-level policy evaluation.
 	EvaluateModule(ctx context.Context, in *PolicyEvaluateModuleRequest, opts ...grpc.CallOption) (*PolicyEvaluateModuleResponse, error)
+	// ValidateProviderSchemas validates the loaded policies against the given
+	// provider schemas and returns any structural errors. The client calls this
+	// after Setup, once it has resolved the provider schemas for the run, so a
+	// policy referencing an attribute a provider does not have fails early rather
+	// than partway through evaluation.
+	ValidateProviderSchemas(ctx context.Context, in *ValidateProviderSchemasRequest, opts ...grpc.CallOption) (*ValidateProviderSchemasResponse, error)
 }
 
 type policyClient struct {
@@ -99,6 +106,16 @@ func (c *policyClient) EvaluateModule(ctx context.Context, in *PolicyEvaluateMod
 	return out, nil
 }
 
+func (c *policyClient) ValidateProviderSchemas(ctx context.Context, in *ValidateProviderSchemasRequest, opts ...grpc.CallOption) (*ValidateProviderSchemasResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ValidateProviderSchemasResponse)
+	err := c.cc.Invoke(ctx, Policy_ValidateProviderSchemas_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PolicyServer is the server API for Policy service.
 // All implementations must embed UnimplementedPolicyServer
 // for forward compatibility.
@@ -120,6 +137,12 @@ type PolicyServer interface {
 	// EvaluateModule evaluates a module configuration against the store modules.
 	// This method is specifically designed for module-level policy evaluation.
 	EvaluateModule(context.Context, *PolicyEvaluateModuleRequest) (*PolicyEvaluateModuleResponse, error)
+	// ValidateProviderSchemas validates the loaded policies against the given
+	// provider schemas and returns any structural errors. The client calls this
+	// after Setup, once it has resolved the provider schemas for the run, so a
+	// policy referencing an attribute a provider does not have fails early rather
+	// than partway through evaluation.
+	ValidateProviderSchemas(context.Context, *ValidateProviderSchemasRequest) (*ValidateProviderSchemasResponse, error)
 	mustEmbedUnimplementedPolicyServer()
 }
 
@@ -141,6 +164,9 @@ func (UnimplementedPolicyServer) EvaluateProvider(context.Context, *PolicyEvalua
 }
 func (UnimplementedPolicyServer) EvaluateModule(context.Context, *PolicyEvaluateModuleRequest) (*PolicyEvaluateModuleResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EvaluateModule not implemented")
+}
+func (UnimplementedPolicyServer) ValidateProviderSchemas(context.Context, *ValidateProviderSchemasRequest) (*ValidateProviderSchemasResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ValidateProviderSchemas not implemented")
 }
 func (UnimplementedPolicyServer) mustEmbedUnimplementedPolicyServer() {}
 func (UnimplementedPolicyServer) testEmbeddedByValue()                {}
@@ -235,6 +261,24 @@ func _Policy_EvaluateModule_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Policy_ValidateProviderSchemas_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ValidateProviderSchemasRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PolicyServer).ValidateProviderSchemas(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Policy_ValidateProviderSchemas_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PolicyServer).ValidateProviderSchemas(ctx, req.(*ValidateProviderSchemasRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Policy_ServiceDesc is the grpc.ServiceDesc for Policy service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -257,6 +301,10 @@ var Policy_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "EvaluateModule",
 			Handler:    _Policy_EvaluateModule_Handler,
+		},
+		{
+			MethodName: "ValidateProviderSchemas",
+			Handler:    _Policy_ValidateProviderSchemas_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -4,7 +4,6 @@
 package terraform
 
 import (
-	"context"
 	"fmt"
 	"log"
 
@@ -199,7 +198,7 @@ func (c *Context) ApplyAndEval(plan *plans.Plan, config *configs.Config, opts *A
 	// walk evaluates them, so a policy that references an attribute a provider
 	// does not have fails here rather than partway through applying.
 	if opts.PolicyClient != nil {
-		diags = diags.Append(validateProviderSchemas(context.Background(), opts.PolicyClient, config, schemas))
+		diags = diags.Append(validateProviderSchemas(c.runContext, opts.PolicyClient, schemas))
 		if diags.HasErrors() {
 			return nil, nil, diags
 		}

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -4,6 +4,7 @@
 package terraform
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -192,6 +193,16 @@ func (c *Context) ApplyAndEval(plan *plans.Plan, config *configs.Config, opts *A
 	diags = diags.Append(schemaDiags)
 	if diags.HasErrors() {
 		return nil, nil, diags
+	}
+
+	// Validate the loaded policies against the run's provider schemas before the
+	// walk evaluates them, so a policy that references an attribute a provider
+	// does not have fails here rather than partway through applying.
+	if opts.PolicyClient != nil {
+		diags = diags.Append(validateProviderSchemas(context.Background(), opts.PolicyClient, config, schemas))
+		if diags.HasErrors() {
+			return nil, nil, diags
+		}
 	}
 
 	changes, err := plan.Changes.Decode(schemas)

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -5,7 +5,6 @@ package terraform
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"log"
 	"sort"
@@ -809,7 +808,7 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 		if diags.HasErrors() {
 			return nil, nil, diags
 		}
-		diags = diags.Append(validateProviderSchemas(context.Background(), opts.PolicyClient, config, schemas))
+		diags = diags.Append(validateProviderSchemas(c.runContext, opts.PolicyClient, schemas))
 		if diags.HasErrors() {
 			return nil, nil, diags
 		}

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -5,6 +5,7 @@ package terraform
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"sort"
@@ -797,6 +798,22 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 	// Initialize the results table to validate provider function calls.
 	// Hold reference to this so we can store the table data in the plan file.
 	funcResults := lang.NewFunctionResultsTable(nil)
+
+	// Validate the loaded policies against the run's provider schemas before the
+	// walk evaluates them, so a policy that references an attribute a provider
+	// does not have fails here rather than partway through planning. Schemas are
+	// already loaded at this point (a cache hit after graph build).
+	if opts.PolicyClient != nil {
+		schemas, schemaDiags := c.Schemas(config, prevRunState)
+		diags = diags.Append(schemaDiags)
+		if diags.HasErrors() {
+			return nil, nil, diags
+		}
+		diags = diags.Append(validateProviderSchemas(context.Background(), opts.PolicyClient, config, schemas))
+		if diags.HasErrors() {
+			return nil, nil, diags
+		}
+	}
 
 	walker, walkDiags := c.walk(graph, walkOp, &graphWalkOpts{
 		Config:                     config,

--- a/internal/terraform/context_plan_policy_schema_test.go
+++ b/internal/terraform/context_plan_policy_schema_test.go
@@ -5,7 +5,10 @@ package terraform
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/zclconf/go-cty/cty"
 
@@ -103,4 +106,137 @@ func TestContext2Plan_PolicyValidateProviderSchemas(t *testing.T) {
 			t.Error("resource policy evaluation must not run after an early schema-validation failure")
 		}
 	})
+
+	t.Run("an apply validation error blocks provider operations", func(t *testing.T) {
+		plan, planDiags := newContext().Plan(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
+		tfdiags.AssertNoDiagnostics(t, planDiags)
+		provider.ApplyResourceChangeCalled = false
+
+		policyClient := policy.NewTestMockClient(t)
+		calls := 0
+		policyClient.ValidateProviderSchemasFn = func(context.Context, policy.ValidateProviderSchemasRequest) policy.ValidateProviderSchemasResponse {
+			calls++
+			return policy.ValidateProviderSchemasResponse{Diagnostics: policy.Diagnostics{
+				policy.NewErrorDiagnostic("Invalid policy", "references an attribute the provider does not have", policy.SetupErrorResult),
+			}}
+		}
+		_, diags := newContext().Apply(plan, m, &ApplyOpts{PolicyClient: policyClient})
+		if !diags.HasErrors() {
+			t.Fatal("expected the schema-validation error to block apply")
+		}
+		if calls != 1 {
+			t.Fatalf("ValidateProviderSchemas called %d times during apply, want once", calls)
+		}
+		if provider.ApplyResourceChangeCalled {
+			t.Error("provider apply must not run after an early schema-validation failure")
+		}
+		if policyClient.EvaluateCalled || policyClient.EvaluateProviderCalled || policyClient.EvaluateModuleCalled {
+			t.Error("policy evaluation must not run after an early schema-validation failure")
+		}
+	})
+}
+
+func TestValidateProviderSchemasRequest(t *testing.T) {
+	testAddr := addrs.MustParseProviderSourceString("example/test")
+	otherAddr := addrs.MustParseProviderSourceString("example/other")
+	schemas := &Schemas{Providers: map[addrs.Provider]providers.ProviderSchema{
+		testAddr: {
+			Provider: providers.Schema{},
+			ResourceTypes: map[string]providers.Schema{
+				"test_empty": {},
+			},
+			DataSources: map[string]providers.Schema{
+				"test_data": {},
+			},
+		},
+		otherAddr: {Provider: providers.Schema{Body: &configschema.Block{}}},
+	}}
+	client := policy.NewTestMockClient(t)
+
+	diags := validateProviderSchemas(t.Context(), client, schemas)
+	tfdiags.AssertNoDiagnostics(t, diags)
+	got := client.ValidateProviderSchemasRequest.ProviderSchemas
+	if len(got) != 2 {
+		t.Fatalf("got %d provider schemas, want 2", len(got))
+	}
+	if types := []string{got[0].Type, got[1].Type}; !slices.Equal(types, []string{"other", "test"}) {
+		t.Fatalf("provider schemas are not ordered deterministically: %v", types)
+	}
+	if !got[1].Config.Equals(cty.EmptyObject) || !got[1].Resources["test_empty"].Equals(cty.EmptyObject) || !got[1].DataSources["test_data"].Equals(cty.EmptyObject) {
+		t.Fatalf("nil schema bodies were not preserved as empty objects: %#v", got[1])
+	}
+}
+
+func TestValidateProviderSchemasTypeCollision(t *testing.T) {
+	first := addrs.MustParseProviderSourceString("example/test")
+	second := addrs.MustParseProviderSourceString("other/test")
+	client := policy.NewTestMockClient(t)
+	schemas := &Schemas{Providers: map[addrs.Provider]providers.ProviderSchema{
+		first:  {Provider: providers.Schema{Body: &configschema.Block{}}},
+		second: {Provider: providers.Schema{Body: &configschema.Block{}}},
+	}}
+
+	diags := validateProviderSchemas(t.Context(), client, schemas)
+	if !diags.HasErrors() {
+		t.Fatal("expected colliding provider types to fail before the RPC")
+	}
+	if client.ValidateProviderSchemasCalled {
+		t.Fatal("ambiguous provider schemas must not be sent to the policy plugin")
+	}
+	detail := diags.Err().Error()
+	if !strings.Contains(detail, first.ForDisplay()) || !strings.Contains(detail, second.ForDisplay()) {
+		t.Fatalf("collision diagnostic does not identify both providers: %s", detail)
+	}
+}
+
+func TestContext2Plan_PolicySchemaValidationCancellation(t *testing.T) {
+	m := testModuleInline(t, map[string]string{"main.tf": `resource "test_resource" "test" {}`})
+	providerAddr := addrs.NewDefaultProvider("test")
+	provider := testProvider("test")
+	provider.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&providerSchema{
+		Provider:      &configschema.Block{},
+		ResourceTypes: map[string]*configschema.Block{"test_resource": {}},
+	})
+	c := testContext2(t, &ContextOpts{Providers: map[addrs.Provider]providers.Factory{
+		providerAddr: testProviderFuncFixed(provider),
+	}})
+	policyClient := policy.NewTestMockClient(t)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	policyClient.ValidateProviderSchemasFn = func(ctx context.Context, req policy.ValidateProviderSchemasRequest) policy.ValidateProviderSchemasResponse {
+		close(entered)
+		select {
+		case <-ctx.Done():
+		case <-release:
+		}
+		return policy.ValidateProviderSchemasResponse{}
+	}
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		c.Plan(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode, PolicyClient: policyClient})
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("schema validation RPC was not entered")
+	}
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		c.Stop()
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		close(release)
+		<-stopped
+		t.Fatal("schema validation did not receive run context cancellation")
+	}
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("plan did not finish after cancellation")
+	}
 }

--- a/internal/terraform/context_plan_policy_schema_test.go
+++ b/internal/terraform/context_plan_policy_schema_test.go
@@ -1,0 +1,106 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/policy"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// The plan flow sends the run's provider schemas to the policy plugin before the
+// walk, and a schema-validation error blocks the run before any policy is
+// evaluated against a real resource.
+func TestContext2Plan_PolicyValidateProviderSchemas(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+			terraform {
+				required_providers {
+					test = {
+						source  = "hashicorp/test"
+						version = "1.0.0"
+					}
+				}
+			}
+
+			resource "test_resource" "test" {
+				value = "x"
+			}
+		`,
+	})
+
+	providerAddr := addrs.NewDefaultProvider("test")
+	provider := testProvider("test")
+	provider.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&providerSchema{
+		Provider: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"region": {Type: cty.String, Optional: true},
+			},
+		},
+		ResourceTypes: map[string]*configschema.Block{
+			"test_resource": {
+				Attributes: map[string]*configschema.Attribute{
+					"id":    {Type: cty.String, Computed: true},
+					"value": {Type: cty.String, Optional: true},
+				},
+			},
+		},
+	})
+
+	newContext := func() *Context {
+		return testContext2(t, &ContextOpts{
+			Providers: map[addrs.Provider]providers.Factory{
+				providerAddr: testProviderFuncFixed(provider),
+			},
+		})
+	}
+
+	t.Run("schemas are sent and a clean run proceeds", func(t *testing.T) {
+		policyClient := policy.NewTestMockClient(t)
+		_, diags := newContext().Plan(m, states.NewState(), &PlanOpts{
+			Mode:         plans.NormalMode,
+			PolicyClient: policyClient,
+		})
+		tfdiags.AssertNoDiagnostics(t, diags)
+
+		if !policyClient.ValidateProviderSchemasCalled {
+			t.Fatal("expected ValidateProviderSchemas to be called before the walk")
+		}
+		got := policyClient.ValidateProviderSchemasRequest.ProviderSchemas
+		if len(got) != 1 || got[0].Type != "test" {
+			t.Fatalf("expected the test provider schema, got %+v", got)
+		}
+		if _, ok := got[0].Resources["test_resource"]; !ok {
+			t.Errorf("expected test_resource in the sent schema, got %v", got[0].Resources)
+		}
+	})
+
+	t.Run("a validation error blocks the run early", func(t *testing.T) {
+		policyClient := policy.NewTestMockClient(t)
+		policyClient.ValidateProviderSchemasFn = func(context.Context, policy.ValidateProviderSchemasRequest) policy.ValidateProviderSchemasResponse {
+			return policy.ValidateProviderSchemasResponse{Diagnostics: policy.Diagnostics{
+				policy.NewErrorDiagnostic("Invalid policy", "references an attribute the provider does not have", policy.SetupErrorResult),
+			}}
+		}
+		_, diags := newContext().Plan(m, states.NewState(), &PlanOpts{
+			Mode:         plans.NormalMode,
+			PolicyClient: policyClient,
+		})
+		if !diags.HasErrors() {
+			t.Fatal("expected the schema-validation error to block the plan")
+		}
+		if policyClient.EvaluateCalled {
+			t.Error("resource policy evaluation must not run after an early schema-validation failure")
+		}
+	})
+}

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func evaluatePolicies(ctx EvalContext, target addrs.AbsResourceInstance, config *configs.Resource, attrs, priorAttrs cty.Value, meta *proto.PolicyEvaluateResourceRequest_ResourceMetadata, callbacks callback.Functions) policy.EvaluationResponse {
@@ -221,4 +222,61 @@ func resourceMatchesFilter(addr addrs.ConfigResource, schema *configschema.Block
 	}
 
 	return true, false
+}
+
+// validateProviderSchemas asks the policy plugin to validate the loaded policies
+// against the run's provider schemas, so a policy that references an attribute a
+// provider does not have fails early rather than partway through evaluation. It
+// is a no-op when policy enforcement is off or there are no schemas. Any error
+// diagnostics it returns should block the run.
+func validateProviderSchemas(ctx context.Context, client policy.Client, config *configs.Config, schemas *Schemas) tfdiags.Diagnostics {
+	if client == nil || schemas == nil || config == nil {
+		return nil
+	}
+
+	var req policy.ValidateProviderSchemasRequest
+	for providerAddr, providerSchema := range schemas.Providers {
+		req.ProviderSchemas = append(req.ProviderSchemas, policy.ProviderSchema{
+			Type:        providerAddr.Type,
+			LocalNames:  providerLocalNames(config, providerAddr),
+			Config:      providerSchema.Provider.Body.ImpliedType(),
+			Resources:   blockImpliedTypes(providerSchema.ResourceTypes),
+			DataSources: blockImpliedTypes(providerSchema.DataSources),
+		})
+	}
+	if len(req.ProviderSchemas) == 0 {
+		return nil
+	}
+
+	return client.ValidateProviderSchemas(ctx, req).Diagnostics.AsTerraformDiags()
+}
+
+// blockImpliedTypes maps each schema's config block to its implied cty object
+// type, the form the policy engine validates against.
+func blockImpliedTypes(schemas map[string]providers.Schema) map[string]cty.Type {
+	if len(schemas) == 0 {
+		return nil
+	}
+	out := make(map[string]cty.Type, len(schemas))
+	for name, schema := range schemas {
+		if schema.Body == nil {
+			continue
+		}
+		out[name] = schema.Body.ImpliedType()
+	}
+	return out
+}
+
+// providerLocalNames returns the configuration's local name for a provider when
+// it differs from the provider type, so a provider policy labelled by an alias
+// resolves. The provider type is already carried separately.
+func providerLocalNames(config *configs.Config, provider addrs.Provider) []string {
+	if config.Module == nil {
+		return nil
+	}
+	local := config.Module.LocalNameForProvider(provider)
+	if local == "" || local == provider.Type {
+		return nil
+	}
+	return []string{local}
 }

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"iter"
 	"log"
+	"sort"
 
 	"github.com/zclconf/go-cty/cty"
 	"go.opentelemetry.io/otel/attribute"
@@ -229,20 +230,44 @@ func resourceMatchesFilter(addr addrs.ConfigResource, schema *configschema.Block
 // provider does not have fails early rather than partway through evaluation. It
 // is a no-op when policy enforcement is off or there are no schemas. Any error
 // diagnostics it returns should block the run.
-func validateProviderSchemas(ctx context.Context, client policy.Client, config *configs.Config, schemas *Schemas) tfdiags.Diagnostics {
-	if client == nil || schemas == nil || config == nil {
+func validateProviderSchemas(ctx context.Context, client policy.Client, schemas *Schemas) tfdiags.Diagnostics {
+	if client == nil || schemas == nil {
 		return nil
 	}
 
+	providerAddrs := make([]addrs.Provider, 0, len(schemas.Providers))
+	for providerAddr := range schemas.Providers {
+		providerAddrs = append(providerAddrs, providerAddr)
+	}
+	sort.Slice(providerAddrs, func(i, j int) bool {
+		if providerAddrs[i].Type != providerAddrs[j].Type {
+			return providerAddrs[i].Type < providerAddrs[j].Type
+		}
+		return providerAddrs[i].ForDisplay() < providerAddrs[j].ForDisplay()
+	})
+
+	var diags tfdiags.Diagnostics
 	var req policy.ValidateProviderSchemasRequest
-	for providerAddr, providerSchema := range schemas.Providers {
+	for i, providerAddr := range providerAddrs {
+		if i > 0 && providerAddrs[i-1].Type == providerAddr.Type {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Ambiguous provider schemas for policy validation",
+				fmt.Sprintf("The provider type %q identifies both %s and %s. Terraform policies identify providers by type, so these schemas cannot be validated safely in the same run.", providerAddr.Type, providerAddrs[i-1].ForDisplay(), providerAddr.ForDisplay()),
+			))
+			continue
+		}
+
+		providerSchema := schemas.Providers[providerAddr]
 		req.ProviderSchemas = append(req.ProviderSchemas, policy.ProviderSchema{
 			Type:        providerAddr.Type,
-			LocalNames:  providerLocalNames(config, providerAddr),
-			Config:      providerSchema.Provider.Body.ImpliedType(),
+			Config:      blockImpliedType(providerSchema.Provider.Body),
 			Resources:   blockImpliedTypes(providerSchema.ResourceTypes),
 			DataSources: blockImpliedTypes(providerSchema.DataSources),
 		})
+	}
+	if diags.HasErrors() {
+		return diags
 	}
 	if len(req.ProviderSchemas) == 0 {
 		return nil
@@ -259,24 +284,14 @@ func blockImpliedTypes(schemas map[string]providers.Schema) map[string]cty.Type 
 	}
 	out := make(map[string]cty.Type, len(schemas))
 	for name, schema := range schemas {
-		if schema.Body == nil {
-			continue
-		}
-		out[name] = schema.Body.ImpliedType()
+		out[name] = blockImpliedType(schema.Body)
 	}
 	return out
 }
 
-// providerLocalNames returns the configuration's local name for a provider when
-// it differs from the provider type, so a provider policy labelled by an alias
-// resolves. The provider type is already carried separately.
-func providerLocalNames(config *configs.Config, provider addrs.Provider) []string {
-	if config.Module == nil {
-		return nil
+func blockImpliedType(block *configschema.Block) cty.Type {
+	if block == nil {
+		return cty.EmptyObject
 	}
-	local := config.Module.LocalNameForProvider(provider)
-	if local == "" || local == provider.Type {
-		return nil
-	}
-	return []string{local}
+	return block.ImpliedType()
 }


### PR DESCRIPTION
Validate policies against the run's provider schemas **before** the plan/apply walk, so a policy that references an attribute a provider does not have fails **early** rather than partway through evaluation.

This is the terraform (host) side of the policy-plugin schema-validation feature. It only affects experimental policy runs (it's a no-op unless a policy client is attached).

## What it does
When `opts.PolicyClient` is set, after `loadSchemas` builds the run's schemas and before the graph walk, terraform enumerates `schemarepo.Schemas`, encodes each provider's config / resource / data-source `configschema.Block.ImpliedType()` as a cty JSON type, and calls the plugin's new `ValidateProviderSchemas` RPC. The returned diagnostics are appended to the run diagnostics; an error blocks the run before any policy is evaluated against a real resource.

Why before the walk (not at `Setup`): `Setup` runs at the command layer and also serves `init` — before any `Context` or schemas exist. Schemas only exist inside `terraform.Context`, so the schema push is a separate post-`Setup` call. Insertion points:
- `context_plan.go` `planWalk` — loads schemas via `c.Schemas` (a cache hit after graph build) then validates, before `c.walk`.
- `context_apply.go` `ApplyAndEval` — reuses the `schemas` already loaded before the walk.

## Changes
- `internal/policy/proto/policy.proto`: new `ValidateProviderSchemas` RPC + `ProviderSchema` / request / response messages (mirrors the plugin's proto for wire compatibility). Regenerated with `make protobuf`.
- `internal/policy`: `ValidateProviderSchemas` added to the `Client` interface, with the client implementation (cty JSON type encoding), host-side request/response types, and the `MockClient`.
- `internal/terraform`: a `validateProviderSchemas` helper (enumerates `schemarepo.Schemas` → the request; local names via `Module.LocalNameForProvider`) wired into `planWalk` and `ApplyAndEval`; a plan test covering both the "schemas sent, clean run" and "validation error blocks the run early" paths.

## Dependencies
- Requires the plugin RPC: **hashicorp/terraform-policy-plugin#82** (which in turn depends on the shared engine, **hashicorp/terraform-policy-core#95**).

## Target
- Experimental (`AllowExperimentalFeatures`); no behavior change for non-policy runs.
