### PR TITLE
PSS: Suppress interactive confirmation of state migration when `state migrate` is run with `-force-copy`.

### DIFF
--- a/internal/command/arguments/state_migrate.go
+++ b/internal/command/arguments/state_migrate.go
@@ -19,6 +19,7 @@ type StateMigrate struct {
 	SourceLockFilePath      string
 	DestinationLockFilePath string
 	Upgrade                 bool
+	ForceCopy               bool
 	InputEnabled            bool
 
 	ViewType ViewType
@@ -34,12 +35,13 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 	}
 
 	var srcLockFilePath, dstLockFilePath string
-	var upgrade, inputEnabled bool
+	var upgrade, inputEnabled, forceCopy bool
 	cmdFlags := defaultFlagSet("state migrate")
 	cmdFlags.StringVar(&srcLockFilePath, "source-provider-lock-file", "", "Path to a provider lock file for the source provider.")
 	cmdFlags.StringVar(&dstLockFilePath, "destination-provider-lock-file", "", "Path to a provider lock file for the destination provider.")
 	cmdFlags.BoolVar(&upgrade, "upgrade", false, "Trigger upgrade of the provider.")
 	cmdFlags.BoolVar(&inputEnabled, "input", true, "Enable input for interactive prompts.")
+	cmdFlags.BoolVar(&forceCopy, "force-copy", false, "Suppress and auto-approve prompts about copying state data. Enables state migrations when interactive prompts are disabled via -input=false.")
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -52,6 +54,7 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 
 	migrate.Upgrade = upgrade
 	migrate.InputEnabled = inputEnabled
+	migrate.ForceCopy = forceCopy
 
 	if inputEnabled {
 		// lock file paths are only to be used in automation

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -86,9 +86,16 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 
 	// When configuring the source and destination backends,
 	// we prepare options for the migration action.
+	//
+	// If input is disabled, we "force" the migration. This stops the migration logic shared
+	// with the init command failing when it discovers that input is disabled.
+	// In "terraform init" the force field is controlled by the -force-copy flag.
+	// In contrast, "terraform state migrate" assumes that if input is disabled the user wants to force the migration.
 	migrateOpts := &backendMigrateOpts{
 		ViewType: args.ViewType,
+		force:    args.ForceCopy,
 	}
+	c.Meta.forceInitCopy = args.ForceCopy // backendMigrateOpts.force is overwritten with this value, so we also need to set it.
 
 	// Load the source backend
 	var source string

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -796,6 +796,140 @@ provider "registry.terraform.io/hashicorp/test2" {
 	})
 }
 
+func TestStateMigrate_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T) {
+	t.Run("both providers already in lock file, user not prompted for provider approval", func(t *testing.T) {
+		wd := tempWorkingDirFixture(t, "state-store-changed/provider-used")
+		t.Chdir(wd.RootModuleDir())
+
+		// Replace dep lock file in fixtures so that both providers are already in the dep lock file.
+		lockFileContents := `# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/test" {
+  version = "1.2.3"
+}
+
+provider "registry.terraform.io/hashicorp/test2" {
+  version = "3.2.1"
+  hashes = [
+    "h1:gv1gFnIZulslzchnaoyMJ5KoPvoRgVvSGb3tVS803iw=",
+  ]
+}`
+		if err := os.WriteFile(filepath.Join(wd.RootModuleDir(), dependencyLockFilename), []byte(lockFileContents), 0644); err != nil {
+			t.Fatalf("unable to overwrite dependency lock file as part of test setup: %s", err)
+		}
+
+		b, err := os.ReadFile("source-pss.tfstate")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// hashicorp/test - source
+		sourcePssSchema := map[string]providers.Schema{
+			"test_src": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+		}
+		sourceProvider := mockPluggableStateStorageProvider(sourcePssSchema)
+		sourceProvider.MockStates = testing_provider.MockStateBytes{
+			"test_src": map[string][]byte{"default": []byte(b)},
+		}
+		// hashicorp/test2 - destination
+		destinationPssSchema := map[string]providers.Schema{
+			"test2_store": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+		}
+		destinationProvider := mockPluggableStateStorageProvider(destinationPssSchema)
+		destinationProvider.MockStates = testing_provider.MockStateBytes{
+			"test2_store": map[string][]byte{}, // No existing state in the destination
+		}
+
+		// Supplying providers via HTTP triggers security features.
+		providerSource := newMockProviderSourceUsingTestHttpServer(t, map[string][]string{
+			"hashicorp/test":  {"1.2.3"},
+			"hashicorp/test2": {"3.2.1"},
+		})
+
+		ui := cli.NewMockUi()
+		view, done := testView(t)
+		c := &StateMigrateCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				WorkingDir:                wd,
+				AllowExperimentalFeatures: true,
+				testingOverrides: &testingOverrides{
+					Providers: map[addrs.Provider]providers.Factory{
+						addrs.NewDefaultProvider("test"):  providers.FactoryFixed(sourceProvider),
+						addrs.NewDefaultProvider("test2"): providers.FactoryFixed(destinationProvider),
+					},
+				},
+				ProviderSource: providerSource,
+			},
+		}
+
+		args := []string{
+			"-input=false", // Simulate running in automation where input is disabled
+			"-force-copy",  // Suppress prompts to perform the migration
+			"-no-color",
+		}
+		code := c.Run(args)
+		out := done(t)
+		if code != 0 {
+			t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
+		}
+
+		expectedMsg := []string{
+			"Initializing provider plugin for state store \"test_src\"...\n- Reusing previous version of hashicorp/test from the dependency lock file",
+			"Initializing provider plugin for state store \"test2_store\"...\n- Reusing previous version of hashicorp/test2 from the dependency lock file",
+			`Migrating state from state store "test_src" (hashicorp/test) to state store "test2_store" (hashicorp/test2)...`,
+		}
+		for _, expectedMsg := range expectedMsg {
+			if !strings.Contains(out.Stdout(), expectedMsg) {
+				t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+			}
+		}
+		notExpectedMsg := []string{
+			"The state store provider was approved automatically", // shouldn't be there as no explicit CLI flag used.
+		}
+		for _, notExpected := range notExpectedMsg {
+			if strings.Contains(out.Stdout(), notExpected) {
+				t.Fatalf("did not expect output %q, but got %q", notExpected, out.Stdout())
+			}
+		}
+
+		// Assert the state is migrated successfully to the destination state store by inspecting the mock.
+		b, err = destinationProvider.MockStates.Read("test2_store", "default")
+		if err != nil {
+			t.Fatalf("unable to find migrated state in mock provider: %s", err)
+		}
+		s, err := statefile.Read(bytes.NewBuffer(b))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, ok := s.State.RootOutputValues["test"]
+		if !ok {
+			t.Fatalf("unable to find test output in migrated state")
+		}
+
+		// Assert the dependency lock file is unchanged, as both providers were already in the lock file.
+		lockFilePath := filepath.Join(wd.RootModuleDir(), dependencyLockFilename)
+		lockFileBytes, err := os.ReadFile(lockFilePath)
+		if err != nil {
+			t.Fatalf("unable to read dependency lock file: %s", err)
+		}
+
+		if diff := cmp.Diff(lockFileContents, string(lockFileBytes)); diff != "" {
+			t.Fatalf("unexpected dependency lock file contents, diff:\n%s", diff)
+		}
+	})
+}
+
 func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-backend")
 	t.Chdir(wd.RootModuleDir())


### PR DESCRIPTION
In `init` users are expected to supply the `-force-copy` to suppress interactive prompts raised by the `Meta.backendMigrateState` method. State migrations can be performed in automation via `init`, but `-input=false -force-copy` flags are needed.

In `state migrate` we have to decide how to handle the prompts suppressed by `-force-copy` in the init command. Due to approving a migration being analogous to approving a plan created during an apply command, which requires `-input=false -auto-approve` to run in automation, we're going to add a `-force-copy` flag to the state migrate command.

This may be overly cautious, but if there are complaints about the flag being excessive we could decide to change the default value from false to true in future.

This PR is blocking https://github.com/hashicorp/terraform/pull/38813

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
