### PR TITLE
Return a clean error from log/pow when the result is NaN

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260716-111133.yaml
+++ b/.changes/v1.16/BUG FIXES-20260716-111133.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`log` and `pow` now return a clean error instead of leaking an internal panic when the result is NaN (e.g. `log(-1, 10)`, `pow(-2, 0.5)`)'
+time: 2026-07-16T08:11:33.000000Z
+custom:
+  Issue: "38883"

--- a/internal/lang/funcs/number.go
+++ b/internal/lang/funcs/number.go
@@ -4,6 +4,7 @@
 package funcs
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 
@@ -37,7 +38,11 @@ var LogFunc = function.New(&function.Spec{
 			return cty.UnknownVal(cty.String), err
 		}
 
-		return cty.NumberFloatVal(math.Log(num) / math.Log(base)), nil
+		result := math.Log(num) / math.Log(base)
+		if math.IsNaN(result) {
+			return cty.UnknownVal(cty.Number), fmt.Errorf("log(%v, %v) produces an undefined (NaN) result", num, base)
+		}
+		return cty.NumberFloatVal(result), nil
 	},
 })
 
@@ -66,7 +71,11 @@ var PowFunc = function.New(&function.Spec{
 			return cty.UnknownVal(cty.String), err
 		}
 
-		return cty.NumberFloatVal(math.Pow(num, power)), nil
+		result := math.Pow(num, power)
+		if math.IsNaN(result) {
+			return cty.UnknownVal(cty.Number), fmt.Errorf("pow(%v, %v) produces an undefined (NaN) result", num, power)
+		}
+		return cty.NumberFloatVal(result), nil
 	},
 })
 

--- a/internal/lang/funcs/number_test.go
+++ b/internal/lang/funcs/number_test.go
@@ -43,6 +43,20 @@ func TestLog(t *testing.T) {
 			cty.NumberFloatVal(-0),
 			false,
 		},
+		// NaN results (e.g. log of a negative number, or base 1 giving 0/0)
+		// must surface a clean error, not leak an internal big.Float panic.
+		{
+			cty.NumberFloatVal(-1),
+			cty.NumberFloatVal(10),
+			cty.NilVal,
+			true,
+		},
+		{
+			cty.NumberFloatVal(1),
+			cty.NumberFloatVal(1),
+			cty.NilVal,
+			true,
+		},
 	}
 
 	for _, test := range tests {
@@ -120,6 +134,14 @@ func TestPow(t *testing.T) {
 			cty.NumberFloatVal(2),
 			cty.NumberFloatVal(0),
 			false,
+		},
+		// A NaN result (e.g. a negative base raised to a fractional power)
+		// must surface a clean error, not leak an internal big.Float panic.
+		{
+			cty.NumberFloatVal(-2),
+			cty.NumberFloatVal(0.5),
+			cty.NilVal,
+			true,
 		},
 	}
 

--- a/internal/lang/funcs/number_test.go
+++ b/internal/lang/funcs/number_test.go
@@ -135,6 +135,13 @@ func TestPow(t *testing.T) {
 			cty.NumberFloatVal(0),
 			false,
 		},
+		// Infinity is representable by cty and must not be treated like NaN.
+		{
+			cty.NumberFloatVal(10),
+			cty.NumberFloatVal(1e10),
+			cty.PositiveInfinity,
+			false,
+		},
 		// A NaN result (e.g. a negative base raised to a fractional power)
 		// must surface a clean error, not leak an internal big.Float panic.
 		{


### PR DESCRIPTION
### Summary

`log()` and `pow()` leak an internal Go panic (including a full stack trace) to the user when their result is `NaN`.

`math.Log` / `math.Pow` return `NaN` for several ordinary inputs, but `cty.NumberFloatVal` is backed by `big.Float`, which panics (`Float.SetFloat64(NaN)`) when handed a `NaN`. The panic escapes `LogFunc.Impl` / `PowFunc.Impl` and is surfaced by the cty function framework as:

```
panic in function implementation: Float.SetFloat64(NaN)
<full goroutine stack trace>
```

instead of a clean diagnostic. Reachable with plain scalar inputs any config can write:

- `log(-1, 10)` — logarithm of a negative number
- `log(1, 1)` — base 1 → `0/0`
- `pow(-2, 0.5)` — a negative base raised to a fractional power

Fixes #38888.

### Fix

Guard the result with `math.IsNaN` and return a normal error, mirroring the existing `big.ErrNaN` handling already present in `SumFunc` (`collection.go`). `±Inf` results (e.g. `log(0, 10)`, `pow(0, -1)`) are unaffected — `big.Float` supports infinities and the existing `log(0, 10) == -Inf` test still passes.

### Testing

Added NaN cases to the existing `TestLog` / `TestPow` tables (they assert a clean error rather than a leaked panic). The new cases fail without the fix and pass with it; the full `internal/lang/funcs` package stays green.
