### PR TITLE
PSS:  Change argument parsing so it's possible to track when a lockfile is supplied via flags by the user

### DIFF
--- a/internal/command/arguments/state_migrate.go
+++ b/internal/command/arguments/state_migrate.go
@@ -82,11 +82,7 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 		}
 	}
 
-	if srcLockFilePath == "" {
-		// setting default here instead of in the flag definition
-		// to make check above free of side effects
-		srcLockFilePath = lockFileName
-	} else {
+	if srcLockFilePath != "" {
 		// If a file is supplied via flag, it must exist.
 		if _, err := os.Stat(srcLockFilePath); err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
@@ -95,13 +91,20 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 				fmt.Sprintf("%q: %s", srcLockFilePath, err.Error()),
 			))
 		}
+
+		srcFilename := filepath.Base(srcLockFilePath)
+		if srcFilename != lockFileName {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid source-provider-lock-file",
+				fmt.Sprintf("Expected lock file name to be %s, got: %s", lockFileName, srcFilename),
+			))
+		}
+
+		migrate.SourceLockFilePath = srcLockFilePath
 	}
 
-	if dstLockFilePath == "" {
-		// setting default here instead of in the flag definition
-		// to make check above free of side effects
-		dstLockFilePath = lockFileName
-	} else {
+	if dstLockFilePath != "" {
 		// If a file is supplied via flag, it must exist.
 		if _, err := os.Stat(dstLockFilePath); err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
@@ -110,27 +113,15 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 				fmt.Sprintf("%q: %s", dstLockFilePath, err.Error()),
 			))
 		}
-	}
 
-	srcFilename := filepath.Base(srcLockFilePath)
-	if srcFilename != lockFileName {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid source-provider-lock-file",
-			fmt.Sprintf("Expected lock file name to be %s, got: %s", lockFileName, srcFilename),
-		))
-	} else {
-		migrate.SourceLockFilePath = srcLockFilePath
-	}
-
-	dstFilename := filepath.Base(dstLockFilePath)
-	if dstFilename != lockFileName {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid destination-provider-lock-file",
-			fmt.Sprintf("Expected lock file name to be %s, got: %s", lockFileName, dstFilename),
-		))
-	} else {
+		dstFilename := filepath.Base(dstLockFilePath)
+		if dstFilename != lockFileName {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid destination-provider-lock-file",
+				fmt.Sprintf("Expected lock file name to be %s, got: %s", lockFileName, dstFilename),
+			))
+		}
 		migrate.DestinationLockFilePath = dstLockFilePath
 	}
 

--- a/internal/command/arguments/state_migrate_test.go
+++ b/internal/command/arguments/state_migrate_test.go
@@ -35,8 +35,8 @@ func TestStateMigrateArgs_valid(t *testing.T) {
 		{
 			rawArgs: []string{""},
 			expectedArgs: &StateMigrate{
-				SourceLockFilePath:      ".terraform.lock.hcl",
-				DestinationLockFilePath: ".terraform.lock.hcl",
+				SourceLockFilePath:      "",
+				DestinationLockFilePath: "",
 				Upgrade:                 false,
 				InputEnabled:            true,
 				ViewType:                ViewHuman,
@@ -95,8 +95,8 @@ func TestStateMigrateArgs_invalid(t *testing.T) {
 		{
 			rawArgs: []string{"-input=false", "-source-provider-lock-file", invalidLockFilePath},
 			expectedArgs: &StateMigrate{
-				SourceLockFilePath:      "",
-				DestinationLockFilePath: ".terraform.lock.hcl",
+				SourceLockFilePath:      invalidLockFilePath,
+				DestinationLockFilePath: "",
 				Upgrade:                 false,
 				InputEnabled:            false,
 				ViewType:                ViewHuman,
@@ -112,8 +112,8 @@ func TestStateMigrateArgs_invalid(t *testing.T) {
 		{
 			rawArgs: []string{"-input=false", "-destination-provider-lock-file", invalidLockFilePath},
 			expectedArgs: &StateMigrate{
-				SourceLockFilePath:      ".terraform.lock.hcl",
-				DestinationLockFilePath: "",
+				SourceLockFilePath:      "",
+				DestinationLockFilePath: invalidLockFilePath,
 				Upgrade:                 false,
 				InputEnabled:            false,
 				ViewType:                ViewHuman,
@@ -133,7 +133,7 @@ func TestStateMigrateArgs_invalid(t *testing.T) {
 			},
 			expectedArgs: &StateMigrate{
 				SourceLockFilePath:      userLockFilePath,
-				DestinationLockFilePath: "",
+				DestinationLockFilePath: invalidLockFilePath,
 				Upgrade:                 false,
 				InputEnabled:            true,
 				ViewType:                ViewHuman,
@@ -162,8 +162,8 @@ func TestStateMigrateArgs_invalid(t *testing.T) {
 				"-json",
 			},
 			expectedArgs: &StateMigrate{
-				SourceLockFilePath:      ".terraform.lock.hcl",
-				DestinationLockFilePath: ".terraform.lock.hcl",
+				SourceLockFilePath:      "",
+				DestinationLockFilePath: "",
 				Upgrade:                 false,
 				InputEnabled:            true,
 				ViewType:                ViewJSON,

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -114,7 +114,13 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			smi.StateStore.ProviderAddr.ForDisplay())
 
 		// Load any pre-existing source provider lock file.
-		srcLocks, srcLockDiags := c.readLockedDependenciesFromPath(args.SourceLockFilePath)
+		var lockfilePath string
+		if args.SourceLockFilePath != "" {
+			lockfilePath = args.SourceLockFilePath
+		} else {
+			lockfilePath = dependencyLockFilename // default
+		}
+		srcLocks, srcLockDiags := c.readLockedDependenciesFromPath(lockfilePath)
 		diags = diags.Append(srcLockDiags)
 		if srcLockDiags.HasErrors() {
 			view.Diagnostics(diags)
@@ -191,7 +197,13 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		}
 
 		// Load any pre-existing destination provider lock file.
-		dstLocks, dstLockDiags := c.readLockedDependenciesFromPath(args.DestinationLockFilePath)
+		var lockfilePath string
+		if args.DestinationLockFilePath != "" {
+			lockfilePath = args.DestinationLockFilePath
+		} else {
+			lockfilePath = dependencyLockFilename // default
+		}
+		dstLocks, dstLockDiags := c.readLockedDependenciesFromPath(lockfilePath)
 		diags = diags.Append(dstLockDiags)
 		if dstLockDiags.HasErrors() {
 			view.Diagnostics(diags)


### PR DESCRIPTION
(This PR is part of decomposing https://github.com/hashicorp/terraform/pull/38813)

The `handleSafeProviderInstallAction` method needs to know when a user provided a lock file path via CLI flags; if the user has intentionally supplied a non-default lock file then we want to display feedback showing it impacted provider installation. We don't want to log "Provider was approved automatically" every time that an `init` reuses a pre-existing lock file as that would be noisy.

The problem is detecting when the lock file path was user supplied. Currently for `init` detection like this:

https://github.com/hashicorp/terraform/blob/c9b1db248b66bc154ec8d63ad1fed40afe117cd4/internal/command/meta_backend.go#L3114-L3118

is sufficient because the parameter only has a value if the user provides the `-state-provider-lock-file` flag.

HOWEVER, in the `state migrate` command we set values for the `-source-provider-lock-file` and `-destination-provider-lock-file` always. If a user supplied the flags then the values are user supplied values, if not we set the value to the default lock file:

https://github.com/hashicorp/terraform/blob/c9b1db248b66bc154ec8d63ad1fed40afe117cd4/internal/command/arguments/state_migrate.go#L81-L94

This means that the `state migrate` command doesn't know if the value it's receiving is a user provided one or a default one. When PSS security features are added to the `state migrate` command the `handleSafeProviderInstallAction` method will always receive a non-empty `flagLockfilePath` parameter and will always show 'provider approved automatically'.

This PR makes the `state migrate` command resemble the `init` command by letting the flag's value remain an empty string if the user hasn't supplied it. 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
