### PR TITLE
cmd/modules: restore hierarchical keys in `terraform modules -json` output

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260718-072526.yaml
+++ b/.changes/v1.16/BUG FIXES-20260718-072526.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'modules: Fix `terraform modules -json` reporting a flat key for nested modules, making it impossible to tell which parent directory the module resolves to'
+time: 2026-07-18T07:25:26.000000+00:00
+custom:
+    Issue: "38890"

--- a/internal/command/modules_test.go
+++ b/internal/command/modules_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	backendCloud "github.com/hashicorp/terraform/internal/cloud"
-	"github.com/hashicorp/terraform/internal/moduleref"
 )
 
 func TestModules_noJsonFlag(t *testing.T) {
@@ -150,7 +149,7 @@ func TestModules_fullCmd_unreferencedEntries(t *testing.T) {
 		t.Fatalf("Got a non-zero exit code: %d\n", code)
 	}
 	output := done(t).All()
-	compareJSONOutput(t, output, expectedOutputJSON)
+	compareJSONOutput(t, output, expectedOutputJSON_unreferencedEntries)
 }
 
 func TestModules_uninstalledModules(t *testing.T) {
@@ -312,8 +311,21 @@ Modules declared by configuration:
 	})
 }
 
+// jsonModuleRecord and jsonManifest mirror the shape produced by
+// flattenManifest, which is not the same shape as moduleref.Manifest.
+type jsonModuleRecord struct {
+	Key     string `json:"key"`
+	Source  string `json:"source"`
+	Version string `json:"version"`
+}
+
+type jsonManifest struct {
+	FormatVersion string             `json:"format_version"`
+	Modules       []jsonModuleRecord `json:"modules"`
+}
+
 func compareJSONOutput(t *testing.T, got string, want string) {
-	var expected, actual moduleref.Manifest
+	var expected, actual jsonManifest
 
 	if err := json.Unmarshal([]byte(got), &actual); err != nil {
 		t.Fatalf("Failed to unmarshal actual JSON: %v", err)
@@ -323,11 +335,11 @@ func compareJSONOutput(t *testing.T, got string, want string) {
 		t.Fatalf("Failed to unmarshal expected JSON: %v", err)
 	}
 
-	sort.Slice(actual.Records, func(i, j int) bool {
-		return actual.Records[i].Key < actual.Records[j].Key
+	sort.Slice(actual.Modules, func(i, j int) bool {
+		return actual.Modules[i].Key < actual.Modules[j].Key
 	})
-	sort.Slice(expected.Records, func(i, j int) bool {
-		return expected.Records[i].Key < expected.Records[j].Key
+	sort.Slice(expected.Modules, func(i, j int) bool {
+		return expected.Modules[i].Key < expected.Modules[j].Key
 	})
 
 	if !reflect.DeepEqual(expected, actual) {
@@ -335,4 +347,6 @@ func compareJSONOutput(t *testing.T, got string, want string) {
 	}
 }
 
-var expectedOutputJSON = `{"format_version":"1.0","modules":[{"key":"test","source":"./mods/test","version":""},{"key":"test2","source":"./test2","version":""},{"key":"test3","source":"./test3","version":""},{"key":"other","source":"./mods/other","version":""}]}`
+var expectedOutputJSON = `{"format_version":"1.0","modules":[{"key":"test","source":"./mods/test","version":""},{"key":"test.test2","source":"./test2","version":""},{"key":"test.test2.test3","source":"./test3","version":""},{"key":"other","source":"./mods/other","version":""}]}`
+
+var expectedOutputJSON_unreferencedEntries = `{"format_version":"1.0","modules":[{"key":"child","source":"./child","version":""},{"key":"count_child","source":"./child","version":""}]}`

--- a/internal/command/views/modules.go
+++ b/internal/command/views/modules.go
@@ -100,31 +100,41 @@ func (v *ModulesJSON) Display(manifest moduleref.Manifest) int {
 // a flattened format with the VersionConstraints and Children attributes
 // ommited for the purposes of the json format of the modules command
 func flattenManifest(m moduleref.Manifest) map[string]interface{} {
-	var flatten func(records []*moduleref.Record)
+	var flatten func(records []*moduleref.Record, keyPrefix string)
 	var recordList []map[string]string
-	flatten = func(records []*moduleref.Record) {
+	flatten = func(records []*moduleref.Record, keyPrefix string) {
 		for _, record := range records {
+			// Key is only unique to a record's siblings, so it must be
+			// qualified with the keys of its ancestors to form a key that
+			// uniquely identifies the module's position in the tree, and
+			// disambiguates it from other modules sharing the same local
+			// name at a different nesting level.
+			key := record.Key
+			if keyPrefix != "" {
+				key = keyPrefix + "." + key
+			}
+
 			if record.Version != nil {
 				recordList = append(recordList, map[string]string{
-					"key":     record.Key,
+					"key":     key,
 					"source":  record.Source.String(),
 					"version": record.Version.String(),
 				})
 			} else {
 				recordList = append(recordList, map[string]string{
-					"key":     record.Key,
+					"key":     key,
 					"source":  record.Source.String(),
 					"version": "",
 				})
 			}
 
 			if len(record.Children) > 0 {
-				flatten(record.Children)
+				flatten(record.Children, key)
 			}
 		}
 	}
 
-	flatten(m.Records)
+	flatten(m.Records, "")
 	ret := map[string]interface{}{
 		"format_version": m.FormatVersion,
 		"modules":        recordList,


### PR DESCRIPTION
## Summary

`terraform modules -json` regressed between v1.10.5 and v1.11.0+: the key for a nested local module used to be hierarchical (e.g. `my_app.something_random`), but is now flattened to just the module's local name (e.g. `something_random`). `source` is still reported relative to the module's immediate parent, so with a flat key there is no way to determine which directory a nested module actually resolves to from the JSON output alone.

Root cause: `flattenManifest` in `internal/command/views/modules.go` walks the module reference tree (built by `internal/moduleref`) and reused each node's local `Key` as-is instead of qualifying it with its ancestors' keys, which is what the pre-1.11 flat internal manifest key effectively did.

## Fix

`flattenManifest` now threads the accumulated parent key through the recursion and joins it with each record's local key using `.`, matching the 1.10.x key format.

I also fixed `compareJSONOutput` in `internal/command/modules_test.go`: it was unmarshaling the JSON output (a `{"key":..,"source":..,"version":..}` list under `"modules"`) into `moduleref.Manifest`, whose fields have no matching JSON tags (`FormatVersion`/`Records` vs. `format_version`/`modules`). Both sides of the comparison silently decoded to their zero value, so the test always passed regardless of what `flattenManifest` produced. That's why this regression escaped the existing `-json` tests. I replaced it with a small struct that mirrors the actual output shape, and updated `TestModules_fullCmd`'s expected JSON to the corrected hierarchical keys. `TestModules_fullCmd_unreferencedEntries` was asserting against the wrong fixture's expected output entirely (a leftover from sharing the `expectedOutputJSON` var across fixtures); it now has its own expected JSON matching its actual fixture (`child`/`count_child`).

Fixes #38872

## Test plan

- `go test ./internal/command/... -run 'TestModules'` — all pass, including the corrected `TestModules_fullCmd` (asserts hierarchical keys `test`, `test.test2`, `test.test2.test3`, `other`) and `TestModules_fullCmd_unreferencedEntries`.
- `go test ./internal/moduleref/...` — pass.
- `go build ./...` — succeeds.