### PR TITLE
command/jsonprovider: expose provider_meta schema in providers schema -json output

### DIFF
--- a/.changes/v1.16/ENHANCEMENTS-20260718-215851.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260718-215851.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'command/jsonprovider: `terraform providers schema -json` now exposes the `provider_meta` schema as a sibling of `provider`'
+time: 2026-07-18T21:58:51.000000+05:30
+custom:
+    Issue: "38891"

--- a/internal/command/e2etest/providers_schema_test.go
+++ b/internal/command/e2etest/providers_schema_test.go
@@ -75,6 +75,12 @@ func TestProvidersSchema(t *testing.T) {
                     "description_kind": "plain"
                 }
             },
+            "provider_meta": {
+                "version": 0,
+                "block": {
+                    "description_kind": "plain"
+                }
+            },
             "resource_schemas": {
                 "simple_resource": {
                     "version": 0,
@@ -167,6 +173,12 @@ func TestProvidersSchema(t *testing.T) {
                 "version": 0,
                 "block": {
                     "description": "This is terraform-provider-simple v6",
+                    "description_kind": "plain"
+                }
+            },
+            "provider_meta": {
+                "version": 0,
+                "block": {
                     "description_kind": "plain"
                 }
             },

--- a/internal/command/jsonprovider/provider.go
+++ b/internal/command/jsonprovider/provider.go
@@ -24,6 +24,7 @@ type Providers struct {
 
 type Provider struct {
 	Provider                 *Schema                                    `json:"provider,omitempty"`
+	ProviderMeta             *Schema                                    `json:"provider_meta,omitempty"`
 	ResourceSchemas          map[string]*Schema                         `json:"resource_schemas,omitempty"`
 	DataSourceSchemas        map[string]*Schema                         `json:"data_source_schemas,omitempty"`
 	EphemeralResourceSchemas map[string]*Schema                         `json:"ephemeral_resource_schemas,omitempty"`
@@ -64,6 +65,7 @@ func Marshal(s *terraform.Schemas) ([]byte, error) {
 func marshalProvider(tps providers.ProviderSchema) *Provider {
 	p := &Provider{
 		Provider:                 marshalSchema(tps.Provider),
+		ProviderMeta:             marshalProviderMetaSchema(tps.ProviderMeta),
 		ResourceSchemas:          marshalSchemas(tps.ResourceTypes),
 		DataSourceSchemas:        marshalSchemas(tps.DataSources),
 		EphemeralResourceSchemas: marshalSchemas(tps.EphemeralResourceTypes),

--- a/internal/command/jsonprovider/provider_test.go
+++ b/internal/command/jsonprovider/provider_test.go
@@ -51,6 +51,18 @@ func TestMarshalProvider(t *testing.T) {
 						DescriptionKind: "plain",
 					},
 				},
+				ProviderMeta: &Schema{
+					Block: &Block{
+						Attributes: map[string]*Attribute{
+							"user_agent": {
+								AttributeType:   json.RawMessage(`["list","string"]`),
+								Optional:        true,
+								DescriptionKind: "plain",
+							},
+						},
+						DescriptionKind: "plain",
+					},
+				},
 				ResourceSchemas: map[string]*Schema{
 					"test_instance": {
 						Version: 42,
@@ -272,6 +284,13 @@ func testProvider() providers.ProviderSchema {
 			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"region": {Type: cty.String, Required: true},
+				},
+			},
+		},
+		ProviderMeta: providers.Schema{
+			Body: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"user_agent": {Type: cty.List(cty.String), Optional: true},
 				},
 			},
 		},

--- a/internal/command/jsonprovider/schema.go
+++ b/internal/command/jsonprovider/schema.go
@@ -26,6 +26,17 @@ func marshalSchema(schema providers.Schema) *Schema {
 	return &ret
 }
 
+// marshalProviderMetaSchema is like marshalSchema, but returns nil when the
+// provider defines no provider_meta schema so that the "provider_meta" key
+// is omitted entirely from the JSON output, rather than rendered as an
+// empty schema.
+func marshalProviderMetaSchema(schema providers.Schema) *Schema {
+	if schema.Body == nil {
+		return nil
+	}
+	return marshalSchema(schema)
+}
+
 func marshalSchemas(schemas map[string]providers.Schema) map[string]*Schema {
 	if schemas == nil {
 		return map[string]*Schema{}

--- a/internal/command/jsonprovider/schema_test.go
+++ b/internal/command/jsonprovider/schema_test.go
@@ -4,10 +4,13 @@
 package jsonprovider
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
 )
 
@@ -46,5 +49,47 @@ func TestMarshalSchema(t *testing.T) {
 		if !cmp.Equal(got, test.Want) {
 			t.Fatalf("wrong result:\n %v\n", cmp.Diff(got, test.Want))
 		}
+	}
+}
+
+func TestMarshalProviderMetaSchema(t *testing.T) {
+	tests := map[string]struct {
+		Input providers.Schema
+		Want  *Schema
+	}{
+		"no_provider_meta_schema": {
+			providers.Schema{},
+			nil,
+		},
+		"provider_meta_schema_defined": {
+			providers.Schema{
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"user_agent": {Type: cty.List(cty.String), Optional: true},
+					},
+				},
+			},
+			&Schema{
+				Block: &Block{
+					Attributes: map[string]*Attribute{
+						"user_agent": {
+							AttributeType:   json.RawMessage(`["list","string"]`),
+							Optional:        true,
+							DescriptionKind: "plain",
+						},
+					},
+					DescriptionKind: "plain",
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := marshalProviderMetaSchema(test.Input)
+			if !cmp.Equal(got, test.Want) {
+				t.Fatalf("wrong result:\n %v\n", cmp.Diff(got, test.Want))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`terraform providers schema -json` omits the `provider_meta` schema for each provider, even though the plugin protocol (`GetProviderSchema.Response`) already returns it as a sibling of `provider`. Consumers of the JSON output, for example provider SDK codegen tooling, have no way to discover the shape of a provider's `provider_meta` block because this field is invisible to that tooling.

This is a real gap: `hashicorp/terraform-provider-aws#45464` added a `provider_meta "aws" { user_agent = [...] }` argument, and `terraform-aws-modules/terraform-aws-rds#615` is a real module consuming it, both currently unable to generate typed bindings for it.

## Changes

* Add a `ProviderMeta` field to `jsonprovider.Provider`, serialized as `provider_meta`, as a sibling of the existing `provider` key.
* Add `marshalProviderMetaSchema`, which mirrors `marshalSchema` but omits the key entirely when a provider defines no `provider_meta` schema, matching how other optional schema sections already behave.
* Update `TestMarshalProvider` and add `TestMarshalProviderMetaSchema` covering both the omitted and populated cases.
* Update the e2e `TestProvidersSchema` golden output, since the test provider does define a (empty) `provider_meta` schema.

Fixes #38824

## Test plan

* `go build ./...`
* `go test ./internal/command/jsonprovider/...`
* `go test ./internal/command/...` (includes the `e2etest` package, whose golden output was updated for the new field)

All commands were run locally and passed.