### PR TITLE
fix: Remove the `@timestamp` field from a golden reference, if it's included, before comparison.

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1424,8 +1424,9 @@ func checkGoldenReferenceStr(t *testing.T, output *terminal.TestOutput, want str
 		index := i + 1
 		var wantMap map[string]interface{}
 		if err := json.Unmarshal([]byte(line), &wantMap); err != nil {
-			t.Errorf("failed to unmarshal want line %d: %s\n%s", index, err, gotLines[index])
+			t.Errorf("failed to unmarshal want line %d: %s\n%s", index, err, wantLines[index])
 		}
+		delete(wantMap, "@timestamp") // If the test fixture includes timestamps ignore and don't compare them, since they will always differ
 		wantLineMaps = append(wantLineMaps, wantMap)
 	}
 	if diff := cmp.Diff(wantLineMaps, gotLineMaps); diff != "" {


### PR DESCRIPTION
Until now, an undocumented requirement of comparing golden references is that timestamps should be removed from each log line in the fixture. Now those can be left in the fixture and be ignored.

This is similar to how we currently handle the Terraform version log line; that log line is expected in the golden reference file but is totally ignored when comparing via these helpers.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->
N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
