### PR TITLE
Update `terraform stacks` command host resolution to include local credentials file

### DIFF
--- a/.changes/v1.16/ENHANCEMENTS-20260720-195952.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260720-195952.yaml
@@ -1,0 +1,7 @@
+kind: ENHANCEMENTS
+body: The `terraform stacks` command now automatically infers the target hostname
+  from the local credentials file (`credentials.tfrc.json`) when neither `TF_STACKS_HOSTNAME`
+  nor `TF_CLOUD_HOSTNAME` is set
+time: 2026-07-20T19:59:52.000000-04:00
+custom:
+  Issue: "34724"

--- a/.changes/v1.16/ENHANCEMENTS-20260720-195952.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260720-195952.yaml
@@ -4,4 +4,4 @@ body: The `terraform stacks` command now automatically infers the target hostnam
   nor `TF_CLOUD_HOSTNAME` is set
 time: 2026-07-20T19:59:52.000000-04:00
 custom:
-  Issue: "34724"
+  Issue: "38896"

--- a/internal/command/cliconfig/cliconfig.go
+++ b/internal/command/cliconfig/cliconfig.go
@@ -125,7 +125,7 @@ func LoadConfig() (*Config, tfdiags.Diagnostics) {
 	// being set as an intention to ignore the default set of CLI config
 	// files because we're doing something special, like running Terraform
 	// in automation with a locally-customized configuration.
-	if cliConfigFileOverride() == "" {
+	if CLIConfigFileOverride() == "" {
 		if configDir, err := ConfigDir(); err == nil {
 			if info, err := os.Stat(configDir); err == nil && info.IsDir() {
 				dirConfig, dirDiags := loadConfigDir(configDir)
@@ -403,7 +403,7 @@ func cliConfigFile() (string, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	mustExist := true
 
-	configFilePath := cliConfigFileOverride()
+	configFilePath := CLIConfigFileOverride()
 	if configFilePath == "" {
 		var err error
 		configFilePath, err = ConfigFile()
@@ -435,7 +435,7 @@ func cliConfigFile() (string, tfdiags.Diagnostics) {
 	return "", diags
 }
 
-func cliConfigFileOverride() string {
+func CLIConfigFileOverride() string {
 	configFilePath := os.Getenv("TF_CLI_CONFIG_FILE")
 	if configFilePath == "" {
 		configFilePath = os.Getenv("TERRAFORM_CONFIG")

--- a/internal/command/cliconfig/credentials.go
+++ b/internal/command/cliconfig/credentials.go
@@ -100,7 +100,7 @@ func (c *Config) credentialsSource(helperType string, helper svcauth.Credentials
 		configured[host] = credsV
 	}
 
-	writableLocal := readHostsInCredentialsFile(credentialsFilePath)
+	writableLocal := ReadHostsInCredentialsFile(credentialsFilePath)
 	unwritableLocal := map[svchost.Hostname]cty.Value{}
 	for host, v := range configured {
 		if _, exists := writableLocal[host]; !exists {
@@ -445,14 +445,14 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 	return nil
 }
 
-// readHostsInCredentialsFile discovers which hosts have credentials configured
+// ReadHostsInCredentialsFile discovers which hosts have credentials configured
 // in the credentials file specifically, as opposed to in any other CLI
 // config file.
 //
 // If the credentials file isn't present or is unreadable for any reason then
 // this returns an empty set, reflecting that effectively no credentials are
 // stored there.
-func readHostsInCredentialsFile(filename string) map[svchost.Hostname]struct{} {
+func ReadHostsInCredentialsFile(filename string) map[svchost.Hostname]struct{} {
 	src, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil
@@ -484,124 +484,6 @@ func readHostsInCredentialsFile(filename string) map[svchost.Hostname]struct{} {
 		ret[host] = struct{}{}
 	}
 	return ret
-}
-
-// ReadCredentialHostsInOrder returns the hostnames declared in the local
-// credentials file (credentials.tfrc.json) in the same order they appear in
-// the file.
-//
-// Invalid hostnames are ignored. If the credentials file is absent then this
-// returns an empty result and no error.
-func ReadCredentialHostsInOrder(configDir string) ([]svchost.Hostname, error) {
-	if strings.TrimSpace(configDir) == "" {
-		return nil, nil
-	}
-
-	filename := filepath.Join(configDir, "credentials.tfrc.json")
-	return readCredentialHostsInOrderFile(filename)
-}
-
-func readCredentialHostsInOrderFile(filename string) ([]svchost.Hostname, error) {
-	src, err := ioutil.ReadFile(filename)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	dec := json.NewDecoder(bytes.NewReader(src))
-
-	openTok, err := dec.Token()
-	if err != nil {
-		return nil, err
-	}
-	open, ok := openTok.(json.Delim)
-	if !ok || open != '{' {
-		return nil, fmt.Errorf("credentials file %s is invalid: expected top-level object", filename)
-	}
-
-	hosts := make([]svchost.Hostname, 0)
-	seen := make(map[svchost.Hostname]struct{})
-
-	for dec.More() {
-		keyTok, err := dec.Token()
-		if err != nil {
-			return nil, err
-		}
-
-		key, ok := keyTok.(string)
-		if !ok {
-			return nil, fmt.Errorf("credentials file %s is invalid: expected string key", filename)
-		}
-
-		if key != "credentials" {
-			var discard json.RawMessage
-			if err := dec.Decode(&discard); err != nil {
-				return nil, err
-			}
-			continue
-		}
-
-		credsOpenTok, err := dec.Token()
-		if err != nil {
-			return nil, err
-		}
-		credsOpen, ok := credsOpenTok.(json.Delim)
-		if !ok || credsOpen != '{' {
-			return nil, fmt.Errorf("credentials file %s has invalid value for \"credentials\" property: must be a JSON object", filename)
-		}
-
-		for dec.More() {
-			hostTok, err := dec.Token()
-			if err != nil {
-				return nil, err
-			}
-
-			givenHost, ok := hostTok.(string)
-			if !ok {
-				return nil, fmt.Errorf("credentials file %s is invalid: expected hostname key", filename)
-			}
-
-			// Consume the credentials object before proceeding.
-			var discard json.RawMessage
-			if err := dec.Decode(&discard); err != nil {
-				return nil, err
-			}
-
-			host, err := svchost.ForComparison(givenHost)
-			if err != nil {
-				continue
-			}
-
-			if _, exists := seen[host]; exists {
-				continue
-			}
-
-			seen[host] = struct{}{}
-			hosts = append(hosts, host)
-		}
-
-		credsCloseTok, err := dec.Token()
-		if err != nil {
-			return nil, err
-		}
-		credsClose, ok := credsCloseTok.(json.Delim)
-		if !ok || credsClose != '}' {
-			return nil, fmt.Errorf("credentials file %s is invalid: expected credentials object to end", filename)
-		}
-	}
-
-	closeTok, err := dec.Token()
-	if err != nil {
-		return nil, err
-	}
-	close, ok := closeTok.(json.Delim)
-	if !ok || close != '}' {
-		return nil, fmt.Errorf("credentials file %s is invalid: expected top-level object to end", filename)
-	}
-
-	return hosts, nil
 }
 
 // ErrUnwritableHostCredentials is an error type that is returned when a caller

--- a/internal/command/cliconfig/credentials.go
+++ b/internal/command/cliconfig/credentials.go
@@ -486,6 +486,124 @@ func readHostsInCredentialsFile(filename string) map[svchost.Hostname]struct{} {
 	return ret
 }
 
+// ReadCredentialHostsInOrder returns the hostnames declared in the local
+// credentials file (credentials.tfrc.json) in the same order they appear in
+// the file.
+//
+// Invalid hostnames are ignored. If the credentials file is absent then this
+// returns an empty result and no error.
+func ReadCredentialHostsInOrder(configDir string) ([]svchost.Hostname, error) {
+	if strings.TrimSpace(configDir) == "" {
+		return nil, nil
+	}
+
+	filename := filepath.Join(configDir, "credentials.tfrc.json")
+	return readCredentialHostsInOrderFile(filename)
+}
+
+func readCredentialHostsInOrderFile(filename string) ([]svchost.Hostname, error) {
+	src, err := ioutil.ReadFile(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(src))
+
+	openTok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	open, ok := openTok.(json.Delim)
+	if !ok || open != '{' {
+		return nil, fmt.Errorf("credentials file %s is invalid: expected top-level object", filename)
+	}
+
+	hosts := make([]svchost.Hostname, 0)
+	seen := make(map[svchost.Hostname]struct{})
+
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, fmt.Errorf("credentials file %s is invalid: expected string key", filename)
+		}
+
+		if key != "credentials" {
+			var discard json.RawMessage
+			if err := dec.Decode(&discard); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		credsOpenTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		credsOpen, ok := credsOpenTok.(json.Delim)
+		if !ok || credsOpen != '{' {
+			return nil, fmt.Errorf("credentials file %s has invalid value for \"credentials\" property: must be a JSON object", filename)
+		}
+
+		for dec.More() {
+			hostTok, err := dec.Token()
+			if err != nil {
+				return nil, err
+			}
+
+			givenHost, ok := hostTok.(string)
+			if !ok {
+				return nil, fmt.Errorf("credentials file %s is invalid: expected hostname key", filename)
+			}
+
+			// Consume the credentials object before proceeding.
+			var discard json.RawMessage
+			if err := dec.Decode(&discard); err != nil {
+				return nil, err
+			}
+
+			host, err := svchost.ForComparison(givenHost)
+			if err != nil {
+				continue
+			}
+
+			if _, exists := seen[host]; exists {
+				continue
+			}
+
+			seen[host] = struct{}{}
+			hosts = append(hosts, host)
+		}
+
+		credsCloseTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		credsClose, ok := credsCloseTok.(json.Delim)
+		if !ok || credsClose != '}' {
+			return nil, fmt.Errorf("credentials file %s is invalid: expected credentials object to end", filename)
+		}
+	}
+
+	closeTok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	close, ok := closeTok.(json.Delim)
+	if !ok || close != '}' {
+		return nil, fmt.Errorf("credentials file %s is invalid: expected top-level object to end", filename)
+	}
+
+	return hosts, nil
+}
+
 // ErrUnwritableHostCredentials is an error type that is returned when a caller
 // tries to write credentials for a host that has existing credentials configured
 // in a file that we cannot automatically update.

--- a/internal/command/cliconfig/credentials.go
+++ b/internal/command/cliconfig/credentials.go
@@ -26,7 +26,7 @@ import (
 // credentialsConfigFile returns the path for the special configuration file
 // that the credentials source will use when asked to save or forget credentials
 // and when a "credentials helper" program is not active.
-func credentialsConfigFile() (string, error) {
+func CredentialsConfigFile() (string, error) {
 	configDir, err := ConfigDir()
 	if err != nil {
 		return "", err
@@ -38,7 +38,7 @@ func credentialsConfigFile() (string, error) {
 // behavior depends on which "credentials" and "credentials_helper" blocks,
 // if any, are present in the receiving config.
 func (c *Config) CredentialsSource(helperPlugins pluginDiscovery.PluginMetaSet) (*CredentialsSource, error) {
-	credentialsFilePath, err := credentialsConfigFile()
+	credentialsFilePath, err := CredentialsConfigFile()
 	if err != nil {
 		// If we managed to load a Config object at all then we would already
 		// have located this file, so this error is very unlikely.

--- a/internal/command/cliconfig/credentials_test.go
+++ b/internal/command/cliconfig/credentials_test.go
@@ -435,6 +435,121 @@ func TestCredentialsStoreForget(t *testing.T) {
 	}
 }
 
+func TestReadCredentialHostsInOrder(t *testing.T) {
+	t.Run("missing credentials file", func(t *testing.T) {
+		dir := t.TempDir()
+
+		got, err := ReadCredentialHostsInOrder(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if diff := cmp.Diff([]svchost.Hostname(nil), got); diff != "" {
+			t.Fatalf("wrong hosts returned\n%s", diff)
+		}
+	})
+
+	t.Run("empty credentials object", func(t *testing.T) {
+		dir := t.TempDir()
+		filename := filepath.Join(dir, "credentials.tfrc.json")
+
+		err := os.WriteFile(filename, []byte(`{"credentials":{}}`), 0600)
+		if err != nil {
+			t.Fatalf("failed to write credentials file: %s", err)
+		}
+
+		got, err := ReadCredentialHostsInOrder(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if diff := cmp.Diff([]svchost.Hostname{}, got); diff != "" {
+			t.Fatalf("wrong hosts returned\n%s", diff)
+		}
+	})
+
+	t.Run("one host", func(t *testing.T) {
+		dir := t.TempDir()
+		filename := filepath.Join(dir, "credentials.tfrc.json")
+
+		err := os.WriteFile(filename, []byte(`{"credentials":{"tfe.company.com":{"token":"x"}}}`), 0600)
+		if err != nil {
+			t.Fatalf("failed to write credentials file: %s", err)
+		}
+
+		got, err := ReadCredentialHostsInOrder(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		want := []svchost.Hostname{svchost.Hostname("tfe.company.com")}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("wrong hosts returned\n%s", diff)
+		}
+	})
+
+	t.Run("multiple hosts preserve order", func(t *testing.T) {
+		dir := t.TempDir()
+		filename := filepath.Join(dir, "credentials.tfrc.json")
+
+		contents := `{
+		  "credentials": {
+		    "third.example.com": {"token":"1"},
+		    "first.example.com": {"token":"2"},
+		    "second.example.com": {"token":"3"}
+		  }
+		}`
+		err := os.WriteFile(filename, []byte(contents), 0600)
+		if err != nil {
+			t.Fatalf("failed to write credentials file: %s", err)
+		}
+
+		got, err := ReadCredentialHostsInOrder(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		want := []svchost.Hostname{
+			svchost.Hostname("third.example.com"),
+			svchost.Hostname("first.example.com"),
+			svchost.Hostname("second.example.com"),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("wrong hosts returned\n%s", diff)
+		}
+	})
+
+	t.Run("invalid hosts are ignored", func(t *testing.T) {
+		dir := t.TempDir()
+		filename := filepath.Join(dir, "credentials.tfrc.json")
+
+		contents := `{
+		  "credentials": {
+		    "valid.example.com": {"token":"1"},
+		    "not a hostname": {"token":"2"},
+		    "another.valid.example.com": {"token":"3"}
+		  }
+		}`
+		err := os.WriteFile(filename, []byte(contents), 0600)
+		if err != nil {
+			t.Fatalf("failed to write credentials file: %s", err)
+		}
+
+		got, err := ReadCredentialHostsInOrder(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		want := []svchost.Hostname{
+			svchost.Hostname("valid.example.com"),
+			svchost.Hostname("another.valid.example.com"),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("wrong hosts returned\n%s", diff)
+		}
+	})
+}
+
 type mockCredentialsHelperChange struct {
 	Host   svchost.Hostname
 	Action string

--- a/internal/command/cliconfig/credentials_test.go
+++ b/internal/command/cliconfig/credentials_test.go
@@ -294,7 +294,7 @@ func TestCredentialsStoreForget(t *testing.T) {
 			t.Fatalf("wrong header value for stored-locally\ngot:  %s\nwant: %s", got, want)
 		}
 
-		got := readHostsInCredentialsFile(mockCredsFilename)
+		got := ReadHostsInCredentialsFile(mockCredsFilename)
 		want := map[svchost.Hostname]struct{}{
 			svchost.Hostname("stored-locally.example.com"): struct{}{},
 		}
@@ -343,7 +343,7 @@ func TestCredentialsStoreForget(t *testing.T) {
 		}
 
 		// Nothing should have changed in the saved credentials file
-		got := readHostsInCredentialsFile(mockCredsFilename)
+		got := ReadHostsInCredentialsFile(mockCredsFilename)
 		want := map[svchost.Hostname]struct{}{
 			svchost.Hostname("stored-locally.example.com"): struct{}{},
 		}
@@ -391,7 +391,7 @@ func TestCredentialsStoreForget(t *testing.T) {
 		}
 
 		// Should not be present in the credentials file anymore
-		got := readHostsInCredentialsFile(mockCredsFilename)
+		got := ReadHostsInCredentialsFile(mockCredsFilename)
 		want := map[svchost.Hostname]struct{}{}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatalf("wrong credentials file content\n%s", diff)
@@ -435,16 +435,14 @@ func TestCredentialsStoreForget(t *testing.T) {
 	}
 }
 
-func TestReadCredentialHostsInOrder(t *testing.T) {
+func TestReadHostsInCredentialsFile(t *testing.T) {
 	t.Run("missing credentials file", func(t *testing.T) {
 		dir := t.TempDir()
+		filename := filepath.Join(dir, "credentials.tfrc.json")
 
-		got, err := ReadCredentialHostsInOrder(dir)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+		got := ReadHostsInCredentialsFile(filename)
 
-		if diff := cmp.Diff([]svchost.Hostname(nil), got); diff != "" {
+		if diff := cmp.Diff(map[svchost.Hostname]struct{}(nil), got); diff != "" {
 			t.Fatalf("wrong hosts returned\n%s", diff)
 		}
 	})
@@ -453,17 +451,13 @@ func TestReadCredentialHostsInOrder(t *testing.T) {
 		dir := t.TempDir()
 		filename := filepath.Join(dir, "credentials.tfrc.json")
 
-		err := os.WriteFile(filename, []byte(`{"credentials":{}}`), 0600)
-		if err != nil {
+		if err := os.WriteFile(filename, []byte(`{"credentials":{}}`), 0600); err != nil {
 			t.Fatalf("failed to write credentials file: %s", err)
 		}
 
-		got, err := ReadCredentialHostsInOrder(dir)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+		got := ReadHostsInCredentialsFile(filename)
 
-		if diff := cmp.Diff([]svchost.Hostname{}, got); diff != "" {
+		if diff := cmp.Diff(map[svchost.Hostname]struct{}{}, got); diff != "" {
 			t.Fatalf("wrong hosts returned\n%s", diff)
 		}
 	})
@@ -472,23 +466,21 @@ func TestReadCredentialHostsInOrder(t *testing.T) {
 		dir := t.TempDir()
 		filename := filepath.Join(dir, "credentials.tfrc.json")
 
-		err := os.WriteFile(filename, []byte(`{"credentials":{"tfe.company.com":{"token":"x"}}}`), 0600)
-		if err != nil {
+		if err := os.WriteFile(filename, []byte(`{"credentials":{"tfe.company.com":{"token":"x"}}}`), 0600); err != nil {
 			t.Fatalf("failed to write credentials file: %s", err)
 		}
 
-		got, err := ReadCredentialHostsInOrder(dir)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+		got := ReadHostsInCredentialsFile(filename)
 
-		want := []svchost.Hostname{svchost.Hostname("tfe.company.com")}
+		want := map[svchost.Hostname]struct{}{
+			svchost.Hostname("tfe.company.com"): {},
+		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatalf("wrong hosts returned\n%s", diff)
 		}
 	})
 
-	t.Run("multiple hosts preserve order", func(t *testing.T) {
+	t.Run("multiple hosts", func(t *testing.T) {
 		dir := t.TempDir()
 		filename := filepath.Join(dir, "credentials.tfrc.json")
 
@@ -499,20 +491,16 @@ func TestReadCredentialHostsInOrder(t *testing.T) {
 		    "second.example.com": {"token":"3"}
 		  }
 		}`
-		err := os.WriteFile(filename, []byte(contents), 0600)
-		if err != nil {
+		if err := os.WriteFile(filename, []byte(contents), 0600); err != nil {
 			t.Fatalf("failed to write credentials file: %s", err)
 		}
 
-		got, err := ReadCredentialHostsInOrder(dir)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+		got := ReadHostsInCredentialsFile(filename)
 
-		want := []svchost.Hostname{
-			svchost.Hostname("third.example.com"),
-			svchost.Hostname("first.example.com"),
-			svchost.Hostname("second.example.com"),
+		want := map[svchost.Hostname]struct{}{
+			svchost.Hostname("third.example.com"):  {},
+			svchost.Hostname("first.example.com"):  {},
+			svchost.Hostname("second.example.com"): {},
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatalf("wrong hosts returned\n%s", diff)
@@ -530,19 +518,15 @@ func TestReadCredentialHostsInOrder(t *testing.T) {
 		    "another.valid.example.com": {"token":"3"}
 		  }
 		}`
-		err := os.WriteFile(filename, []byte(contents), 0600)
-		if err != nil {
+		if err := os.WriteFile(filename, []byte(contents), 0600); err != nil {
 			t.Fatalf("failed to write credentials file: %s", err)
 		}
 
-		got, err := ReadCredentialHostsInOrder(dir)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+		got := ReadHostsInCredentialsFile(filename)
 
-		want := []svchost.Hostname{
-			svchost.Hostname("valid.example.com"),
-			svchost.Hostname("another.valid.example.com"),
+		want := map[svchost.Hostname]struct{}{
+			svchost.Hostname("valid.example.com"):         {},
+			svchost.Hostname("another.valid.example.com"): {},
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatalf("wrong hosts returned\n%s", diff)

--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-svchost/disco"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	"github.com/hashicorp/terraform/internal/cloud"
+	"github.com/hashicorp/terraform/internal/command/cliconfig"
 	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/pluginshared"
 	"github.com/hashicorp/terraform/internal/stacksplugin/stacksplugin1"
@@ -147,6 +148,58 @@ func (c *StacksCommand) realRun(args []string, stdout, stderr io.Writer) int {
 	return stacks1.Execute(args, stdout, stderr)
 }
 
+func (c *StacksCommand) resolveDisplayHostname() (string, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	displayHostname := strings.TrimSpace(os.Getenv("TF_STACKS_HOSTNAME"))
+	if displayHostname != "" {
+		return displayHostname, diags
+	}
+
+	displayHostname = strings.TrimSpace(os.Getenv("TF_CLOUD_HOSTNAME"))
+	if displayHostname != "" {
+		return displayHostname, diags
+	}
+
+	hosts, err := cliconfig.ReadCredentialHostsInOrder(c.CLIConfigDir)
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Could not inspect credentials file for stacks hostname, using default hostname",
+			err.Error(),
+		))
+		log.Printf("[TRACE] stacksplugin hostname inference failed, falling back to %q", defaultHostname)
+		return defaultHostname, diags
+	}
+
+	if len(hosts) == 1 {
+		displayHostname = hosts[0].ForDisplay()
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"No hostname environment variable set, using hostname from credentials file",
+			fmt.Sprintf("No hostname environment variable set. Using %q from your credentials file. Set TF_STACKS_HOSTNAME or TF_CLOUD_HOSTNAME to override.", displayHostname),
+		))
+		return displayHostname, diags
+	}
+
+	if len(hosts) > 1 {
+		hostnames := make([]string, 0, len(hosts))
+		for _, host := range hosts {
+			hostnames = append(hostnames, fmt.Sprintf("%q", host.ForDisplay()))
+		}
+
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Multiple hostnames found in credentials file",
+			fmt.Sprintf("Multiple hostnames found in credentials file: %s. Cannot determine which to use. Set TF_STACKS_HOSTNAME or TF_CLOUD_HOSTNAME to specify the intended host.", strings.Join(hostnames, ", ")),
+		))
+		return "", diags
+	}
+
+	log.Printf("[TRACE] stacksplugin hostname not set, falling back to %q", defaultHostname)
+	return defaultHostname, diags
+}
+
 // discoverAndConfigure is an implementation detail of initPlugin. It fills in the
 // pluginService and pluginConfig fields on a StacksCommand struct.
 func (c *StacksCommand) discoverAndConfigure() tfdiags.Diagnostics {
@@ -184,10 +237,10 @@ func (c *StacksCommand) discoverAndConfigure() tfdiags.Diagnostics {
 		return diags
 	}
 
-	displayHostname := os.Getenv("TF_STACKS_HOSTNAME")
-	if strings.TrimSpace(displayHostname) == "" {
-		log.Printf("[TRACE] stacksplugin hostname not set, falling back to %q", defaultHostname)
-		displayHostname = defaultHostname
+	displayHostname, hostnameDiags := c.resolveDisplayHostname()
+	diags = diags.Append(hostnameDiags)
+	if diags.HasErrors() {
+		return diags
 	}
 
 	hostname, err := svchost.ForComparison(displayHostname)
@@ -210,7 +263,7 @@ func (c *StacksCommand) discoverAndConfigure() tfdiags.Diagnostics {
 		return diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Hostname discovery failed",
-			err.Error(),
+			fmt.Sprintf("%s\n\nSet TF_STACKS_HOSTNAME or TF_CLOUD_HOSTNAME to specify the intended host.", err.Error()),
 		))
 	}
 
@@ -223,7 +276,7 @@ func (c *StacksCommand) discoverAndConfigure() tfdiags.Diagnostics {
 		token, err = cloud.CliConfigToken(hostname, cb.Services())
 		if err != nil {
 			// some commands like stacks init and validate could be run without a token so allow it without errors
-			diags.Append(tfdiags.Sourceless(
+			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Warning,
 				"Could not read token from credentials file, proceeding without a token",
 				err.Error(),

--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -160,13 +160,17 @@ func (c *StacksCommand) resolveDisplayHostname() (string, tfdiags.Diagnostics) {
 		return displayHostname, diags
 	}
 
-	credentialsDirectory := c.CLIConfigDir
-	if override := cliconfig.CLIConfigFileOverride(); override != "" {
-		credentialsDirectory = path.Dir(override)
-		log.Printf("[TRACE] stacksplugin reading credentials from override config directory %q", credentialsDirectory)
+	credentialsFile, err := cliconfig.CredentialsConfigFile()
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Could not inspect credentials file for stacks hostname, using default hostname",
+			err.Error(),
+		))
+		log.Printf("[TRACE] stacksplugin hostname inference failed, falling back to %q", defaultHostname)
+		return defaultHostname, diags
 	}
 
-	credentialsFile := path.Join(credentialsDirectory, "credentials.tfrc.json")
 	hosts := cliconfig.ReadHostsInCredentialsFile(credentialsFile)
 
 	if len(hosts) == 1 {

--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -150,7 +150,6 @@ func (c *StacksCommand) realRun(args []string, stdout, stderr io.Writer) int {
 
 func (c *StacksCommand) resolveDisplayHostname() (string, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-
 	displayHostname := strings.TrimSpace(os.Getenv("TF_STACKS_HOSTNAME"))
 	if displayHostname != "" {
 		return displayHostname, diags
@@ -161,7 +160,13 @@ func (c *StacksCommand) resolveDisplayHostname() (string, tfdiags.Diagnostics) {
 		return displayHostname, diags
 	}
 
-	hosts, err := cliconfig.ReadCredentialHostsInOrder(c.CLIConfigDir)
+	credentialsDirectory := c.CLIConfigDir
+	if override := cliconfig.CLIConfigFileOverride(); override != "" {
+		credentialsDirectory = path.Dir(override)
+		log.Printf("[TRACE] stacksplugin reading credentials from override config directory %q", credentialsDirectory)
+	}
+
+	hosts, err := cliconfig.ReadCredentialHostsInOrder(credentialsDirectory)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Warning,

--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -180,6 +180,7 @@ func (c *StacksCommand) resolveDisplayHostname() (string, tfdiags.Diagnostics) {
 		for host := range hosts {
 			hostnames = append(hostnames, fmt.Sprintf("%q", host.ForDisplay()))
 		}
+		slices.Sort(hostnames)
 
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -166,24 +166,18 @@ func (c *StacksCommand) resolveDisplayHostname() (string, tfdiags.Diagnostics) {
 		log.Printf("[TRACE] stacksplugin reading credentials from override config directory %q", credentialsDirectory)
 	}
 
-	hosts, err := cliconfig.ReadCredentialHostsInOrder(credentialsDirectory)
-	if err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Warning,
-			"Could not inspect credentials file for stacks hostname, using default hostname",
-			err.Error(),
-		))
-		log.Printf("[TRACE] stacksplugin hostname inference failed, falling back to %q", defaultHostname)
-		return defaultHostname, diags
-	}
+	credentialsFile := path.Join(credentialsDirectory, "credentials.tfrc.json")
+	hosts := cliconfig.ReadHostsInCredentialsFile(credentialsFile)
 
 	if len(hosts) == 1 {
-		return hosts[0].ForDisplay(), diags
+		for host := range hosts {
+			return host.ForDisplay(), diags
+		}
 	}
 
 	if len(hosts) > 1 {
 		hostnames := make([]string, 0, len(hosts))
-		for _, host := range hosts {
+		for host := range hosts {
 			hostnames = append(hostnames, fmt.Sprintf("%q", host.ForDisplay()))
 		}
 

--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -178,13 +178,7 @@ func (c *StacksCommand) resolveDisplayHostname() (string, tfdiags.Diagnostics) {
 	}
 
 	if len(hosts) == 1 {
-		displayHostname = hosts[0].ForDisplay()
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Warning,
-			"No hostname environment variable set, using hostname from credentials file",
-			fmt.Sprintf("No hostname environment variable set. Using %q from your credentials file. Set TF_STACKS_HOSTNAME or TF_CLOUD_HOSTNAME to override.", displayHostname),
-		))
-		return displayHostname, diags
+		return hosts[0].ForDisplay(), diags
 	}
 
 	if len(hosts) > 1 {

--- a/internal/command/stacks_test.go
+++ b/internal/command/stacks_test.go
@@ -82,11 +82,10 @@ func TestStacks_resolveDisplayHostname(t *testing.T) {
 			wantHostname: defaultHostname,
 		},
 		{
-			name:             "TF_CLI_CONFIG_FILE set, uses credentials from its directory",
-			tfCLIConfigFile:  "custom.tfrc",
-			credentialsJSON:  `{"credentials":{"tfe.company.com":{"token":"x"}}}`,
-			wantHostname:     "tfe.company.com",
-			wantWarnContains: "Set TF_STACKS_HOSTNAME or TF_CLOUD_HOSTNAME to override.",
+			name:            "TF_CLI_CONFIG_FILE set, uses credentials from its directory",
+			tfCLIConfigFile: "custom.tfrc",
+			credentialsJSON: `{"credentials":{"tfe.company.com":{"token":"x"}}}`,
+			wantHostname:    "tfe.company.com",
 		},
 		{
 			name:            "TF_CLI_CONFIG_FILE set, no credentials file falls back to default",

--- a/internal/command/stacks_test.go
+++ b/internal/command/stacks_test.go
@@ -68,10 +68,9 @@ func TestStacks_resolveDisplayHostname(t *testing.T) {
 			wantHostname:    "cloud.example.com",
 		},
 		{
-			name:             "uses single credentials hostname with warning",
-			credentialsJSON:  `{"credentials":{"tfe.company.com":{"token":"x"}}}`,
-			wantHostname:     "tfe.company.com",
-			wantWarnContains: "Set TF_STACKS_HOSTNAME or TF_CLOUD_HOSTNAME to override.",
+			name:            "uses single credentials hostname",
+			credentialsJSON: `{"credentials":{"tfe.company.com":{"token":"x"}}}`,
+			wantHostname:    "tfe.company.com",
 		},
 		{
 			name:            "multiple credentials hostnames returns error",

--- a/internal/command/stacks_test.go
+++ b/internal/command/stacks_test.go
@@ -48,7 +48,6 @@ func TestStacks_resolveDisplayHostname(t *testing.T) {
 		name             string
 		tfStacksHostname string
 		tfCloudHostname  string
-		tfCLIConfigFile  string
 		credentialsJSON  string
 		wantHostname     string
 		wantErrContains  string
@@ -81,27 +80,25 @@ func TestStacks_resolveDisplayHostname(t *testing.T) {
 			name:         "missing credentials file falls back to default",
 			wantHostname: defaultHostname,
 		},
-		{
-			name:            "TF_CLI_CONFIG_FILE set, uses credentials from its directory",
-			tfCLIConfigFile: "custom.tfrc",
-			credentialsJSON: `{"credentials":{"tfe.company.com":{"token":"x"}}}`,
-			wantHostname:    "tfe.company.com",
-		},
-		{
-			name:            "TF_CLI_CONFIG_FILE set, no credentials file falls back to default",
-			tfCLIConfigFile: "custom.tfrc",
-			wantHostname:    defaultHostname,
-		},
 	}
 
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			dir := t.TempDir()
+			// Override HOME so cliconfig.ConfigDir() resolves to a temp dir
+			// we control, avoiding interference from real credentials on the
+			// developer's machine.
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+
 			if test.credentialsJSON != "" {
-				filename := filepath.Join(dir, "credentials.tfrc.json")
-				err := os.WriteFile(filename, []byte(test.credentialsJSON), 0600)
-				if err != nil {
+				// CredentialsConfigFile() returns $HOME/.terraform.d/credentials.tfrc.json
+				configDir := filepath.Join(home, ".terraform.d")
+				if err := os.MkdirAll(configDir, 0700); err != nil {
+					t.Fatalf("failed to create config dir: %s", err)
+				}
+				filename := filepath.Join(configDir, "credentials.tfrc.json")
+				if err := os.WriteFile(filename, []byte(test.credentialsJSON), 0600); err != nil {
 					t.Fatalf("failed to write credentials file: %s", err)
 				}
 			}
@@ -109,16 +106,7 @@ func TestStacks_resolveDisplayHostname(t *testing.T) {
 			t.Setenv("TF_STACKS_HOSTNAME", test.tfStacksHostname)
 			t.Setenv("TF_CLOUD_HOSTNAME", test.tfCloudHostname)
 
-			if test.tfCLIConfigFile != "" {
-				overridePath := filepath.Join(dir, test.tfCLIConfigFile)
-				if err := os.WriteFile(overridePath, []byte(""), 0600); err != nil {
-					t.Fatalf("failed to write override config file: %s", err)
-				}
-				t.Setenv("TF_CLI_CONFIG_FILE", overridePath)
-				dir = t.TempDir()
-			}
-
-			c := &StacksCommand{Meta: Meta{CLIConfigDir: dir}}
+			c := &StacksCommand{Meta: Meta{}}
 			hostname, diags := c.resolveDisplayHostname()
 
 			if test.wantErrContains != "" {

--- a/internal/command/stacks_test.go
+++ b/internal/command/stacks_test.go
@@ -48,6 +48,7 @@ func TestStacks_resolveDisplayHostname(t *testing.T) {
 		name             string
 		tfStacksHostname string
 		tfCloudHostname  string
+		tfCLIConfigFile  string
 		credentialsJSON  string
 		wantHostname     string
 		wantErrContains  string
@@ -81,6 +82,18 @@ func TestStacks_resolveDisplayHostname(t *testing.T) {
 			name:         "missing credentials file falls back to default",
 			wantHostname: defaultHostname,
 		},
+		{
+			name:             "TF_CLI_CONFIG_FILE set, uses credentials from its directory",
+			tfCLIConfigFile:  "custom.tfrc",
+			credentialsJSON:  `{"credentials":{"tfe.company.com":{"token":"x"}}}`,
+			wantHostname:     "tfe.company.com",
+			wantWarnContains: "Set TF_STACKS_HOSTNAME or TF_CLOUD_HOSTNAME to override.",
+		},
+		{
+			name:            "TF_CLI_CONFIG_FILE set, no credentials file falls back to default",
+			tfCLIConfigFile: "custom.tfrc",
+			wantHostname:    defaultHostname,
+		},
 	}
 
 	for _, test := range tests {
@@ -97,6 +110,15 @@ func TestStacks_resolveDisplayHostname(t *testing.T) {
 
 			t.Setenv("TF_STACKS_HOSTNAME", test.tfStacksHostname)
 			t.Setenv("TF_CLOUD_HOSTNAME", test.tfCloudHostname)
+
+			if test.tfCLIConfigFile != "" {
+				overridePath := filepath.Join(dir, test.tfCLIConfigFile)
+				if err := os.WriteFile(overridePath, []byte(""), 0600); err != nil {
+					t.Fatalf("failed to write override config file: %s", err)
+				}
+				t.Setenv("TF_CLI_CONFIG_FILE", overridePath)
+				dir = t.TempDir()
+			}
 
 			c := &StacksCommand{Meta: Meta{CLIConfigDir: dir}}
 			hostname, diags := c.resolveDisplayHostname()

--- a/internal/command/stacks_test.go
+++ b/internal/command/stacks_test.go
@@ -4,7 +4,10 @@
 package command
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"google.golang.org/grpc/metadata"
@@ -37,5 +40,98 @@ func TestStacksPluginConfig_ToMetadata(t *testing.T) {
 	result := inputStruct.ToMetadata()
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Expected: %#v\nGot: %#v\n", expected, result)
+	}
+}
+
+func TestStacks_resolveDisplayHostname(t *testing.T) {
+	tests := []struct {
+		name             string
+		tfStacksHostname string
+		tfCloudHostname  string
+		credentialsJSON  string
+		wantHostname     string
+		wantErrContains  string
+		wantWarnContains string
+	}{
+		{
+			name:             "uses TF_STACKS_HOSTNAME first",
+			tfStacksHostname: "stacks.example.com",
+			tfCloudHostname:  "cloud.example.com",
+			credentialsJSON:  `{"credentials":{"cred.example.com":{"token":"x"}}}`,
+			wantHostname:     "stacks.example.com",
+		},
+		{
+			name:            "uses TF_CLOUD_HOSTNAME when stacks hostname missing",
+			tfCloudHostname: "cloud.example.com",
+			credentialsJSON: `{"credentials":{"cred.example.com":{"token":"x"}}}`,
+			wantHostname:    "cloud.example.com",
+		},
+		{
+			name:             "uses single credentials hostname with warning",
+			credentialsJSON:  `{"credentials":{"tfe.company.com":{"token":"x"}}}`,
+			wantHostname:     "tfe.company.com",
+			wantWarnContains: "Set TF_STACKS_HOSTNAME or TF_CLOUD_HOSTNAME to override.",
+		},
+		{
+			name:            "multiple credentials hostnames returns error",
+			credentialsJSON: `{"credentials":{"app.terraform.io":{"token":"x"},"tfe.company.com":{"token":"y"}}}`,
+			wantErrContains: "Multiple hostnames found in credentials file",
+		},
+		{
+			name:         "missing credentials file falls back to default",
+			wantHostname: defaultHostname,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if test.credentialsJSON != "" {
+				filename := filepath.Join(dir, "credentials.tfrc.json")
+				err := os.WriteFile(filename, []byte(test.credentialsJSON), 0600)
+				if err != nil {
+					t.Fatalf("failed to write credentials file: %s", err)
+				}
+			}
+
+			t.Setenv("TF_STACKS_HOSTNAME", test.tfStacksHostname)
+			t.Setenv("TF_CLOUD_HOSTNAME", test.tfCloudHostname)
+
+			c := &StacksCommand{Meta: Meta{CLIConfigDir: dir}}
+			hostname, diags := c.resolveDisplayHostname()
+
+			if test.wantErrContains != "" {
+				if !diags.HasErrors() {
+					t.Fatalf("expected error diagnostics")
+				}
+				if got := diags.Err().Error(); !strings.Contains(got, test.wantErrContains) {
+					t.Fatalf("wrong error\ngot:  %s\nwant: %s", got, test.wantErrContains)
+				}
+				return
+			}
+
+			if diags.HasErrors() {
+				t.Fatalf("unexpected error diagnostics: %s", diags.Err().Error())
+			}
+
+			if hostname != test.wantHostname {
+				t.Fatalf("wrong hostname\ngot:  %q\nwant: %q", hostname, test.wantHostname)
+			}
+
+			if test.wantWarnContains == "" {
+				if diags.HasWarnings() {
+					t.Fatalf("unexpected warnings: %s", diags.ErrWithWarnings().Error())
+				}
+				return
+			}
+
+			if !diags.HasWarnings() {
+				t.Fatalf("expected warning diagnostics")
+			}
+			if got := diags.ErrWithWarnings().Error(); !strings.Contains(got, test.wantWarnContains) {
+				t.Fatalf("wrong warning\ngot:  %s\nwant: %s", got, test.wantWarnContains)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Improves hostname resolution for the Stacks plugin by automatically inferring the target hostname from the local credentials file (`credentials.tfrc.json`) when no explicit hostname environment variable is set.

Previously, the `StacksCommand` only checked the `TF_STACKS_HOSTNAME` environment variable and fell back to the default hostname (`app.terraform.io`) if it was unset. This meant users running Terraform Enterprise (TFE) instances needed to always remember to set the environment variable explicitly.

## Changes

The new resolution logic follows this priority order:

1. **`TF_STACKS_HOSTNAME`** - used directly if set.
2. **`TF_CLOUD_HOSTNAME`** - used if set and `TF_STACKS_HOSTNAME` is not 
3.  **Check for credentials file override**

    a. Single entry in credentials.tfrc.json - if exactly one hostname is present in the credentials file, it is used automatically with a warning message
    
    b. Single entry in custom credentials file - if exactly one hostname is present in the credentials file, it is used automatically with a warning message

5. **Multiple entries in credentials file** - an error diagnostic is returned because the intended host is ambiguous; the user must set `TF_STACKS_HOSTNAME` or `TF_CLOUD_HOSTNAME` to disambiguate.
6. **Default hostname** - falls back to `app.terraform.io` when no credentials are present.

Additional changes:

- Added `ReadCredentialHostsInOrder` (and internal `readCredentialHostsInOrderFile`) to `internal/command/cliconfig`. This function parses the credentials file using a JSON decoder so that the original declaration order of hostnames is preserved
- Improved the error message for hostname discovery failure to include a hint about setting `TF_STACKS_HOSTNAME` or `TF_CLOUD_HOSTNAME`.

## Testing

Added/updated tests covering:
- `TF_STACKS_HOSTNAME` set explicitly
- `TF_CLOUD_HOSTNAME` fallback
- Credentials file override
- Single credential entry auto-resolution with warning
- Multiple credential entries returning ambiguity error
- Default hostname fallback when no credentials are present
- `ReadCredentialHostsInOrder` preserving declaration order

## Jira
https://hashicorp.atlassian.net/browse/TF-34724?atlOrigin=eyJpIjoiNGYyZjc2Y2E3ZGM0NDFhMWI1YjNmNmMyNmJjNjQzMDgiLCJwIjoiaiJ9

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
