### PR TITLE
test: Mark some test-related functions as helpers, so error messages are easier to reason about.

### DIFF
--- a/internal/terminal/testing.go
+++ b/internal/terminal/testing.go
@@ -34,6 +34,8 @@ import (
 // any setup errors by logging a message to the given testing.T object and
 // then failing the test, preventing any later code from running.
 func StreamsForTesting(t *testing.T) (streams *Streams, close func(*testing.T) *TestOutput) {
+	t.Helper()
+
 	stdinR, err := os.Open(os.DevNull)
 	if err != nil {
 		t.Fatalf("failed to open /dev/null to represent stdin: %s", err)
@@ -99,6 +101,8 @@ func StreamsForTesting(t *testing.T) (streams *Streams, close func(*testing.T) *
 	go consume(stderrR, true)
 
 	close = func(t *testing.T) *TestOutput {
+		t.Helper()
+
 		err := stdinR.Close()
 		if err != nil {
 			t.Errorf("failed to close stdin handle: %s", err)


### PR DESCRIPTION
For example, if you had `view, done := testView(t)` in an integration test and you called `done(t)` more than once accidentally there would be an error about streams already being closed and the details wouldn't point you to where in your test setup you had caused that problem to occur.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
