### PR TITLE
refactor: Make `workspace list` human output implementation use the `views` package

### DIFF
--- a/internal/command/views/workspace_list.go
+++ b/internal/command/views/workspace_list.go
@@ -4,9 +4,11 @@
 package views
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
+	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	viewsjson "github.com/hashicorp/terraform/internal/command/views/json"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -20,14 +22,46 @@ type WorkspaceList interface {
 func NewWorkspaceList(viewType arguments.ViewType, view *View) WorkspaceList {
 	switch viewType {
 	case arguments.ViewHuman:
-		// TODO: Implement human-readable output for workspace list command using the views package, and remove the use of cli.Ui. This is a breaking change.
-		panic("human-readable output for workspace list command is not supported via the views package.")
+		return &WorkspaceListHuman{
+			view: view,
+		}
 	case arguments.ViewJSON:
 		return &WorkspaceListJSON{
 			view: view,
 		}
 	default:
 		panic(fmt.Sprintf("unsupported view type: %s", viewType))
+	}
+}
+
+// The WorkspaceListHuman implementation renders human-readable logs, suitable for direct consumption by a human user.
+type WorkspaceListHuman struct {
+	view *View
+}
+
+var _ WorkspaceList = (*WorkspaceListHuman)(nil)
+
+// List is used to assemble the list of Workspaces and log it via Output
+func (v *WorkspaceListHuman) List(selected string, list []string, diags tfdiags.Diagnostics) {
+	// Print diags above output
+	v.view.Diagnostics(diags)
+
+	// Print list
+	if len(list) > 0 {
+		var out bytes.Buffer
+		for _, s := range list {
+			if s == selected {
+				out.WriteString("* ")
+			} else {
+				out.WriteString("  ")
+			}
+			out.WriteString(s)
+			out.WriteString("\n")
+		}
+		v.view.streams.Println(out.String())
+	} else {
+		// Warn that no states exist
+		v.view.Diagnostics(warnNoEnvsExistDiag(selected))
 	}
 }
 
@@ -99,4 +133,36 @@ func (v *WorkspaceListJSON) List(current string, list []string, diags tfdiags.Di
 	}
 
 	v.view.streams.Println(string(jsonOutput))
+}
+
+// warnNoEnvsExistDiag creates a warning diagnostic saying that no workspaces exist,
+// and provides guidance about how to create the workspace based on whether the workspace is
+// custom or not.
+func warnNoEnvsExistDiag(currentWorkspace string) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	summary := "Terraform cannot find any existing workspaces."
+
+	if currentWorkspace == backend.DefaultStateName {
+		// Recommended actions for the user includes running `init` if they're using the default workspace.
+		msg := fmt.Sprintf(
+			"The %q workspace is selected in your working directory. You can create this workspace by running \"terraform init\", by using the \"terraform workspace new\" subcommand or by including the \"-or-create\" flag with the \"terraform workspace select\" subcommand.",
+			currentWorkspace,
+		)
+		return diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			summary,
+			msg,
+		))
+	}
+
+	msg := fmt.Sprintf(
+		"The %q workspace is selected in your working directory. You can create this workspace by using the \"terraform workspace new\" subcommand or including the \"-or-create\" flag with the \"terraform workspace select\" subcommand.",
+		currentWorkspace,
+	)
+	return diags.Append(tfdiags.Sourceless(
+		tfdiags.Warning,
+		summary,
+		msg,
+	))
 }

--- a/internal/command/views/workspace_list_test.go
+++ b/internal/command/views/workspace_list_test.go
@@ -5,6 +5,7 @@ package views
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -12,6 +13,66 @@ import (
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
+
+func TestWorkspaceListHuman(t *testing.T) {
+	testCases := map[string]struct {
+		selected string
+		list     []string
+		diags    tfdiags.Diagnostics
+		wantLog  string
+	}{
+		"success": {
+			"default",
+			[]string{"default", "other"},
+			nil,
+			"* default\n  other",
+		},
+		"success with warning": {
+			"default",
+			[]string{"default", "other"},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Warning,
+					"Example warning",
+					"This is an example warning message.",
+				),
+			},
+			"Warning: Example warning\n\nThis is an example warning message.\n* default\n  other",
+		},
+		"error": {
+			"foobar",
+			[]string{},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Example error",
+					"This is an example error message.",
+				),
+			},
+			"Error: Example error\n\nThis is an example error message.\n\n" +
+				"Warning: Terraform cannot find any existing workspaces.\n\n" +
+				"The \"foobar\" workspace is selected in your working directory. You can create\nthis workspace by using the \"terraform workspace new\" subcommand or including\nthe \"-or-create\" flag with the \"terraform workspace select\" subcommand.",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			view := NewView(streams)
+			view.Configure(&arguments.View{NoColor: true})
+			v := NewWorkspaceList(arguments.ViewHuman, view)
+
+			v.List(tc.selected, tc.list, tc.diags)
+
+			got := strings.TrimSpace(done(t).All())
+			want := strings.TrimSpace(tc.wantLog)
+
+			// Assert contents
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatalf("unexpected diff in human output:\n%s", diff)
+			}
+		})
+	}
+}
 
 func TestWorkspaceListJSON(t *testing.T) {
 	testCases := map[string]struct {
@@ -69,7 +130,7 @@ func TestWorkspaceListJSON(t *testing.T) {
 			},
 		},
 		"error": {
-			"",
+			"foobar",
 			[]string{},
 			tfdiags.Diagnostics{
 				tfdiags.Sourceless(

--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -4,12 +4,10 @@
 package command
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -151,33 +149,3 @@ to match the workspace name you are trying to create, and then run this command
 again.
 `
 )
-
-// warnNoEnvsExistDiag creates a warning diagnostic saying that no workspaces exist,
-// and provides guidance about how to create the workspace based on whether the workspace is
-// custom or not.
-func warnNoEnvsExistDiag(currentWorkspace string) tfdiags.Diagnostic {
-	summary := "Terraform cannot find any existing workspaces."
-
-	if currentWorkspace == backend.DefaultStateName {
-		// Recommended actions for the user includes running `init` if they're using the default workspace.
-		msg := fmt.Sprintf(
-			"The %q workspace is selected in your working directory. You can create this workspace by running \"terraform init\", by using the \"terraform workspace new\" subcommand or by including the \"-or-create\" flag with the \"terraform workspace select\" subcommand.",
-			currentWorkspace,
-		)
-		return tfdiags.Sourceless(
-			tfdiags.Warning,
-			summary,
-			msg,
-		)
-	}
-
-	msg := fmt.Sprintf(
-		"The %q workspace is selected in your working directory. You can create this workspace by using the \"terraform workspace new\" subcommand or including the \"-or-create\" flag with the \"terraform workspace select\" subcommand.",
-		currentWorkspace,
-	)
-	return tfdiags.Sourceless(
-		tfdiags.Warning,
-		summary,
-		msg,
-	)
-}

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -126,7 +126,9 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 
 	//// List Workspaces
 	ui = testUiWrapped(t)
+	view, done := testView(t)
 	meta.Ui = ui
+	meta.View = view
 	meta.WorkingDir = workdir.NewDir(".")
 	listCmd := &WorkspaceListCommand{
 		Meta: meta,
@@ -134,15 +136,17 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 	args = []string{}
 	code = listCmd.Run(args)
 	if code != 0 {
-		t.Fatalf("bad: %d\n\n%s\n%s", code, ui.ErrorWriter, ui.OutputWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
-	if !strings.Contains(ui.OutputWriter.String(), newWorkspace) {
-		t.Errorf("unexpected output, expected the new %q workspace to be listed present, but it's missing. Got:\n%s", newWorkspace, ui.OutputWriter)
+	if !strings.Contains(done(t).All(), newWorkspace) {
+		t.Errorf("unexpected output, expected the new %q workspace to be listed present, but it's missing. Got:\n%s", newWorkspace, done(t).All())
 	}
 
 	//// Select Workspace
 	ui = testUiWrapped(t)
+	view, _ = testView(t)
 	meta.Ui = ui
+	meta.View = view
 	selCmd := &WorkspaceSelectCommand{
 		Meta: meta,
 	}
@@ -229,7 +233,7 @@ func TestWorkspace_list_noReturnedWorkspaces(t *testing.T) {
 	})
 
 	ui := testUiWrapped(t)
-	view, _ := testView(t)
+	view, done := testView(t)
 	meta := Meta{
 		AllowExperimentalFeatures: true,
 		Ui:                        ui,
@@ -253,30 +257,33 @@ func TestWorkspace_list_noReturnedWorkspaces(t *testing.T) {
 	listCmd := &WorkspaceListCommand{
 		Meta: meta,
 	}
-	args := []string{}
+	args := []string{
+		"-no-color",
+	}
 	if code := listCmd.Run(args); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
 
 	// Users see a warning that the selected workspace doesn't exist yet
+	output := done(t)
 	expectedWarningMessages := []string{
 		"Warning: Terraform cannot find any existing workspaces.",
 		"The \"default\" workspace is selected in your working directory.",
 		"init",
 	}
 	for _, msg := range expectedWarningMessages {
-		if !strings.Contains(ui.OutputWriter.String(), msg) {
+		if !strings.Contains(output.Stdout(), msg) {
 			t.Fatalf("expected stdout output to include: %s\ngot: %s",
 				msg,
-				ui.OutputWriter,
+				output.Stdout(),
 			)
 		}
 	}
 
 	// No other output is present
-	if ui.ErrorWriter.String() != "" {
+	if strings.TrimSpace(output.Stderr()) != "" {
 		t.Fatalf("unexpected stderr: %s",
-			ui.ErrorWriter,
+			output.Stderr(),
 		)
 	}
 }
@@ -413,8 +420,10 @@ func TestWorkspace_createAndList(t *testing.T) {
 
 	listCmd := &WorkspaceListCommand{}
 	ui := testUiWrapped(t)
+	view, done := testView(t)
 	listCmd.Meta = Meta{
 		Ui:         ui,
+		View:       view,
 		WorkingDir: workdir.NewDir("."),
 	}
 
@@ -422,7 +431,8 @@ func TestWorkspace_createAndList(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	actual := strings.TrimSpace(ui.OutputWriter.String())
+	output := done(t)
+	actual := strings.TrimSpace(output.Stdout())
 	expected := "default\n  test_a\n  test_b\n* test_c"
 
 	if actual != expected {
@@ -539,8 +549,10 @@ func TestWorkspace_createInvalid(t *testing.T) {
 	// list workspaces to make sure none were created
 	listCmd := &WorkspaceListCommand{}
 	ui := testUiWrapped(t)
+	view, done := testView(t)
 	listCmd.Meta = Meta{
 		Ui:         ui,
+		View:       view,
 		WorkingDir: workdir.NewDir("."),
 	}
 
@@ -548,7 +560,8 @@ func TestWorkspace_createInvalid(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	actual := strings.TrimSpace(ui.OutputWriter.String())
+	output := done(t)
+	actual := strings.TrimSpace(output.Stdout())
 	expected := "* default"
 
 	if actual != expected {
@@ -885,8 +898,10 @@ func TestWorkspace_cannotDeleteDefaultWorkspace(t *testing.T) {
 	// Assert there is a default and "test" workspace, and "test" is selected
 	listCmd := &WorkspaceListCommand{}
 	ui = testUiWrapped(t)
+	view, done := testView(t)
 	listCmd.Meta = Meta{
 		Ui:         ui,
+		View:       view,
 		WorkingDir: workdir.NewDir("."),
 	}
 
@@ -894,7 +909,8 @@ func TestWorkspace_cannotDeleteDefaultWorkspace(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	actual := strings.TrimSpace(ui.OutputWriter.String())
+	output := done(t)
+	actual := strings.TrimSpace(output.Stdout())
 	expected := "default\n* test"
 
 	if actual != expected {
@@ -1048,9 +1064,11 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 
 	// Assert `terraform env list` returns expected deprecation warning
 	ui = testUiWrapped(t)
+	view, done := testView(t)
 	listCmd := &WorkspaceListCommand{
 		Meta: Meta{
 			Ui:         ui,
+			View:       view,
 			WorkingDir: workdir.NewDir("."),
 		},
 		LegacyName: true,
@@ -1059,16 +1077,17 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	if code := listCmd.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
-	if !strings.Contains(ui.OutputWriter.String(), expectedWarning) {
+	output := done(t)
+	if !strings.Contains(output.Stdout(), expectedWarning) {
 		t.Fatalf("expected the command to return a warning, but it was missing.\nwanted: %s\ngot: %s",
 			expectedWarning,
-			ui.OutputWriter.String(),
+			output.Stdout(),
 		)
 	}
 
 	// Assert `terraform env list -json` returns expected deprecation warning
 	ui = testUiWrapped(t)
-	view, done := testView(t)
+	view, done = testView(t)
 	listCmd = &WorkspaceListCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -1081,12 +1100,12 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	if code := listCmd.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
-	output := cleanString(done(t).All())
+	output = done(t)
 	expectedWarningJSON := "Warning: the \\\"terraform env\\\" family of commands is deprecated."
-	if !strings.Contains(output, expectedWarningJSON) {
+	if !strings.Contains(output.Stdout(), expectedWarningJSON) {
 		t.Fatalf("expected the command to return a warning, but it was missing.\nwanted: %s\ngot: %s",
 			expectedWarningJSON,
-			output,
+			output.Stdout(),
 		)
 	}
 
@@ -1119,15 +1138,19 @@ func TestWorkspace_extraArgError(t *testing.T) {
 
 	// No temp directory needed as the tests check argument parsing.
 
-	newMeta := func() (Meta, *ui.WrappedMockUi) {
+	newMeta := func(colourEnabled bool) (Meta, *ui.WrappedMockUi, *views.View, func(t *testing.T) *terminal.TestOutput) {
 		ui := testUiWrapped(t)
+		view, done := testView(t)
 		return Meta{
-			Ui: ui,
-		}, ui
+			Ui:         ui,
+			View:       view,
+			Color:      colourEnabled,
+			WorkingDir: workdir.NewDir("."),
+		}, ui, view, done
 	}
 
 	// New
-	meta, ui := newMeta()
+	meta, ui, _, _ := newMeta(false)
 	newCmd := &WorkspaceNewCommand{
 		Meta: meta,
 	}
@@ -1141,21 +1164,24 @@ func TestWorkspace_extraArgError(t *testing.T) {
 	}
 
 	// List
-	meta, ui = newMeta()
+	meta, _, _, done := newMeta(false)
 	listCmd := &WorkspaceListCommand{
 		Meta: meta,
 	}
-	args = []string{"extra-arg"} // The list subcommand does not accept any arguments, so this should error
+	args = []string{
+		"-no-color",
+		"extra-arg", // The list subcommand does not accept any arguments, so this should error
+	}
 	if code := listCmd.Run(args); code != 1 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
 	expectedError = "Error: Too many command line arguments. Did you mean to use -chdir?\n"
-	if !strings.Contains(ui.ErrorWriter.String(), expectedError) {
-		t.Fatalf("expected error to include \"%s\" but was missing, got: %s", expectedError, ui.ErrorWriter.String())
+	if !strings.Contains(done(t).Stderr(), expectedError) {
+		t.Fatalf("expected error to include \"%s\" but was missing, got: %s", expectedError, done(t).Stderr())
 	}
 
 	// Show
-	meta, ui = newMeta()
+	meta, ui, _, _ = newMeta(false)
 	showCmd := &WorkspaceShowCommand{
 		Meta: meta,
 	}
@@ -1165,7 +1191,7 @@ func TestWorkspace_extraArgError(t *testing.T) {
 	}
 
 	// Select
-	meta, ui = newMeta()
+	meta, ui, _, _ = newMeta(false)
 	selectCmd := &WorkspaceSelectCommand{
 		Meta: meta,
 	}
@@ -1179,7 +1205,7 @@ func TestWorkspace_extraArgError(t *testing.T) {
 	}
 
 	// Delete
-	meta, ui = newMeta()
+	meta, ui, _, _ = newMeta(false)
 	deleteCmd := &WorkspaceDeleteCommand{
 		Meta: meta,
 	}
@@ -1251,14 +1277,14 @@ func TestWorkspace_humanOutput(t *testing.T) {
 
 	// Assert output from listing workspaces with color enabled
 	useColor := true
-	meta, ui, _, _ := newMeta(useColor)
+	meta, _, _, done := newMeta(useColor)
 	listCmd := &WorkspaceListCommand{
 		Meta: meta,
 	}
 	if code := listCmd.Run(nil); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).Stderr())
 	}
-	actual := ui.OutputWriter.String()
+	actual := done(t).Stdout()
 	expectedOutput := "  default\n  test_a\n  test_b\n  test_c\n  test_d\n  test_e\n* test_f\n\n"
 	if actual != expectedOutput {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expectedOutput, actual)
@@ -1266,14 +1292,14 @@ func TestWorkspace_humanOutput(t *testing.T) {
 
 	// Assert output from listing workspaces with color disabled
 	useColor = false
-	meta, ui, _, _ = newMeta(useColor)
+	meta, _, _, done = newMeta(useColor)
 	listCmd = &WorkspaceListCommand{
 		Meta: meta,
 	}
 	if code := listCmd.Run(nil); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).Stderr())
 	}
-	actual = ui.OutputWriter.String()
+	actual = done(t).Stdout()
 	expectedOutput = "  default\n  test_a\n  test_b\n  test_c\n  test_d\n  test_e\n* test_f\n\n"
 	if actual != expectedOutput {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expectedOutput, actual)
@@ -1281,7 +1307,7 @@ func TestWorkspace_humanOutput(t *testing.T) {
 
 	// Assert output from showing the current workspace with color enabled
 	useColor = true
-	meta, ui, _, _ = newMeta(useColor)
+	meta, ui, _, _ := newMeta(useColor)
 	showCmd := &WorkspaceShowCommand{
 		Meta: meta,
 	}

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -4,11 +4,8 @@
 package command
 
 import (
-	"bytes"
-	"fmt"
 	"strings"
 
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -23,32 +20,18 @@ type WorkspaceListCommand struct {
 func (c *WorkspaceListCommand) Run(rawArgs []string) int {
 	var diags tfdiags.Diagnostics
 
-	// c.Meta.process removes global flags (-no-color, -compact-warnings) and uses them to configure the Ui and View.
-	//
-	// Other command implementations remove those arguments via arguments.ParseView, instead. That is only possible if views
-	// are used for both human and machine output. This command still uses cli.Ui for human output, so c.Meta.process is necessary.
-	rawArgs = c.Meta.process(rawArgs)
+	// Parse and apply global view arguments
+	common, rawArgs := arguments.ParseView(rawArgs)
+	c.View.Configure(common)
 
 	// Parse command-specific arguments.
 	args, diags := arguments.ParseWorkspaceList(rawArgs)
 
 	// Prepare the view
-	//
-	// Note - here the view uses:
-	// - cli.Ui for human output
-	// - view.View for machine-readable output
-	//
-	// Note: We don't call c.View.Configure here after obtaining the view because it's already called in c.Meta.process.
-	// TODO: When we migrate human output to use views fully instead of cli.Ui we would replace using c.Meta.process with arguments.ParseView.
-	// arguments.ParseView returns a 'common' View that can be used as an argument in the c.View.Configure method.
-	view := newWorkspaceList(args.ViewType, c.View, c.Ui, &c.Meta)
+	view := views.NewWorkspaceList(args.ViewType, c.View)
 
-	// Warn against using `terraform env` commands
-	if args.ViewType == arguments.ViewHuman {
-		envCommandShowWarning(c.Ui, c.LegacyName)
-	} else {
-		diags = diags.Append(envCommandWarningDiag(c.LegacyName))
-	}
+	// Warn against using `terraform env` commands, if needed
+	diags = diags.Append(envCommandWarningDiag(c.LegacyName))
 
 	// Now the view is ready, process any error diagnostics from parsing arguments.
 	if diags.HasErrors() {
@@ -123,50 +106,4 @@ Options:
 
 func (c *WorkspaceListCommand) Synopsis() string {
 	return "List Workspaces"
-}
-
-type workspaceListHuman struct {
-	ui   cli.Ui
-	meta *Meta
-}
-
-// List is used to assemble the list of Workspaces and log it via Output
-func (v *workspaceListHuman) List(selected string, list []string, diags tfdiags.Diagnostics) {
-	// Print diags above output
-	v.meta.showDiagnostics(diags)
-
-	// Print list
-	if len(list) > 0 {
-		var out bytes.Buffer
-		for _, s := range list {
-			if s == selected {
-				out.WriteString("* ")
-			} else {
-				out.WriteString("  ")
-			}
-			out.WriteString(s + "\n")
-		}
-		v.ui.Output(out.String())
-	} else {
-		// Warn that no states exist
-		v.meta.showDiagnostics(warnNoEnvsExistDiag(selected))
-	}
-}
-
-// newWorkspaceList returns a views.WorkspaceList interface.
-//
-// When human-readable output is migrated from cli.Ui to views.View this method should be deleted and
-// replaced with using a views.NewWorkspaceList method.
-func newWorkspaceList(vt arguments.ViewType, view *views.View, ui cli.Ui, meta *Meta) views.WorkspaceList {
-	switch vt {
-	case arguments.ViewJSON:
-		return views.NewWorkspaceList(vt, view)
-	case arguments.ViewHuman:
-		return &workspaceListHuman{
-			ui:   ui,
-			meta: meta,
-		}
-	default:
-		panic(fmt.Sprintf("unknown view type %v", vt))
-	}
 }


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/pull/38392
Reference: https://github.com/hashicorp/terraform/pull/38397

While completing that work we mistakenly thought that cli.Ui sent warning diagnostics to stderr whereas view.View sent warnings to stdout, so we believed that migrating human output to using a View was a breaking change.

That was incorrect and due to some limitations in how we use cli.Ui during integration tests, which was addressed in https://github.com/hashicorp/terraform/pull/38811

So after making that realisation, we are free to refactor human output to use Views directly. **This PR** makes the `workspace list`'s human output be produced using Views and removes the cli.Ui/Views hybrid code from before. These changes mean:
* The way views and global flags are processed can be simplified
* The way the warning about using the `env` alias of the command can be simplified

I've also added some test coverage of human output in the views package.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
