### PR TITLE
fix: Remove constants that aren't used anywhere in the codebase

### DIFF
--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -482,22 +482,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "Migrating from HCP Terraform or Terraform Enterprise to local state.",
 		JSONValue:  "Migrating from HCP Terraform or Terraform Enterprise to local state.",
 	},
-	"backend_cloud_migrate_state_store": {
-		HumanValue: "Migrating from HCP Terraform Terraform Enterprise to state store %q.",
-		JSONValue:  "Migrating from HCP Terraform Terraform Enterprise to state store %q.",
-	},
-	"backend_migrate_state_store": {
-		HumanValue: "Migrating from backend %q to state store %q.",
-		JSONValue:  "Migrating from backend %q to state store %q.",
-	},
-	"state_store_migrate_local": {
-		HumanValue: stateMigrateLocalHuman,
-		JSONValue:  stateMigrateLocalJSON,
-	},
-	"state_store_migrate_state_store": {
-		HumanValue: "Migrating from state store %q (%s) to %q (%s). Reason: %s.",
-		JSONValue:  "Migrating from state store %q (%s) to %q (%s). Reason: %s.",
-	},
 }
 
 type InitMessageCode string
@@ -545,14 +529,6 @@ const (
 	BackendMigrateLocalMessage InitMessageCode = "backend_migrate_local"
 	// BackendCloudMigrateLocalMessage indicates migration from cloud to local
 	BackendCloudMigrateLocalMessage InitMessageCode = "backend_cloud_migrate_local"
-	// BackendCloudMigrateStateStoreMessage indicates migration from cloud to a state store
-	BackendCloudMigrateStateStoreMessage InitMessageCode = "backend_cloud_migrate_state_store"
-	// BackendMigrateStateStoreMessage indicates migration from a backend to a state store
-	BackendMigrateStateStoreMessage InitMessageCode = "backend_migrate_state_store"
-	// StateMigrateLocalMessage indicates migration from state store to local
-	StateMigrateLocalMessage InitMessageCode = "state_store_migrate_local"
-	// StateStoreMigrationMessage indicates migration from state store to state store
-	StateStoreMigrationMessage InitMessageCode = "state_store_migrate_state_store"
 	// FindingMatchingVersionMessage indicates that Terraform is looking for a provider version that matches the constraint during installation
 	FindingMatchingVersionMessage InitMessageCode = "finding_matching_version_message"
 	// InstalledProviderVersionInfo describes a successfully installed provider along with its version
@@ -692,7 +668,3 @@ has changed. Terraform will now check for existing state in the backends.`
 const backendMigrateLocalHuman = `Terraform has detected you're unconfiguring your previously set %q backend.`
 
 const backendMigrateLocalJSON = `Terraform has detected you're unconfiguring your previously set %q backend.`
-
-const stateMigrateLocalHuman = `Terraform has detected you're unconfiguring your previously set %q state store.`
-
-const stateMigrateLocalJSON = `Terraform has detected you're unconfiguring your previously set %q state store.`


### PR DESCRIPTION
Title says it all - these were added in https://github.com/hashicorp/terraform/commit/87b3390189c3f993d59274df00bb4d1424d9e976.

I believe they were relevant in the past when we still had PSS-related state migrations present in the `init` command, but those have since been moved to the `state migrate` command.

Even prior to that though, we currently block use of `-json` alongside `-migrate-state` so these messages were unusable then anyway.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
