### PR TITLE
chore: Update v1.16 change files

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260401-152120.yaml
+++ b/.changes/v1.16/BUG FIXES-20260401-152120.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: import blocks no longer ignore provider local names
+body: "`import` blocks now correctly respect provider local names."
 time: 2026-04-01T15:21:20.292002-04:00
 custom:
     Issue: "38338"

--- a/.changes/v1.16/BUG FIXES-20260514-081915.yaml
+++ b/.changes/v1.16/BUG FIXES-20260514-081915.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: Fix a `terraform apply` panic when the plan contained a no-op change for a deposed object on a resource whose configuration declared a `lifecycle.precondition` or `lifecycle.postcondition`
+body: "`terraform apply` no longer panics when the plan contains a no-op change for a deposed resource that has `lifecycle.precondition` or `lifecycle.postcondition` blocks."
 time: 2026-05-14T08:19:15+00:00
 custom:
     Issue: "38586"

--- a/.changes/v1.16/BUG FIXES-20260515-135704.yaml
+++ b/.changes/v1.16/BUG FIXES-20260515-135704.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: 'workspace: Terraform will now error if an invalid workspace name becomes selected due to actions performed out-of-band'
+body: "workspace: Terraform now raises an error if an invalid workspace name becomes selected due to out-of-band changes."
 time: 2026-05-15T13:57:04.484645+01:00
 custom:
     Issue: "38594"

--- a/.changes/v1.16/BUG FIXES-20260515-201307.yaml
+++ b/.changes/v1.16/BUG FIXES-20260515-201307.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: 'test: Terraform will now raise a warning when a file referenced via `-filter` flag does not exist.'
+body: "test: Terraform now raises a warning when a file referenced via the `-filter` flag does not exist."
 time: 2026-05-15T20:13:07.430709+01:00
 custom:
     Issue: "38603"

--- a/.changes/v1.16/BUG FIXES-20260522-180848.yaml
+++ b/.changes/v1.16/BUG FIXES-20260522-180848.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: 'init: Stop removing locks from the dependency lock file corresponding to providers configured as a dev_override'
+body: "init: Terraform no longer removes locks from the dependency lock file for providers configured as `dev_override`."
 time: 2026-05-22T18:08:48.823127+01:00
 custom:
     Issue: "38634"

--- a/.changes/v1.16/BUG FIXES-20260528-171432.yaml
+++ b/.changes/v1.16/BUG FIXES-20260528-171432.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: 'init: Add warnings when unmanaged providers are in use and will impact provider installation processes.'
+body: "init: Terraform now warns when unmanaged providers are in use and may impact provider installation."
 time: 2026-05-28T17:14:32.881514+01:00
 custom:
     Issue: "38656"

--- a/.changes/v1.16/BUG FIXES-20260625-103056.yaml
+++ b/.changes/v1.16/BUG FIXES-20260625-103056.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: return correct error when import target exists in state, but not config
+body: "Terraform now returns the correct error when an `import` target exists in state but has no corresponding configuration."
 time: 2026-06-25T10:30:56.385054-04:00
 custom:
     Issue: "38782"

--- a/.changes/v1.16/BUG FIXES-20260626-130626.yaml
+++ b/.changes/v1.16/BUG FIXES-20260626-130626.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: merge no longer panics with null objects
+body: "The `merge()` function no longer panics when passed `null` objects."
 time: 2026-06-26T13:06:26.78064-04:00
 custom:
   Issue: "38792"

--- a/.changes/v1.16/ENHANCEMENTS-20260408-082543.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260408-082543.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: 'feat(cli): terraform state show accepts a -json flag'
+body: "state show: The `state show` command can now produce machine-readable output when supplied with the `-json` flag"
 time: 2026-04-08T08:25:43.767443-04:00
 custom:
-    Issue: "23940"
+  Issue: "23940"

--- a/.changes/v1.16/ENHANCEMENTS-20260417-110628.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260417-110628.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: "workspace: The `workspace list` command can now produce machine-readable output when supplied with the `-json` flag"
+time: 2026-04-17T11:06:28.651099+01:00
+custom:
+  Issue: "38397"

--- a/.changes/v1.16/ENHANCEMENTS-20260427-112604.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260427-112604.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: Show info when resources are left behind due to skip_cleanup
+body: "test: Terraform now reports which resources were left behind when `skip_cleanup` is set."
 time: 2026-04-27T11:26:04.782451-04:00
 custom:
-    Issue: "38449"
+  Issue: "38449"

--- a/.changes/v1.16/ENHANCEMENTS-20260602-090423.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260602-090423.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: Action configuration now has a new `caller` symbol which contains the object value from the calling resource.
+body: "stacks: Action configurations now have access to a `caller` symbol containing the object value of the calling resource."
 time: 2026-06-02T09:04:23.077822-04:00
 custom:
     Issue: "38668"

--- a/.changes/v1.16/ENHANCEMENTS-20260610-163709.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260610-163709.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: Actions can now use before_destroy and after_destroy events
+body: "Actions can now use `before_destroy` and `after_destroy` events."
 time: 2026-06-10T16:37:09.502275-04:00
 custom:
     Issue: "38668"

--- a/.changes/v1.16/ENHANCEMENTS-20260612-124603.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260612-124603.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: 'cloud: Render a summary of Terraform policy evaluation outcomes for plan and apply runs against HCP Terraform'
+body: "cloud: Terraform now displays a summary of policy evaluation outcomes for `plan` and `apply` runs against HCP Terraform."
 time: 2026-06-12T12:46:03.000000-04:00
 custom:
     Issue: "38715"

--- a/.changes/v1.16/ENHANCEMENTS-20260612-140500.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260612-140500.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: 'policy: Resolve the policy plugin entitlement (host, token, organization) from the configured cloud/remote backend for init, plan, and apply, instead of the plugin reading credentials itself'
+body: "policy: Terraform now resolves policy plugin credentials from the configured cloud or remote backend during `init`, `plan`, and `apply`, rather than requiring the plugin to read credentials itself."
 time: 2026-06-12T14:05:00.000000-04:00
 custom:
     Issue: "38716"

--- a/.changes/v1.16/ENHANCEMENTS-20260618-120930.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260618-120930.yaml
@@ -1,6 +1,5 @@
 kind: ENHANCEMENTS
-body: The 'terraform graph' command now accepts a -format flag, and can output graphs
-  in Mermaid format
+body: "graph: The `terraform graph` command can now output graphs in Mermaid format using the `-format=mermaid` flag."
 time: 2026-06-18T12:09:30.518397+01:00
 custom:
   Issue: "38719"

--- a/.changes/v1.16/ENHANCEMENTS-20260624-130421.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260624-130421.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: child module outputs with unreferenced deprecated nested attributes no longer return deprecation warnings.
+body: "Child module outputs with unreferenced deprecated nested attributes no longer return deprecation warnings."
 time: 2026-06-24T13:04:21.373803-04:00
 custom:
     Issue: "38778"

--- a/.changes/v1.16/ENHANCEMENTS-20260625-131757.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260625-131757.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: Support destroy=false in resource lifecycle blocks.
+body: "Resource `lifecycle` blocks now support `destroy = false` to prevent a resource from being destroyed."
 time: 2026-06-25T13:17:57.053523-04:00
 custom:
     Issue: "38784"

--- a/.changes/v1.16/ENHANCEMENTS-20260626-130712.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260626-130712.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: contains() function can now test for null
+body: "The `contains()` function can now test for `null` values."
 time: 2026-06-26T13:07:12.264854-04:00
 custom:
   Issue: "38792"

--- a/.changes/v1.16/ENHANCEMENTS-20260702-115320.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260702-115320.yaml
@@ -1,6 +1,5 @@
 kind: ENHANCEMENTS
-body: 'The `terraform console` command now accepts an optional `-scope=<module address>` flag, which can be
-    used to evaluate expressions within the scope of a module or a specific module instance.'
+body: "console: The `terraform console` command now accepts an optional `-scope=<module address>` flag, which can be used to evaluate expressions within the scope of a module or a specific module instance."
 time: 2026-07-02T11:53:20.352299-04:00
 custom:
-    Issue: "31861"
+  Issue: "31861"

--- a/.changes/v1.16/ENHANCEMENTS-20260708-095111.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260708-095111.yaml
@@ -1,6 +1,5 @@
 kind: ENHANCEMENTS
-body: If `-invoke` results in multiple resource calls triggering the action, it can
-  now be combined with `-target` to specify the calling resource instance
+body: "`-invoke` can now be combined with `-target` to specify the calling resource instance when multiple resources trigger the same action."
 time: 2026-07-08T09:51:11.784345-04:00
 custom:
   Issue: "38845"

--- a/.changes/v1.16/NEW FEATURES-20251217-113349.yaml
+++ b/.changes/v1.16/NEW FEATURES-20251217-113349.yaml
@@ -1,5 +1,5 @@
 kind: NEW FEATURES
-body: Store PlannedPrivate data for providers
+body: "Terraform now stores planned private data for providers, allowing provider-specific state to be preserved across plan and apply."
 time: 2025-12-17T11:33:49.911997-05:00
 custom:
     Issue: "37986"

--- a/.changes/v1.16/NEW FEATURES-20260320-085123.yaml
+++ b/.changes/v1.16/NEW FEATURES-20260320-085123.yaml
@@ -1,5 +1,5 @@
 kind: NEW FEATURES
-body: New store block in terraform_data that can handle ephemeral and sensitive values
+body: "`terraform_data`: The new `store` block can hold ephemeral and sensitive values across plan and apply."
 time: 2026-03-20T08:51:23.141458-04:00
 custom:
     Issue: "38298"

--- a/.changes/v1.16/NEW FEATURES-20260410-085729.yaml
+++ b/.changes/v1.16/NEW FEATURES-20260410-085729.yaml
@@ -1,5 +1,5 @@
 kind: NEW FEATURES
-body: 'import: add support for import blocks inside modules'
+body: "import: `import` blocks inside modules are now supported."
 time: 2026-04-10T08:57:29.804462-04:00
 custom:
     Issue: "38352"

--- a/.changes/v1.16/NEW FEATURES-20260414-181903.yaml
+++ b/.changes/v1.16/NEW FEATURES-20260414-181903.yaml
@@ -1,5 +1,5 @@
 kind: NEW FEATURES
-body: We now produce builds for Linux s390x (zLinux)
+body: "Terraform is now available as a pre-built binary for Linux s390x (zLinux)."
 time: 2026-04-14T18:19:03.50934+01:00
 custom:
     Issue: "38384"

--- a/.changes/v1.16/NEW FEATURES-20260417-110628.yaml
+++ b/.changes/v1.16/NEW FEATURES-20260417-110628.yaml
@@ -1,5 +1,0 @@
-kind: NEW FEATURES
-body: 'workspace: The `workspace list` command can now produce machine-readable output when supplied with the `-json` flag'
-time: 2026-04-17T11:06:28.651099+01:00
-custom:
-    Issue: "38397"

--- a/.changes/v1.16/NEW FEATURES-20260612-114956.yaml
+++ b/.changes/v1.16/NEW FEATURES-20260612-114956.yaml
@@ -1,5 +1,5 @@
 kind: NEW FEATURES
-body: Resource action triggers can now use `on_failure` modes of `halt`, `taint`, or `continue`
+body: "Resource action triggers can now use `on_failure` modes of `halt`, `taint`, or `continue`."
 time: 2026-06-12T11:49:56.096388-04:00
 custom:
     Issue: "38722"

--- a/.changes/v1.16/UPGRADE NOTES-20260330-145227.yaml
+++ b/.changes/v1.16/UPGRADE NOTES-20260330-145227.yaml
@@ -1,5 +1,5 @@
 kind: UPGRADE NOTES
-body: Provisioner bastion_host_key is now correctly applied. Existing usage of bastion_host_key should verify the configured key is correct.
+body: "`bastion_host_key` is now correctly applied by provisioners. Review your provisioner configurations to verify the configured key is correct before upgrading."
 time: 2026-03-30T14:52:27.996705-04:00
 custom:
     Issue: "38318"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,67 +3,67 @@
 
 NEW FEATURES:
 
-* Store PlannedPrivate data for providers ([#37986](https://github.com/hashicorp/terraform/issues/37986))
+* Terraform now stores planned private data for providers, allowing provider-specific state to be preserved across plan and apply. ([#37986](https://github.com/hashicorp/terraform/issues/37986))
 
-* New store block in terraform_data that can handle ephemeral and sensitive values ([#38298](https://github.com/hashicorp/terraform/issues/38298))
+* `terraform_data`: The new `store` block can hold ephemeral and sensitive values across plan and apply. ([#38298](https://github.com/hashicorp/terraform/issues/38298))
 
 * Providers can now use nested blocks as computed values ([#38305](https://github.com/hashicorp/terraform/issues/38305))
 
-* import: add support for import blocks inside modules ([#38352](https://github.com/hashicorp/terraform/issues/38352))
+* import: `import` blocks inside modules are now supported. ([#38352](https://github.com/hashicorp/terraform/issues/38352))
 
-* We now produce builds for Linux s390x (zLinux) ([#38384](https://github.com/hashicorp/terraform/issues/38384))
+* Terraform is now available as a pre-built binary for Linux s390x (zLinux). ([#38384](https://github.com/hashicorp/terraform/issues/38384))
 
-* workspace: The `workspace list` command can now produce machine-readable output when supplied with the `-json` flag ([#38397](https://github.com/hashicorp/terraform/issues/38397))
-
-* Resource action triggers can now use `on_failure` modes of `halt`, `taint`, or `continue` ([#38722](https://github.com/hashicorp/terraform/issues/38722))
+* Resource action triggers can now use `on_failure` modes of `halt`, `taint`, or `continue`. ([#38722](https://github.com/hashicorp/terraform/issues/38722))
 
 
 ENHANCEMENTS:
 
-* feat(cli): terraform state show accepts a -json flag ([#23940](https://github.com/hashicorp/terraform/issues/23940))
+* state show: The `state show` command can now produce machine-readable output when supplied with the `-json` flag ([#23940](https://github.com/hashicorp/terraform/issues/23940))
 
-* Show info when resources are left behind due to skip_cleanup ([#38449](https://github.com/hashicorp/terraform/issues/38449))
+* workspace: The `workspace list` command can now produce machine-readable output when supplied with the `-json` flag ([#38397](https://github.com/hashicorp/terraform/issues/38397))
 
-* Action configuration now has a new `caller` symbol which contains the object value from the calling resource. ([#38668](https://github.com/hashicorp/terraform/issues/38668))
+* test: Terraform now reports which resources were left behind when `skip_cleanup` is set. ([#38449](https://github.com/hashicorp/terraform/issues/38449))
 
-* Actions can now use before_destroy and after_destroy events ([#38668](https://github.com/hashicorp/terraform/issues/38668))
+* stacks: Action configurations now have access to a `caller` symbol containing the object value of the calling resource. ([#38668](https://github.com/hashicorp/terraform/issues/38668))
 
-* cloud: Render a summary of Terraform policy evaluation outcomes for plan and apply runs against HCP Terraform ([#38715](https://github.com/hashicorp/terraform/issues/38715))
+* Actions can now use `before_destroy` and `after_destroy` events. ([#38668](https://github.com/hashicorp/terraform/issues/38668))
 
-* policy: Resolve the policy plugin entitlement (host, token, organization) from the configured cloud/remote backend for init, plan, and apply, instead of the plugin reading credentials itself ([#38716](https://github.com/hashicorp/terraform/issues/38716))
+* cloud: Terraform now displays a summary of policy evaluation outcomes for `plan` and `apply` runs against HCP Terraform. ([#38715](https://github.com/hashicorp/terraform/issues/38715))
 
-* The 'terraform graph' command now accepts a -format flag, and can output graphs in Mermaid format ([#38719](https://github.com/hashicorp/terraform/issues/38719))
+* policy: Terraform now resolves policy plugin credentials from the configured cloud or remote backend during `init`, `plan`, and `apply`, rather than requiring the plugin to read credentials itself. ([#38716](https://github.com/hashicorp/terraform/issues/38716))
 
-* child module outputs with unreferenced deprecated nested attributes no longer return deprecation warnings. ([#38778](https://github.com/hashicorp/terraform/issues/38778))
+* graph: The `terraform graph` command can now output graphs in Mermaid format using the `-format=mermaid` flag. ([#38719](https://github.com/hashicorp/terraform/issues/38719))
 
-* Support destroy=false in resource lifecycle blocks. ([#38784](https://github.com/hashicorp/terraform/issues/38784))
+* Child module outputs with unreferenced deprecated nested attributes no longer return deprecation warnings. ([#38778](https://github.com/hashicorp/terraform/issues/38778))
 
-* contains() function can now test for null ([#38792](https://github.com/hashicorp/terraform/issues/38792))
+* Resource `lifecycle` blocks now support `destroy = false` to prevent a resource from being destroyed. ([#38784](https://github.com/hashicorp/terraform/issues/38784))
 
-* The `terraform console` command now accepts an optional `-scope=<module address>` flag, which can be used to evaluate expressions within the scope of a module or a specific module instance. ([#31861](https://github.com/hashicorp/terraform/issues/31861))
+* The `contains()` function can now test for `null` values. ([#38792](https://github.com/hashicorp/terraform/issues/38792))
 
-* If `-invoke` results in multiple resource calls triggering the action, it can now be combined with `-target` to specify the calling resource instance ([#38845](https://github.com/hashicorp/terraform/issues/38845))
+* console: The `terraform console` command now accepts an optional `-scope=<module address>` flag, which can be used to evaluate expressions within the scope of a module or a specific module instance. ([#31861](https://github.com/hashicorp/terraform/issues/31861))
+
+* `-invoke` can now be combined with `-target` to specify the calling resource instance when multiple resources trigger the same action. ([#38845](https://github.com/hashicorp/terraform/issues/38845))
 
 
 BUG FIXES:
 
-* import blocks no longer ignore provider local names ([#38338](https://github.com/hashicorp/terraform/issues/38338))
+* `import` blocks now correctly respect provider local names. ([#38338](https://github.com/hashicorp/terraform/issues/38338))
 
-* Fix a `terraform apply` panic when the plan contained a no-op change for a deposed object on a resource whose configuration declared a `lifecycle.precondition` or `lifecycle.postcondition` ([#38586](https://github.com/hashicorp/terraform/issues/38586))
+* `terraform apply` no longer panics when the plan contains a no-op change for a deposed resource that has `lifecycle.precondition` or `lifecycle.postcondition` blocks. ([#38586](https://github.com/hashicorp/terraform/issues/38586))
 
-* workspace: Terraform will now error if an invalid workspace name becomes selected due to actions performed out-of-band ([#38594](https://github.com/hashicorp/terraform/issues/38594))
+* workspace: Terraform now raises an error if an invalid workspace name becomes selected due to out-of-band changes. ([#38594](https://github.com/hashicorp/terraform/issues/38594))
 
-* test: Terraform will now raise a warning when a file referenced via `-filter` flag does not exist. ([#38603](https://github.com/hashicorp/terraform/issues/38603))
+* test: Terraform now raises a warning when a file referenced via the `-filter` flag does not exist. ([#38603](https://github.com/hashicorp/terraform/issues/38603))
 
-* init: Stop removing locks from the dependency lock file corresponding to providers configured as a dev_override ([#38634](https://github.com/hashicorp/terraform/issues/38634))
+* init: Terraform no longer removes locks from the dependency lock file for providers configured as `dev_override`. ([#38634](https://github.com/hashicorp/terraform/issues/38634))
 
-* init: Add warnings when unmanaged providers are in use and will impact provider installation processes. ([#38656](https://github.com/hashicorp/terraform/issues/38656))
+* init: Terraform now warns when unmanaged providers are in use and may impact provider installation. ([#38656](https://github.com/hashicorp/terraform/issues/38656))
 
 * Actions are now invoked with respect to all resource dependencies. ([#38668](https://github.com/hashicorp/terraform/issues/38668))
 
-* return correct error when import target exists in state, but not config ([#38782](https://github.com/hashicorp/terraform/issues/38782))
+* Terraform now returns the correct error when an `import` target exists in state but has no corresponding configuration. ([#38782](https://github.com/hashicorp/terraform/issues/38782))
 
-* merge no longer panics with null objects ([#38792](https://github.com/hashicorp/terraform/issues/38792))
+* The `merge()` function no longer panics when passed `null` objects. ([#38792](https://github.com/hashicorp/terraform/issues/38792))
 
 
 NOTES:
@@ -73,7 +73,7 @@ NOTES:
 
 UPGRADE NOTES:
 
-* Provisioner bastion_host_key is now correctly applied. Existing usage of bastion_host_key should verify the configured key is correct. ([#38318](https://github.com/hashicorp/terraform/issues/38318))
+* `bastion_host_key` is now correctly applied by provisioners. Review your provisioner configurations to verify the configured key is correct before upgrading. ([#38318](https://github.com/hashicorp/terraform/issues/38318))
 
 
 EXPERIMENTS:


### PR DESCRIPTION
I mentioned that I thought the v1.16 change log could be cleaned up, so instead of leaving it at that here are some proposed changes. My understanding is that in the past, before `changie` was introduced for changelog generation, it was usual for an engineer to edit the changelog of a new release and introduce consistency then. This PR serves the same purpose.

To get these results I:
* Explored the change files for v1.16 and identified some easy changes to make:
    * Consistent 'enhancement' type for adding `-json` support.
* Used an agent to analyse changelogs for v1.0 to the present day v1.16 changelog and propose a style guide for the entries.
    * During this process I:
        * Emphasised user-facing language is important
        * Chose to standardise on active voice over passive voice, and use present tense
        * Chose consistent use of backticks to format flags/block names/identifiers.
        * Specified to use sentence case
        * Specified to use a prefix if a change is scoped to a specific command or backend implementation.
* Started a new agent session and tasked that agent with using the style guide to propose changes to the change files for v1.16.
* For each proposed change I manually reviewed and accepted/rejected proposed changes. For example, some of the actions-related changes were going to mistakenly have a `stacks:` prefix added.

As team we need to agree on any skills etc used to enforce a style guide on our changelog, and when this was previously discussed interest was low. Therefore this PR is not introducing a style guide, it is only proposing changes to the v1.16 change files based on an initial version of that style guide.

We can merge this PR or just use it as the start of discussions - happy for whatever.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
