### PR TITLE
forget: do not return references for resources being forgotten (fixes cycle errors)

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -5275,12 +5275,12 @@ resource "test_object" "forget_too" {
 	)
 
 	plan, diags := ctx.Plan(m, state, &PlanOpts{Mode: plans.DestroyMode})
-	assertNoDiagnostics(t, diags)
+	if !diags.HasWarnings() { // forgetting emits a warning, but there should be no errors.
+		t.Errorf("missing expected forget warning")
+	}
+	assertNoDiagnostics(t, diags.ErrorsOnly())
 
 	state, applyDiags := ctx.Apply(plan, m, nil)
-	if len(diags) > 0 {
-		fmt.Printf("%v\n", diags.ErrWithWarnings())
-	}
 	assertNoDiagnostics(t, applyDiags)
 	if !state.Empty() {
 		t.Fatal("unexpected resources in state")

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -243,7 +243,7 @@ resource "test_instance" "a" {
 		s.SetResourceInstanceCurrent(addrB, &states.ResourceInstanceObjectSrc{
 			AttrsJSON:    []byte(`{"id":"b"}`),
 			Status:       states.ObjectReady,
-			Dependencies: []addrs.ConfigResource{addrA.ContainingResource().Config()},
+			Dependencies: []addrs.ConfigResource{addrA.ConfigResource()},
 		}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
 	})
 
@@ -5219,4 +5219,70 @@ resource test_object default {}
 			t.Fatalf("wrong number of resources remaining in state")
 		}
 	})
+}
+
+func TestContext2Apply_forget_cycle(t *testing.T) {
+	// three cheers for users who test alpha releases!
+	// https://github.com/hashicorp/terraform/issues/38898
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "forget" {
+	test_string = test_object.forget_too.test_string
+	lifecycle {
+		destroy = false
+	}
+}
+
+resource "test_object" "forget_too" {
+	test_string = "hi"
+	lifecycle {
+		destroy = false
+	}
+}
+`})
+
+	p := simpleMockProvider()
+
+	hook := new(MockHook)
+	ctx := testContext2(t, &ContextOpts{
+		Hooks: []Hook{hook},
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	forget := mustResourceInstanceAddr("test_object.forget")
+	forget2 := mustResourceInstanceAddr("test_object.forget_too")
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		forget.Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"test_string":"hi"}`),
+			Dependencies: []addrs.ConfigResource{forget2.ConfigResource()},
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+	)
+	root.SetResourceInstanceCurrent(
+		forget2.Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"test_string":"hi"}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+	)
+
+	plan, diags := ctx.Plan(m, state, &PlanOpts{Mode: plans.DestroyMode})
+	assertNoDiagnostics(t, diags)
+
+	state, applyDiags := ctx.Apply(plan, m, nil)
+	if len(diags) > 0 {
+		fmt.Printf("%v\n", diags.ErrWithWarnings())
+	}
+	assertNoDiagnostics(t, applyDiags)
+	if !state.Empty() {
+		t.Fatal("unexpected resources in state")
+	}
 }

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -92,9 +92,7 @@ func (n *NodeDestroyResourceInstance) ReferenceableAddrs() []addrs.Referenceable
 }
 
 func (n *NodeDestroyResourceInstance) References() []*addrs.Reference {
-	// destroyers don't reference, except when we need destroy actions to be
-	// reevaluated.
-	return n.destroyActionPlanReferences()
+	return nil
 }
 
 // GraphNodeExecutable

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -251,6 +251,11 @@ func (n *NodeDestroyDeposedResourceInstanceObject) ReferenceableAddrs() []addrs.
 	return nil
 }
 
+func (n *NodeDestroyDeposedResourceInstanceObject) References() []*addrs.Reference {
+	// Deposed objects don't participate in references.
+	return nil
+}
+
 // GraphNodeDestroyer
 func (n *NodeDestroyDeposedResourceInstanceObject) DestroyAddr() *addrs.AbsResourceInstance {
 	addr := n.ResourceInstanceAddr()

--- a/internal/terraform/node_resource_forget.go
+++ b/internal/terraform/node_resource_forget.go
@@ -34,6 +34,11 @@ func (n *NodeForgetResourceInstance) DestroyAddr() *addrs.AbsResourceInstance {
 	return &n.Addr
 }
 
+func (n *NodeForgetResourceInstance) References() []*addrs.Reference {
+	// Forgotten resources don't participate in references
+	return nil
+}
+
 func (n *NodeForgetResourceInstance) Name() string {
 	return n.ResourceInstanceAddr().String() + " (forget)"
 }

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -89,7 +89,7 @@ func (n *NodePlannableResourceInstanceOrphan) ReferenceableAddrs() []addrs.Refer
 }
 
 func (n *NodePlannableResourceInstanceOrphan) References() (refs []*addrs.Reference) {
-	return n.destroyActionPlanReferences()
+	return nil
 }
 
 func (n *NodePlannableResourceInstanceOrphan) AttachActionTriggers(triggers []*resourceActionTrigger) {


### PR DESCRIPTION
This fixes the cycle error reported in #38898 by overriding References inside NodeForgetResourceInstance to behave the same way destroy & deposed references work: they don't (no references)


Closes #38898