### PR TITLE
chore: gitignore the .bob IDE directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ coverage.txt
 # IDEs
 .vscode/
 .zed/
+.bob/


### PR DESCRIPTION
My understanding is that a `.bob/` directory is _usually_ in a person's home directory, but it is possible to create them within projects. Teams might commit `.bob/skills` etc to version control, though we're unlikely to, so I propose we ignore the whole thing.

A `.bob/` directory can include secrets, so I think it's worth gitignoring in this project to avoid accidents.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
