### PR TITLE
command/state-migrate: Implement support for upgrades

### DIFF
--- a/internal/command/e2etest/pluggable_state_store_test.go
+++ b/internal/command/e2etest/pluggable_state_store_test.go
@@ -412,6 +412,102 @@ func TestPrimary_stateStore_stateMigrateCmd_upgrade(t *testing.T) {
 	}
 }
 
+func TestPrimary_stateStore_stateMigrateCmd_upgrade_failure(t *testing.T) {
+	t.Parallel()
+	if !canRunGoBuild {
+		// We're running in a separate-build-then-run context, so we can't
+		// currently execute this test which depends on being able to build
+		// new executable at runtime.
+		//
+		// (See the comment on canRunGoBuild's declaration for more information.)
+		t.Skip("can't run without building a new provider executable")
+	}
+
+	fixturePath := filepath.Join("testdata", "state-migrate-upgrade")
+
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
+
+	// setup FS mirror
+	tmpDir := t.TempDir()
+	mirrorPath := filepath.Join(tmpDir, "mirror")
+	cliCfgFilePath := filepath.Join(tmpDir, "test.tfrc")
+	cfgBody := fmt.Sprintf(`provider_installation {
+  filesystem_mirror {
+    path    = %q
+    include = ["registry.terraform.io/hashicorp/simple6"]
+  }
+  direct {
+    exclude = ["registry.terraform.io/hashicorp/simple6"]
+  }
+}
+`, mirrorPath)
+	os.WriteFile(cliCfgFilePath, []byte(cfgBody), 0o700)
+	tf.AddEnv("TF_CLI_CONFIG_FILE=" + cliCfgFilePath)
+
+	// In order to test integration with PSS we need two provider plugins implementing a state store
+	// which we can tell apart to be able to verify successful upgrade between them.
+	platform := getproviders.CurrentPlatform.String()
+	// Build v1.0.0 plugin
+	simpleProviderv1 := filepath.Join(t.TempDir(), "terraform-provider-simple6")
+	simpleProviderv1Exe := e2e.GoBuild("github.com/hashicorp/terraform/internal/provider-simple-v6/main",
+		simpleProviderv1, "-ldflags", "-X 'main.fsStatesDir=v1.tfstate.d'")
+	providerv1MirrorPath := filepath.Join(mirrorPath, "registry.terraform.io", "hashicorp", "simple6", "1.0.0")
+	if err := os.MkdirAll(filepath.Join(providerv1MirrorPath, platform), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(simpleProviderv1Exe, filepath.Join(providerv1MirrorPath, platform, "terraform-provider-simple6")); err != nil {
+		t.Fatal(err)
+	}
+	// assume there is no v2.0.0 in the FS mirror
+
+	stdout, stderr, err := tf.Run("state", "migrate", "-upgrade", "-input=false", "-force-copy", "-no-color")
+	if err == nil {
+		t.Fatalf("expected error, got none\nstderr:\n%q\n\nstdout: %q", stderr, stdout)
+	}
+
+	expectedErrMsg := `Could not retrieve the list of available versions for provider
+hashicorp/simple6: no available releases match the given constraints 2.0.0`
+	if !strings.Contains(stderr, expectedErrMsg) {
+		t.Fatalf("unexpected stderr\ngiven: %q\nexpected to find: %q", stderr, expectedErrMsg)
+	}
+
+	expectedMsg := []string{
+		`Initializing provider hashicorp/simple6 (1.0.0) for state store "simple6_fs"...
+- Reusing version 1.0.0 of hashicorp/simple6 from the dependency lock file
+- Installing hashicorp/simple6 v1.0.0...`,
+		`Initializing provider hashicorp/simple6 (2.0.0) for state store "simple6_fs"...
+- Finding hashicorp/simple6 versions matching "2.0.0"...`,
+	}
+	for _, expectedMsg := range expectedMsg {
+		if !strings.Contains(stdout, expectedMsg) {
+			t.Fatalf("expected output %q, got %q", expectedMsg, stdout)
+		}
+	}
+
+	// verify state still exists in the old location
+	newStatePath := filepath.Join(tf.WorkDir(), "v1.tfstate.d", "default", "terraform.tfstate")
+	newStateFile, err := os.Open(newStatePath)
+	t.Cleanup(func() { newStateFile.Close() })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify lockfile has the provider still set at OLD version
+	lockPath := filepath.Join(tf.WorkDir(), depsfile.LockFilePath)
+	updatedLocks, diags := depsfile.LoadLocksFromFile(lockPath)
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %s", diags)
+	}
+	pAddr := addrs.MustParseProviderSourceString("hashicorp/simple6")
+	pLock := updatedLocks.Provider(pAddr)
+
+	expectedVersion := getproviders.MustParseVersion("1.0.0")
+	givenVersion := pLock.Version()
+	if expectedVersion.String() != givenVersion.String() {
+		t.Fatalf("mismatching version, expected %s, given %s", expectedVersion, givenVersion)
+	}
+}
+
 // Tests using the `terraform output` command in combination with pluggable state storage:
 // > `terraform output`
 // > `terraform output <name>`

--- a/internal/command/e2etest/pluggable_state_store_test.go
+++ b/internal/command/e2etest/pluggable_state_store_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/e2e"
 	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/states"
@@ -280,6 +281,134 @@ resource "terraform_data" "my-data" {
 `
 	if diff := cmp.Diff(stdout, expectedMsg); diff != "" {
 		t.Errorf("wrong result, diff:\n%s", diff)
+	}
+}
+
+// Test using `terraform state migrate` subcommand
+func TestPrimary_stateStore_stateMigrateCmd_upgrade(t *testing.T) {
+	t.Parallel()
+	if !canRunGoBuild {
+		// We're running in a separate-build-then-run context, so we can't
+		// currently execute this test which depends on being able to build
+		// new executable at runtime.
+		//
+		// (See the comment on canRunGoBuild's declaration for more information.)
+		t.Skip("can't run without building a new provider executable")
+	}
+
+	fixturePath := filepath.Join("testdata", "state-migrate-upgrade")
+
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
+
+	// Load old state for comparison
+	oldStatePath := filepath.Join(tf.WorkDir(), "v1.tfstate.d", "default", "terraform.tfstate")
+	oldStateFile, err := os.Open(oldStatePath)
+	t.Cleanup(func() { oldStateFile.Close() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldState, err := statefile.Read(oldStateFile)
+	oldStateFile.Close()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// setup FS mirror
+	tmpDir := t.TempDir()
+	mirrorPath := filepath.Join(tmpDir, "mirror")
+	cliCfgFilePath := filepath.Join(tmpDir, "test.tfrc")
+	cfgBody := fmt.Sprintf(`provider_installation {
+  filesystem_mirror {
+    path    = %q
+    include = ["registry.terraform.io/hashicorp/simple6"]
+  }
+  direct {
+    exclude = ["registry.terraform.io/hashicorp/simple6"]
+  }
+}
+`, mirrorPath)
+	os.WriteFile(cliCfgFilePath, []byte(cfgBody), 0o700)
+	tf.AddEnv("TF_CLI_CONFIG_FILE=" + cliCfgFilePath)
+
+	// In order to test integration with PSS we need two provider plugins implementing a state store
+	// which we can tell apart to be able to verify successful upgrade between them.
+	platform := getproviders.CurrentPlatform.String()
+	// Build v1.0.0 plugin
+	simpleProviderv1 := filepath.Join(t.TempDir(), "terraform-provider-simple6")
+	simpleProviderv1Exe := e2e.GoBuild("github.com/hashicorp/terraform/internal/provider-simple-v6/main",
+		simpleProviderv1, "-ldflags", "-X 'main.fsStatesDir=v1.tfstate.d'")
+	providerv1MirrorPath := filepath.Join(mirrorPath, "registry.terraform.io", "hashicorp", "simple6", "1.0.0")
+	if err := os.MkdirAll(filepath.Join(providerv1MirrorPath, platform), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(simpleProviderv1Exe, filepath.Join(providerv1MirrorPath, platform, "terraform-provider-simple6")); err != nil {
+		t.Fatal(err)
+	}
+	// Build v2.0.0 plugin
+	simpleProviderv2 := filepath.Join(t.TempDir(), "terraform-provider-simple6")
+	simpleProviderv2Exe := e2e.GoBuild("github.com/hashicorp/terraform/internal/provider-simple-v6/main",
+		simpleProviderv2, "-ldflags", "-X 'main.fsStatesDir=v2.tfstate.d'")
+	providerv2MirrorPath := filepath.Join(mirrorPath, "registry.terraform.io", "hashicorp", "simple6", "2.0.0")
+	if err := os.MkdirAll(filepath.Join(providerv2MirrorPath, platform), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(simpleProviderv2Exe, filepath.Join(providerv2MirrorPath, platform, "terraform-provider-simple6")); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := tf.Run("state", "migrate", "-upgrade", "-input=false", "-force-copy", "-no-color")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%q", err, stderr)
+	}
+
+	expectedMsg := []string{
+		`Initializing provider hashicorp/simple6 (1.0.0) for state store "simple6_fs"...
+- Reusing version 1.0.0 of hashicorp/simple6 from the dependency lock file
+- Installing hashicorp/simple6 v1.0.0...`,
+		`Initializing provider hashicorp/simple6 (2.0.0) for state store "simple6_fs"...
+- Finding hashicorp/simple6 versions matching "2.0.0"...
+- Installing hashicorp/simple6 v2.0.0...`,
+		`Migrating state from state store "simple6_fs" (hashicorp/simple6 1.0.0) to state store "simple6_fs" (hashicorp/simple6 2.0.0)...`,
+		`Finished migrating state from state store "simple6_fs" (hashicorp/simple6 1.0.0) to state store "simple6_fs" (hashicorp/simple6 2.0.0).`,
+	}
+	for _, expectedMsg := range expectedMsg {
+		if !strings.Contains(stdout, expectedMsg) {
+			t.Fatalf("expected output %q, got %q", expectedMsg, stdout)
+		}
+	}
+
+	// verify state exists in the new location
+	newStatePath := filepath.Join(tf.WorkDir(), "v2.tfstate.d", "default", "terraform.tfstate")
+	newStateFile, err := os.Open(newStatePath)
+	t.Cleanup(func() { newStateFile.Close() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Load new state for comparison
+	newState, err := statefile.Read(newStateFile)
+	newStateFile.Close()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// verify state contents
+	if diff := cmp.Diff(oldState.State.String(), newState.State.String()); diff != "" {
+		t.Fatalf("unexpected state: %s", diff)
+	}
+
+	// verify lockfile was updated
+	lockPath := filepath.Join(tf.WorkDir(), depsfile.LockFilePath)
+	updatedLocks, diags := depsfile.LoadLocksFromFile(lockPath)
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %s", diags)
+	}
+	pAddr := addrs.MustParseProviderSourceString("hashicorp/simple6")
+	pLock := updatedLocks.Provider(pAddr)
+
+	expectedVersion := getproviders.MustParseVersion("2.0.0")
+	givenVersion := pLock.Version()
+	if expectedVersion.String() != givenVersion.String() {
+		t.Fatalf("mismatching version, expected %s, given %s", expectedVersion, givenVersion)
 	}
 }
 

--- a/internal/command/e2etest/testdata/state-migrate-upgrade/.terraform.lock.hcl
+++ b/internal/command/e2etest/testdata/state-migrate-upgrade/.terraform.lock.hcl
@@ -1,0 +1,6 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/simple6" {
+  version = "1.0.0"
+}

--- a/internal/command/e2etest/testdata/state-migrate-upgrade/upgrade-from.tfmigrate.hcl
+++ b/internal/command/e2etest/testdata/state-migrate-upgrade/upgrade-from.tfmigrate.hcl
@@ -1,0 +1,13 @@
+state_store_provider {
+  simple6 = {
+    source  = "registry.terraform.io/hashicorp/simple6"
+    version = "1.0.0"
+  }
+}
+
+from {
+  state_store "simple6_fs" {
+    provider "simple6" {}
+    // workspace_dir set to v1.tfstate.d during build
+  }
+}

--- a/internal/command/e2etest/testdata/state-migrate-upgrade/upgrade-to.tf
+++ b/internal/command/e2etest/testdata/state-migrate-upgrade/upgrade-to.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    simple6 = {
+      source  = "registry.terraform.io/hashicorp/simple6"
+      version = "2.0.0"
+    }
+  }
+
+  state_store "simple6_fs" {
+    provider "simple6" {}
+    // workspace_dir set to v2.tfstate.d during build
+  }
+}
+
+variable "name" {
+  default = "world"
+}
+
+resource "terraform_data" "my-data" {
+  input = "hello ${var.name}"
+}

--- a/internal/command/e2etest/testdata/state-migrate-upgrade/v1.tfstate.d/default/terraform.tfstate
+++ b/internal/command/e2etest/testdata/state-migrate-upgrade/v1.tfstate.d/default/terraform.tfstate
@@ -1,0 +1,40 @@
+{
+    "version": 4,
+    "terraform_version": "1.16.0",
+    "serial": 1,
+    "lineage": "9e13d881-e480-7a63-d47a-b4f5224e6743",
+    "outputs": {
+        "greeting": {
+            "value": "hello world",
+            "type": "string"
+        }
+    },
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "terraform_data",
+            "name": "my-data",
+            "provider": "provider[\"terraform.io/builtin/terraform\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "id": "d71fb368-2ba1-fb4c-5bd9-6a2b7f05d60c",
+                        "input": {
+                            "value": "hello world",
+                            "type": "string"
+                        },
+                        "output": {
+                            "value": "hello world",
+                            "type": "string"
+                        },
+                        "triggers_replace": null
+                    },
+                    "sensitive_attributes": [],
+                    "identity_schema_version": 0
+                }
+            ]
+        }
+    ],
+    "check_results": null
+}

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -124,7 +124,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			return 1
 		}
 
-		upgrade := false // The first provider download step will never be an upgrade. Either it's constrained by a preexisting lock or there is no lock.
+		upgrade := false // The source provider download step will never be an upgrade. Either it's constrained by a preexisting lock or there is no lock.
 		var srcProviderDiags tfdiags.Diagnostics
 		var output bool
 		output, sourceLock, srcProviderDiags = c.getSingleProvider(ctx, smi.StateStore, smi.StateStoreProvider.Requirement, srcLocks, upgrade, MigrationSource, view)
@@ -227,7 +227,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		//
 		// We only pass in a single required provider, so we expect a single lock to be
 		// returned. This will be added the dependency lock file after a successful migration.
-		upgrade := false // TODO - control this by -upgrade flag
+		upgrade := args.Upgrade
 		var dstProviderDiags tfdiags.Diagnostics
 		var output bool
 		output, destinationLock, dstProviderDiags = c.getSingleProvider(ctx, rootMod.StateStore, dstReq, mergedLocks, upgrade, MigrationDestination, view)


### PR DESCRIPTION
Depends on https://github.com/hashicorp/terraform/pull/38918

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
