### PR TITLE
e2etest: Introduce buildArgs for GoBuild

### DIFF
--- a/internal/command/e2etest/main_test.go
+++ b/internal/command/e2etest/main_test.go
@@ -59,9 +59,8 @@ func setup() func() {
 	terraformBin = tmpFilename
 
 	// Make an experimental TF executable available for use in tests
-	os.Setenv(e2e.TestExperimentFlag, "true")
-	defer os.Unsetenv(e2e.TestExperimentFlag)
-	tmpExperimentalFilename := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
+	tmpExperimentalFilename := e2e.GoBuild("github.com/hashicorp/terraform", "terraform",
+		e2e.TestExperimentsAllowedArgs...)
 	experimentalTerraformBin = tmpExperimentalFilename
 
 	// Tests running in the ad-hoc testing mode are allowed to use "go build"

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -19,10 +19,9 @@ import (
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
 
-// TestExperimentFlag is the name of the environment variable that
-// can be set to built a terraform binary with experimental features enabled.
-// Any value besides "false" or an empty string will enable the feature.
-var TestExperimentFlag = "TF_TEST_EXPERIMENTS"
+// TestExperimentsAllowedArgs is a slice of args that can be passed to [GoBuild]
+// to build a terraform binary with experimental features enabled.
+var TestExperimentsAllowedArgs = []string{"-ldflags", "-X 'main.experimentsAllowed=yes'"}
 
 // Type binary represents the combination of a compiled binary
 // and a temporary working directory to run it in.
@@ -254,7 +253,7 @@ func (b *binary) SetLocalState(state *states.State) error {
 	return statefile.Write(sf, f)
 }
 
-func GoBuild(pkgPath, tmpPrefix string) string {
+func GoBuild(pkgPath, tmpPrefix string, buildArgs ...string) string {
 	dir, prefix := filepath.Split(tmpPrefix)
 	tmpFile, err := os.CreateTemp(dir, prefix)
 	if err != nil {
@@ -266,8 +265,8 @@ func GoBuild(pkgPath, tmpPrefix string) string {
 	}
 
 	args := []string{"build", "-o", tmpFilename}
-	if exp := os.Getenv(TestExperimentFlag); exp != "" && exp != "false" {
-		args = append(args, "-ldflags", "-X 'main.experimentsAllowed=yes'")
+	if len(buildArgs) > 0 {
+		args = append(args, buildArgs...)
 	}
 	args = append(args, pkgPath)
 	cmd := exec.Command("go", args...)


### PR DESCRIPTION
This is to enable (E2E) tests to pass arbitrary build arguments while building a binary. Currently build arguments are only needed to build a version of Terraform with experiments enabled but in https://github.com/hashicorp/terraform/pull/38908 I'm planning on using the same function to build providers and there I would like to use some other build arguments.

Aside from this specific use case though I do believe the explicit arg-passing is a cleaner way of solving this than environment variables, which have tendency to leak to various places, complicate tests running in parallel etc.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
