### PR TITLE
provider-simple-v6: Enable state dir to be set at build time

### DIFF
--- a/internal/provider-simple-v6/main/main.go
+++ b/internal/provider-simple-v6/main/main.go
@@ -7,13 +7,23 @@ import (
 	"github.com/hashicorp/terraform/internal/grpcwrap"
 	plugin "github.com/hashicorp/terraform/internal/plugin6"
 	simple "github.com/hashicorp/terraform/internal/provider-simple-v6"
+	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfplugin6"
 )
 
+var fsStatesDir string
+
 func main() {
+	var p providers.Interface
+	if fsStatesDir == "" {
+		p = simple.Provider()
+	} else {
+		p = simple.ProviderWithFsStatesDir(fsStatesDir)
+	}
+
 	plugin.Serve(&plugin.ServeOpts{
 		GRPCProviderFunc: func() tfplugin6.ProviderServer {
-			return grpcwrap.Provider6(simple.Provider())
+			return grpcwrap.Provider6(p)
 		},
 	})
 }

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -34,10 +34,16 @@ func Provider() providers.Interface {
 	return provider()
 }
 
-// ProviderWithDefaultState returns an instance of providers.Interface,
+func ProviderWithFsStatesDir(statesDir string) providers.Interface {
+	p := provider()
+	p.fs.statesDir = statesDir
+	return p
+}
+
+// ProviderWithInMemDefaultState returns an instance of providers.Interface,
 // where the underlying simple struct has been changed to indicate that the
 // 'default' state has already been created as an empty state file.
-func ProviderWithDefaultState() providers.Interface {
+func ProviderWithInMemDefaultState() providers.Interface {
 	// Get the empty state file as bytes
 	f := statefile.New(nil, "", 0)
 

--- a/internal/provider-simple-v6/state_store_fs.go
+++ b/internal/provider-simple-v6/state_store_fs.go
@@ -75,7 +75,7 @@ func (f *FsStore) ConfigureStateStore(req providers.ConfigureStateStoreRequest) 
 	configVal := req.Config
 	if v := configVal.GetAttr("workspace_dir"); !v.IsNull() {
 		f.statesDir = v.AsString()
-	} else {
+	} else if f.statesDir == "" {
 		f.statesDir = defaultStatesDir
 	}
 

--- a/internal/provider-simple-v6/state_store_inmem_test.go
+++ b/internal/provider-simple-v6/state_store_inmem_test.go
@@ -17,7 +17,7 @@ import (
 func TestInMemStoreLocked(t *testing.T) {
 	// backend.TestBackendStateLocks assumes the "default" state exists
 	// by default, so we need to make it exist using the method below.
-	provider := ProviderWithDefaultState()
+	provider := ProviderWithInMemDefaultState()
 
 	plug1, err := pluggable.NewPluggable(provider, inMemStoreName)
 	if err != nil {


### PR DESCRIPTION
This enables state directory within `provider-simple-v6` to be set at build time, which in combination with https://github.com/hashicorp/terraform/pull/38915 allows us to test provider upgrade scenarios in https://github.com/hashicorp/terraform/pull/38908

I also renamed an existing helper function as I'm adding a new one and this clarifies what each one is for.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
