### PR TITLE
Node query resource policy execution

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -155,6 +155,16 @@ type (
 
 		// A combination of Policy- and Enforcement-level diagnostics.
 		Diagnostics Diagnostics
+
+		// Identity is a structured map of the identity attributes for the resource that
+		// was evaluated. It is only populated for query (list block) resources and is used
+		// by downstream consumers to correlate results to rows in the UI.
+		Identity map[string]string
+
+		// ListBlockAddr is the string address of the list block that originated this
+		// evaluation. It is only populated for query (list block) resources and is used
+		// to group results by their originating list block.
+		ListBlockAddr string
 	}
 )
 
@@ -228,6 +238,15 @@ func (r EvaluationResponse) WithLocalRange(localRange *hcl.Range) EvaluationResp
 	for idx := range r.Enforcements {
 		r.Enforcements[idx].LocalRange = localRange
 	}
+	return r
+}
+
+// WithQueryMetadata returns a copy of the response annotated with the identity map and list
+// block address. These fields are used by downstream consumers (UI, cloud backend) to correlate
+// policy results to the specific query row that produced them.
+func (r EvaluationResponse) WithQueryMetadata(identity map[string]string, listBlockAddr string) EvaluationResponse {
+	r.Identity = identity
+	r.ListBlockAddr = listBlockAddr
 	return r
 }
 

--- a/internal/terraform/context.go
+++ b/internal/terraform/context.go
@@ -7,7 +7,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"runtime"
 	"sort"
+	"strconv"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"
@@ -104,6 +107,8 @@ type Context struct {
 
 	l                   sync.Mutex // Lock acquired during any task
 	parallelSem         Semaphore
+	policySem           Semaphore
+	policySemOnce       sync.Once
 	providerInputConfig map[string]map[string]cty.Value
 	runCond             *sync.Cond
 	runContext          context.Context
@@ -197,6 +202,36 @@ type ContextGraphOpts struct {
 
 	// Legacy graphs only: won't prune the graph
 	Verbose bool
+}
+
+// policySemaphore returns the semaphore used to limit concurrent policy
+// evaluations. It is initialized lazily on first access with a capacity
+// determined by GOMAXPROCS or the TF_POLICY_PARALLELISM environment variable.
+func (c *Context) policySemaphore() Semaphore {
+	c.policySemOnce.Do(func() {
+		capacity := getPolicyParallelism()
+		c.policySem = NewSemaphore(capacity)
+		log.Printf("[DEBUG] Policy evaluation semaphore initialized with capacity %d", capacity)
+	})
+	return c.policySem
+}
+
+// getPolicyParallelism determines the parallelism level for policy evaluations.
+// It checks the TF_POLICY_PARALLELISM environment variable first, and falls back
+// to GOMAXPROCS if the variable is not set or contains an invalid value.
+func getPolicyParallelism() int {
+	if envVal := os.Getenv("TF_POLICY_PARALLELISM"); envVal != "" {
+		if n, err := strconv.Atoi(envVal); err == nil && n > 0 {
+			log.Printf("[DEBUG] Using TF_POLICY_PARALLELISM=%d for policy evaluation parallelism", n)
+			return n
+		}
+		log.Printf("[WARN] Invalid TF_POLICY_PARALLELISM value %q, falling back to GOMAXPROCS", envVal)
+	}
+
+	// Default to GOMAXPROCS
+	n := runtime.GOMAXPROCS(0)
+	log.Printf("[DEBUG] Using GOMAXPROCS=%d for policy evaluation parallelism", n)
+	return n
 }
 
 // Stop stops the running task.

--- a/internal/terraform/context.go
+++ b/internal/terraform/context.go
@@ -108,7 +108,6 @@ type Context struct {
 	l                   sync.Mutex // Lock acquired during any task
 	parallelSem         Semaphore
 	policySem           Semaphore
-	policySemOnce       sync.Once
 	providerInputConfig map[string]map[string]cty.Value
 	runCond             *sync.Cond
 	runContext          context.Context
@@ -170,6 +169,7 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 		plugins: plugins,
 
 		parallelSem:         NewSemaphore(par),
+		policySem:           NewSemaphore(getPolicyParallelism()),
 		providerInputConfig: make(map[string]map[string]cty.Value),
 		sh:                  sh,
 		tracingCtx:          opts.TracingContext,
@@ -205,14 +205,9 @@ type ContextGraphOpts struct {
 }
 
 // policySemaphore returns the semaphore used to limit concurrent policy
-// evaluations. It is initialized lazily on first access with a capacity
-// determined by GOMAXPROCS or the TF_POLICY_PARALLELISM environment variable.
+// evaluations. Its capacity is determined at context construction time by
+// GOMAXPROCS or the TF_POLICY_PARALLELISM environment variable.
 func (c *Context) policySemaphore() Semaphore {
-	c.policySemOnce.Do(func() {
-		capacity := getPolicyParallelism()
-		c.policySem = NewSemaphore(capacity)
-		log.Printf("[DEBUG] Policy evaluation semaphore initialized with capacity %d", capacity)
-	})
 	return c.policySem
 }
 

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -235,6 +235,12 @@ type EvalContext interface {
 	// Absent if policy evaluation is not enabled.
 	PolicyClient() policy.Client
 
+	// PolicySemaphore returns the semaphore used to limit concurrent policy
+	// evaluations. This is separate from the provider operation semaphore to
+	// ensure policy evaluations don't consume provider parallelism slots.
+	// Returns nil if policy evaluation is not enabled.
+	PolicySemaphore() Semaphore
+
 	Config() *configs.Config
 
 	// Deprecations returns the deprecations object that tracks meta-information

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -97,6 +97,7 @@ type BuiltinEvalContext struct {
 	OverrideValues          *mocking.Overrides
 	ProviderLocksValue      map[addrs.Provider]*depsfile.ProviderLock
 	PolicyClientValue       policy.Client
+	PolicySemaphoreValue    Semaphore
 	DeprecationsValue       *deprecation.Deprecations
 }
 
@@ -106,6 +107,10 @@ func (ctx *BuiltinEvalContext) ProviderLocks() map[addrs.Provider]*depsfile.Prov
 
 func (ctx *BuiltinEvalContext) PolicyClient() policy.Client {
 	return ctx.PolicyClientValue
+}
+
+func (ctx *BuiltinEvalContext) PolicySemaphore() Semaphore {
+	return ctx.PolicySemaphoreValue
 }
 
 func (ctx *BuiltinEvalContext) PolicyGraph() *policySubgraph {

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -61,11 +61,6 @@ type MockEvalContext struct {
 	ProviderSchemaSchema providers.ProviderSchema
 	ProviderSchemaError  error
 
-	ResourceIdentitySchemasCalled  bool
-	ResourceIdentitySchemasAddr    addrs.AbsProviderConfig
-	ResourceIdentitySchemasSchemas providers.ResourceIdentitySchemas
-	ResourceIdentitySchemasError   error
-
 	CloseProviderCalled   bool
 	CloseProviderAddr     addrs.AbsProviderConfig
 	CloseProviderProvider providers.Interface
@@ -173,11 +168,12 @@ type MockEvalContext struct {
 	ForgetCalled bool
 	ForgetValues bool
 
-	ProviderLocksValue map[addrs.Provider]*depsfile.ProviderLock
-	PolicyClientValue  policy.Client
-	ConfigValue        *configs.Config
-	DeprecationCalled  bool
-	DeprecationState   *deprecation.Deprecations
+	ProviderLocksValue   map[addrs.Provider]*depsfile.ProviderLock
+	PolicyClientValue    policy.Client
+	PolicySemaphoreValue Semaphore
+	ConfigValue          *configs.Config
+	DeprecationCalled    bool
+	DeprecationState     *deprecation.Deprecations
 }
 
 // MockEvalContext implements EvalContext
@@ -224,12 +220,6 @@ func (c *MockEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) (provider
 	c.ProviderSchemaCalled = true
 	c.ProviderSchemaAddr = addr
 	return c.ProviderSchemaSchema, c.ProviderSchemaError
-}
-
-func (c *MockEvalContext) ResourceIdentitySchemas(addr addrs.AbsProviderConfig) (providers.ResourceIdentitySchemas, error) {
-	c.ResourceIdentitySchemasCalled = true
-	c.ResourceIdentitySchemasAddr = addr
-	return c.ResourceIdentitySchemasSchemas, c.ProviderSchemaError
 }
 
 func (c *MockEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error {
@@ -468,6 +458,10 @@ func (c *MockEvalContext) ProviderLocks() map[addrs.Provider]*depsfile.ProviderL
 
 func (c *MockEvalContext) PolicyClient() policy.Client {
 	return c.PolicyClientValue
+}
+
+func (c *MockEvalContext) PolicySemaphore() Semaphore {
+	return c.PolicySemaphoreValue
 }
 
 func (c *MockEvalContext) Config() *configs.Config {

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -159,6 +159,7 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		forget:                  w.Forget,
 		ProviderLocksValue:      w.ProviderLocks,
 		PolicyClientValue:       w.PolicyClient,
+		PolicySemaphoreValue:    w.Context.policySemaphore(),
 		DeprecationsValue:       w.Deprecations,
 	}
 

--- a/internal/terraform/node_policy_resource.go
+++ b/internal/terraform/node_policy_resource.go
@@ -80,9 +80,6 @@ func (n *nodeResourcePolicy) Execute(ctx EvalContext, operation walkOperation) t
 	}
 
 	result := evaluatePolicies(ctx, n.ResourceAddr, resourceConfig, n.After, n.Before, meta, callbacks)
-	if resourceConfig != nil {
-		result = result.WithLocalRange(resourceConfig.DeclRange.Ptr())
-	}
 	if !result.Empty() {
 		hookErr := ctx.Hook(func(h Hook) (HookAction, error) {
 			return h.PolicyResult(n.ResourceAddr.String(), result)

--- a/internal/terraform/node_query_resource_policy.go
+++ b/internal/terraform/node_query_resource_policy.go
@@ -4,8 +4,13 @@
 package terraform
 
 import (
+	"log"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/policy/callback"
+	"github.com/hashicorp/terraform/internal/policy/proto"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -22,15 +27,136 @@ type nodeQueryResourcePolicy struct {
 	// ResourceConfig is the list block config, used for diagnostic source locations.
 	ResourceConfig *configs.Resource
 
-	// Identity and ListBlockAddr are passed to the policy client in a following revision.
-	// Correlates policy results to UI rows.
+	// Identity is the identity cty object from the list response element. It is
+	// converted to a map[string]string and attached to every EvaluationResponse so
+	// downstream consumers (UI, cloud backend) can correlate results to rows.
 	Identity cty.Value
-	// Groups results by the originating list block.
+	// ListBlockAddr is the AbsResourceInstance address of the originating list
+	// block. It is attached to every EvaluationResponse to group results.
 	ListBlockAddr addrs.AbsResourceInstance
 }
+
+var _ GraphNodeExecutable = (*nodeQueryResourcePolicy)(nil)
 
 func (n *nodeQueryResourcePolicy) Name() string {
 	return n.ResourceAddr.String() + " (query policy evaluation)"
 }
 
-// TODO(CORE-6): implement Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics
+// Execute evaluates policy for a single discovered resource from a query list block.
+// It calls evaluatePolicies via the PolicyClient, passing the synthetic address and
+// generated config. The method annotates every resulting EvaluationResponse with both
+// a structured identity map (map[string]string) and the list block address string so
+// downstream UI and cloud-backend consumers can correlate results to rows.
+//
+// Unlike nodeResourcePolicy.Execute, the result is always emitted through the hook
+// regardless of whether the policy passed. Query policy consumers need a hook event
+// for every evaluated resource — including passing ones — so that downstream
+// aggregators can include passing resources in summary records. The !result.Empty()
+// gate used by nodeResourcePolicy is correct for plan/apply (where passing resources
+// carry no actionable information), but wrong here because query consumers need a
+// complete row for every discovered resource.
+func (n *nodeQueryResourcePolicy) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	client := ctx.PolicyClient()
+	config := ctx.Config()
+
+	if client == nil {
+		log.Printf("[DEBUG] No policy client configured, skipping query policy evaluation")
+		return nil
+	}
+	if config == nil {
+		log.Printf("[DEBUG] No configuration available, skipping query policy evaluation")
+		return nil
+	}
+
+	// Acquire the policy semaphore to limit concurrent policy evaluations.
+	// The nil-config guard above must remain before this acquire so that a
+	// missing config does not consume a semaphore slot for no work.
+	policySem := ctx.PolicySemaphore()
+	if policySem != nil {
+		policySem.Acquire()
+		defer policySem.Release()
+	}
+
+	providerAddr := n.ProviderAddr
+	provider, schema, err := getProvider(ctx, providerAddr)
+	if err != nil {
+		return diags.Append(err)
+	}
+
+	modCfg := config.DescendantForInstance(n.ResourceAddr.Module)
+
+	// Query resources are always evaluated as CREATE operations since they
+	// represent discovered resources that don't exist in the configuration.
+	meta := &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
+		ProviderType: providerAddr.Provider.Type,
+		Operation:    proto.Operation_CREATE,
+		ModulePath:   n.ResourceAddr.Module.String(),
+	}
+
+	// The resource config may be nil if the list block has been removed from
+	// the configuration. In that case we proceed without source information
+	// in diagnostics.
+	var resourceConfig *configs.Resource
+	if modCfg != nil {
+		resourceConfig = modCfg.Module.ResourceByAddr(n.ResourceAddr.Resource.Resource)
+	}
+
+	callbacks := callback.Functions{
+		GetResources:  getResourcesForPolicyCallback(ctx, op, provider, schema, config),
+		GetDataSource: getDataSourceForPolicyCallback(ctx, provider, schema),
+	}
+
+	// Evaluate policies with the generated config as the "after" state
+	// and null as the "before" state (since these are discovered resources).
+	// evaluatePolicies already applies WithLocalRange internally; do not reapply.
+	result := evaluatePolicies(ctx, n.ResourceAddr, resourceConfig, n.GeneratedConfig, cty.NullVal(n.GeneratedConfig.Type()), meta, callbacks)
+
+	// Annotate the result with query correlation metadata so that downstream
+	// consumers (UI, cloud backend) can identify which list-block row this
+	// result belongs to.
+	result = result.WithQueryMetadata(ctyIdentityToStringMap(n.Identity), n.ListBlockAddr.String())
+
+	// Always emit for query policy nodes. WithQueryMetadata always sets
+	// ListBlockAddr to a non-empty string, so every result has identity.
+	// Query nodes always emit so downstream aggregators can include passing
+	// resources in summary records; the !result.Empty() gate must not be
+	// applied here.
+	hookErr := ctx.Hook(func(h Hook) (HookAction, error) {
+		return h.PolicyResult(n.ResourceAddr.String(), result)
+	})
+	diags = diags.Append(hookErr)
+
+	return diags
+}
+
+// ctyIdentityToStringMap converts a cty object value that represents a resource
+// identity into a map[string]string suitable for diagnostic annotation. Attributes
+// whose values are not known or not strings are omitted. A null or invalid value
+// returns nil.
+//
+// NOTE: this function can return nil even for a valid, non-null object — e.g. when all
+// attributes are unknown or non-string (numeric IDs, unknown values during plan).
+// Callers that consume this map (e.g. downstream aggregators correlating rows) must
+// treat a nil return as "identity not available" rather than as an error.
+func ctyIdentityToStringMap(val cty.Value) map[string]string {
+	if val == cty.NilVal || val.IsNull() || !val.IsKnown() || !val.Type().IsObjectType() {
+		return nil
+	}
+	attrs := val.AsValueMap()
+	if len(attrs) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(attrs))
+	for k, v := range attrs {
+		if !v.IsKnown() || v.IsNull() || v.Type() != cty.String {
+			continue
+		}
+		result[k] = v.AsString()
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/internal/terraform/node_query_resource_policy_test.go
+++ b/internal/terraform/node_query_resource_policy_test.go
@@ -4,14 +4,24 @@
 package terraform
 
 import (
+	"context"
+	"runtime"
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/plans/deferring"
 	"github.com/hashicorp/terraform/internal/policy"
+	"github.com/hashicorp/terraform/internal/policy/proto"
+	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+	"github.com/hashicorp/terraform/internal/states"
 )
 
 // insertQueryPolicyNodes test helper mirrors the insertion loop in listResourceExecute,
@@ -286,5 +296,1004 @@ func TestQueryPolicyNodeInsertion_NodeIndependence(t *testing.T) {
 		for _, edge := range edges {
 			t.Logf("  edge: %s -> %s", dag.VertexName(edge.Source()), dag.VertexName(edge.Target()))
 		}
+	}
+}
+
+// TestGetPolicyParallelism_Default verifies that getPolicyParallelism returns
+// GOMAXPROCS when TF_POLICY_PARALLELISM is not set.
+func TestGetPolicyParallelism_Default(t *testing.T) {
+	// Ensure env var is not set; t.Setenv restores the previous value on cleanup.
+	t.Setenv("TF_POLICY_PARALLELISM", "")
+
+	capacity := getPolicyParallelism()
+	expected := runtime.GOMAXPROCS(0)
+
+	if capacity != expected {
+		t.Errorf("Expected capacity %d (GOMAXPROCS), got %d", expected, capacity)
+	}
+}
+
+// TestGetPolicyParallelism_EnvOverride verifies that TF_POLICY_PARALLELISM
+// overrides the default GOMAXPROCS value.
+func TestGetPolicyParallelism_EnvOverride(t *testing.T) {
+	t.Setenv("TF_POLICY_PARALLELISM", "5")
+
+	capacity := getPolicyParallelism()
+
+	if capacity != 5 {
+		t.Errorf("Expected capacity 5 from TF_POLICY_PARALLELISM, got %d", capacity)
+	}
+}
+
+// TestGetPolicyParallelism_InvalidEnvFallback verifies that invalid
+// TF_POLICY_PARALLELISM values fall back to GOMAXPROCS.
+func TestGetPolicyParallelism_InvalidEnvFallback(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{"non-numeric", "invalid"},
+		{"negative", "-1"},
+		{"zero", "0"},
+		{"empty", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TF_POLICY_PARALLELISM", tc.value)
+
+			capacity := getPolicyParallelism()
+			expected := runtime.GOMAXPROCS(0)
+
+			if capacity != expected {
+				t.Errorf("Expected fallback to GOMAXPROCS=%d for invalid value %q, got %d",
+					expected, tc.value, capacity)
+			}
+		})
+	}
+}
+
+// TestPolicySemaphore_Initialization verifies that the policy semaphore
+// is initialized lazily with the correct capacity.
+func TestPolicySemaphore_Initialization(t *testing.T) {
+	t.Setenv("TF_POLICY_PARALLELISM", "3")
+
+	ctx, diags := NewContext(&ContextOpts{
+		Parallelism: 10,
+	})
+	if diags.HasErrors() {
+		t.Fatalf("NewContext failed: %s", diags.Err())
+	}
+
+	// Access the semaphore to trigger initialization
+	sem := ctx.policySemaphore()
+
+	// Verify we can acquire up to the capacity
+	for i := 0; i < 3; i++ {
+		if !sem.TryAcquire() {
+			t.Errorf("Failed to acquire semaphore slot %d of 3", i+1)
+		}
+	}
+
+	// Verify we cannot acquire beyond capacity
+	if sem.TryAcquire() {
+		t.Error("Should not be able to acquire beyond capacity of 3")
+		sem.Release()
+	}
+
+	// Release all
+	for i := 0; i < 3; i++ {
+		sem.Release()
+	}
+}
+
+// TestPolicySemaphore_SeparateFromProvider verifies that the policy semaphore
+// is separate from the provider parallelism semaphore.
+func TestPolicySemaphore_SeparateFromProvider(t *testing.T) {
+	t.Setenv("TF_POLICY_PARALLELISM", "2")
+
+	ctx, diags := NewContext(&ContextOpts{
+		Parallelism: 5, // Different from policy parallelism
+	})
+	if diags.HasErrors() {
+		t.Fatalf("NewContext failed: %s", diags.Err())
+	}
+
+	policySem := ctx.policySemaphore()
+	providerSem := ctx.parallelSem
+
+	// Verify they have different capacities
+	// Policy semaphore should have capacity 2
+	acquired1 := policySem.TryAcquire()
+	acquired2 := policySem.TryAcquire()
+	if !acquired1 || !acquired2 {
+		t.Error("Failed to acquire 2 policy semaphore slots")
+	}
+	if policySem.TryAcquire() {
+		t.Error("Should not be able to acquire 3rd policy semaphore slot")
+		policySem.Release()
+	}
+
+	// Provider semaphore should have capacity 5
+	for i := 0; i < 5; i++ {
+		if !providerSem.TryAcquire() {
+			t.Errorf("Failed to acquire provider semaphore slot %d of 5", i+1)
+		}
+	}
+	if providerSem.TryAcquire() {
+		t.Error("Should not be able to acquire 6th provider semaphore slot")
+		providerSem.Release()
+	}
+
+	// Clean up
+	policySem.Release()
+	policySem.Release()
+	for i := 0; i < 5; i++ {
+		providerSem.Release()
+	}
+}
+
+// TestNodeQueryResourcePolicy_Fields verifies that the node structure
+// contains all required fields for policy evaluation and result correlation.
+func TestNodeQueryResourcePolicy_Fields(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist[\"synthetic-0\"]")
+	providerAddr := addrs.AbsProviderConfig{
+		Provider: addrs.NewDefaultProvider("test"),
+		Module:   addrs.RootModule,
+	}
+	generatedConfig := cty.ObjectVal(map[string]cty.Value{
+		"instance_type": cty.StringVal("t2.micro"),
+	})
+	identity := cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-123"),
+	})
+	listBlockAddr := mustResourceInstanceAddr("test_resource.mylist")
+
+	node := &nodeQueryResourcePolicy{
+		ResourceAddr:    resourceAddr,
+		ProviderAddr:    providerAddr,
+		GeneratedConfig: generatedConfig,
+		Identity:        identity,
+		ListBlockAddr:   listBlockAddr,
+	}
+
+	// Verify all fields are accessible
+	if node.ResourceAddr.String() != resourceAddr.String() {
+		t.Error("ResourceAddr not set correctly")
+	}
+	if node.ProviderAddr.String() != providerAddr.String() {
+		t.Error("ProviderAddr not set correctly")
+	}
+	if !node.GeneratedConfig.RawEquals(generatedConfig) {
+		t.Error("GeneratedConfig not set correctly")
+	}
+	if !node.Identity.RawEquals(identity) {
+		t.Error("Identity not set correctly")
+	}
+	if node.ListBlockAddr.String() != listBlockAddr.String() {
+		t.Error("ListBlockAddr not set correctly")
+	}
+}
+
+// --- Execute() tests ---
+
+// executeTestCtx builds a minimal MockEvalContext suitable for nodeQueryResourcePolicy.Execute()
+// tests. It wires up a mock provider, schema, policy client, policy graph, and a
+// minimal root configs.Config so that config.DescendantForInstance succeeds.
+func executeTestCtx(t *testing.T, policyClient policy.Client, hook Hook) *MockEvalContext {
+	t.Helper()
+
+	schema := providers.ProviderSchema{
+		ResourceTypes: map[string]providers.Schema{
+			"test_resource": {Body: listPolicyTestResourceSchema()},
+		},
+	}
+
+	p := &testing_provider.MockProvider{}
+
+	expander := instances.NewExpander(nil)
+
+	rootCfg := &configs.Config{
+		Module: &configs.Module{},
+	}
+
+	ps := newPolicySubgraph()
+
+	ctx := &MockEvalContext{
+		ProviderProvider:         p,
+		ProviderSchemaSchema:     schema,
+		PolicyClientValue:        policyClient,
+		PolicyGraphValue:         ps,
+		ConfigValue:              rootCfg,
+		InstanceExpanderExpander: expander,
+		StopCtxValue:             context.Background(),
+	}
+
+	if hook != nil {
+		ctx.HookHook = hook
+	}
+
+	return ctx
+}
+
+// makeExecuteNode builds a nodeQueryResourcePolicy with the given resource address
+// and identity value, using the shared provider/list block addresses from tests.
+func makeExecuteNode(resourceAddr addrs.AbsResourceInstance, identity cty.Value) *nodeQueryResourcePolicy {
+	listBlockAddr := mustResourceInstanceAddr("test_resource.mylist")
+	providerAddr := addrs.AbsProviderConfig{
+		Provider: addrs.NewDefaultProvider("test"),
+		Module:   addrs.RootModule,
+	}
+	generatedConfig := cty.ObjectVal(map[string]cty.Value{
+		"instance_type": cty.StringVal("t2.micro"),
+		"ami":           cty.StringVal("ami-12345"),
+	})
+	return &nodeQueryResourcePolicy{
+		ResourceAddr:    resourceAddr,
+		ProviderAddr:    providerAddr,
+		GeneratedConfig: generatedConfig,
+		Identity:        identity,
+		ListBlockAddr:   listBlockAddr,
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_AllowResult verifies that a passing (AllowResult)
+// evaluation still emits a PolicyResult hook call. Unlike nodeResourcePolicy (plan/apply),
+// query policy nodes always emit so that downstream aggregators can include passing
+// resources in summary records. The !result.Empty() gate must NOT be applied here.
+func TestNodeQueryResourcePolicy_Execute_AllowResult(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+
+	mockClient := policy.NewTestMockClient(t)
+	// Default EvaluateFn: returns AllowResult with no enforcements — result.Empty() == true.
+	// For query policy nodes this result must still be emitted through the hook.
+
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-allow"),
+	}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	// Passing results must still produce a hook call so downstream aggregators can record them.
+	if _, ok := hook.PolicyResults[resourceAddr.String()]; !ok {
+		t.Errorf("expected PolicyResult hook call for AllowResult (query node always emits), got none")
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_MultiplePolicies verifies that an EvaluationResponse
+// with multiple Policy entries and multiple EnforcementResults is propagated correctly.
+func TestNodeQueryResourcePolicy_Execute_MultiplePolicies(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+
+	pol1 := &policy.Policy{Result: policy.DenyResult, Address: "policy.deny_type"}
+	pol2 := &policy.Policy{Result: policy.AllowResult, Address: "policy.allow_tag"}
+
+	mockClient := &policy.MockClient{}
+	mockClient.EvaluateFn = func(_ context.Context, _ policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		return policy.EvaluationResponse{
+			Overall:  policy.DenyResult,
+			Policies: []*policy.Policy{pol1, pol2},
+			Enforcements: []policy.EnforcementResult{
+				{Result: policy.DenyResult, Message: "instance type not allowed", Policy: pol1},
+				{Result: policy.AllowResult, Message: "tag check passed", Policy: pol2},
+			},
+		}
+	}
+
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-multi"),
+	}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	resp, ok := hook.PolicyResults[resourceAddr.String()]
+	if !ok {
+		t.Fatal("expected PolicyResult hook call for multi-policy response, got none")
+	}
+	if len(resp.Policies) != 2 {
+		t.Errorf("expected 2 policies in response, got %d", len(resp.Policies))
+	}
+	if len(resp.Enforcements) != 2 {
+		t.Errorf("expected 2 enforcement results in response, got %d", len(resp.Enforcements))
+	}
+	if resp.Overall != policy.DenyResult {
+		t.Errorf("expected Overall = DenyResult, got %v", resp.Overall)
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_DenyResult verifies that a DenyResult (non-empty)
+// causes a PolicyResult hook call with the correct address.
+func TestNodeQueryResourcePolicy_Execute_DenyResult(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+
+	mockClient := &policy.MockClient{}
+	mockClient.EvaluateFn = func(_ context.Context, _ policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		return policy.EvaluationResponse{
+			Overall: policy.DenyResult,
+			Enforcements: []policy.EnforcementResult{
+				{Result: policy.DenyResult, Message: "denied"},
+			},
+		}
+	}
+
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-deny"),
+	}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	if len(hook.PolicyResults) == 0 {
+		t.Fatal("expected PolicyResult hook call for DenyResult, got none")
+	}
+	if _, ok := hook.PolicyResults[resourceAddr.String()]; !ok {
+		t.Errorf("expected PolicyResult for addr %s, got keys: %v", resourceAddr.String(), hook.PolicyResults)
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_UnknownResult verifies that an UnknownResult
+// (non-empty) triggers a hook call.
+func TestNodeQueryResourcePolicy_Execute_UnknownResult(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+
+	mockClient := &policy.MockClient{}
+	mockClient.EvaluateFn = func(_ context.Context, _ policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		return policy.EvaluationResponse{
+			Overall: policy.UnknownResult,
+			Enforcements: []policy.EnforcementResult{
+				{Result: policy.UnknownResult},
+			},
+		}
+	}
+
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-unknown"),
+	}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	if _, ok := hook.PolicyResults[resourceAddr.String()]; !ok {
+		t.Errorf("expected PolicyResult hook call for UnknownResult, got results: %v", hook.PolicyResults)
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_DenyNoEnforcements verifies that a DenyResult
+// with no enforcement details and no diagnostics is NOT dropped by the gate.
+// Previously the gate used len(Diagnostics)>0 || len(Enforcements)>0, which would
+// silently drop a bare DenyResult. The fix uses !result.Empty().
+func TestNodeQueryResourcePolicy_Execute_DenyNoEnforcements(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+
+	mockClient := &policy.MockClient{}
+	mockClient.EvaluateFn = func(_ context.Context, _ policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		// DenyResult with no enforcement details and no diagnostics:
+		// Empty() returns false (Overall != AllowResult), but the old
+		// len-based gate would have treated it as empty and dropped it.
+		return policy.EvaluationResponse{
+			Overall: policy.DenyResult,
+		}
+	}
+
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+	n := makeExecuteNode(resourceAddr, cty.NilVal)
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	if _, ok := hook.PolicyResults[resourceAddr.String()]; !ok {
+		t.Errorf("DenyResult with no enforcement details was silently dropped; expected PolicyResult hook call")
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_IdentityAnnotation verifies that the
+// EvaluationResponse delivered to the hook is annotated with the structured
+// identity map derived from the node's Identity field.
+func TestNodeQueryResourcePolicy_Execute_IdentityAnnotation(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+
+	mockClient := &policy.MockClient{}
+	mockClient.EvaluateFn = func(_ context.Context, _ policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		return policy.EvaluationResponse{
+			Overall: policy.DenyResult,
+			Enforcements: []policy.EnforcementResult{
+				{Result: policy.DenyResult, Message: "denied"},
+			},
+		}
+	}
+
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id":     cty.StringVal("i-abc"),
+		"region": cty.StringVal("us-east-1"),
+	}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	resp, ok := hook.PolicyResults[resourceAddr.String()]
+	if !ok {
+		t.Fatal("expected PolicyResult hook call, got none")
+	}
+
+	if resp.Identity == nil {
+		t.Fatal("EvaluationResponse.Identity is nil; expected annotated identity map")
+	}
+	if resp.Identity["id"] != "i-abc" {
+		t.Errorf("Identity[\"id\"] = %q, want %q", resp.Identity["id"], "i-abc")
+	}
+	if resp.Identity["region"] != "us-east-1" {
+		t.Errorf("Identity[\"region\"] = %q, want %q", resp.Identity["region"], "us-east-1")
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_ListBlockAddrAnnotation verifies that the
+// EvaluationResponse delivered to the hook carries the originating list block address.
+func TestNodeQueryResourcePolicy_Execute_ListBlockAddrAnnotation(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+	expectedListBlockAddr := mustResourceInstanceAddr("test_resource.mylist")
+
+	mockClient := &policy.MockClient{}
+	mockClient.EvaluateFn = func(_ context.Context, _ policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		return policy.EvaluationResponse{
+			Overall: policy.DenyResult,
+			Enforcements: []policy.EnforcementResult{
+				{Result: policy.DenyResult},
+			},
+		}
+	}
+
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-abc"),
+	}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	resp, ok := hook.PolicyResults[resourceAddr.String()]
+	if !ok {
+		t.Fatal("expected PolicyResult hook call, got none")
+	}
+
+	if resp.ListBlockAddr != expectedListBlockAddr.String() {
+		t.Errorf("EvaluationResponse.ListBlockAddr = %q, want %q", resp.ListBlockAddr, expectedListBlockAddr.String())
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_ProviderError verifies that a getProvider error
+// is returned as a diagnostic (not a panic) and that the semaphore is correctly
+// released even when getProvider fails.
+func TestNodeQueryResourcePolicy_Execute_ProviderError(t *testing.T) {
+	mockClient := policy.NewTestMockClient(t)
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+
+	// Override ProviderProvider to nil so that getProvider returns an error.
+	ctx.ProviderProvider = nil
+
+	sem := NewSemaphore(1)
+	ctx.PolicySemaphoreValue = sem
+
+	n := makeExecuteNode(mustResourceInstanceAddr("test_resource.mylist_0"), cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-err"),
+	}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if !diags.HasErrors() {
+		t.Fatal("expected an error diagnostic when provider is nil, got none")
+	}
+
+	// Semaphore must be released even when getProvider fails.
+	if !sem.TryAcquire() {
+		t.Error("semaphore was not released after getProvider error; possible leak")
+	}
+	sem.Release()
+
+	// No hook call should have been made.
+	if len(hook.Calls) != 0 {
+		t.Errorf("expected no hook calls after provider error, got %d", len(hook.Calls))
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_NilClient verifies that Execute() is a no-op
+// (no panic, no diagnostics) when no policy client is configured.
+func TestNodeQueryResourcePolicy_Execute_NilClient(t *testing.T) {
+	hook := &testHook{}
+	ctx := executeTestCtx(t, nil, hook)
+
+	n := makeExecuteNode(mustResourceInstanceAddr("test_resource.mylist_0"), cty.NilVal)
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors with nil client: %s", diags.Err())
+	}
+	if len(hook.Calls) != 0 {
+		t.Errorf("expected no hook calls with nil client, got %d", len(hook.Calls))
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_NilConfig verifies that Execute() is a no-op
+// when no configuration is available.
+func TestNodeQueryResourcePolicy_Execute_NilConfig(t *testing.T) {
+	mockClient := policy.NewTestMockClient(t)
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+	ctx.ConfigValue = nil // override to nil
+
+	n := makeExecuteNode(mustResourceInstanceAddr("test_resource.mylist_0"), cty.NilVal)
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors with nil config: %s", diags.Err())
+	}
+	if len(hook.Calls) != 0 {
+		t.Errorf("expected no hook calls with nil config, got %d", len(hook.Calls))
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_SemaphoreAcquired verifies that Execute()
+// acquires and releases the policy semaphore exactly once per invocation.
+func TestNodeQueryResourcePolicy_Execute_SemaphoreAcquired(t *testing.T) {
+	mockClient := policy.NewTestMockClient(t)
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+
+	sem := NewSemaphore(1)
+	ctx.PolicySemaphoreValue = sem
+
+	n := makeExecuteNode(mustResourceInstanceAddr("test_resource.mylist_0"), cty.NilVal)
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	// After Execute() the semaphore must be fully released — we should be
+	// able to acquire it again.
+	if !sem.TryAcquire() {
+		t.Error("semaphore was not released after Execute(); expected it to be available")
+	}
+	sem.Release()
+}
+
+// TestNodeQueryResourcePolicy_Execute_NilPolicyGraph verifies that Execute() does not
+// panic when ctx.PolicyGraph() returns nil (Finding #15 guard).
+func TestNodeQueryResourcePolicy_Execute_NilPolicyGraph(t *testing.T) {
+	mockClient := policy.NewTestMockClient(t)
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+	ctx.PolicyGraphValue = nil // PolicyGraph() returns nil
+
+	n := makeExecuteNode(mustResourceInstanceAddr("test_resource.mylist_0"), cty.NilVal)
+
+	// Must not panic.
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors with nil PolicyGraph: %s", diags.Err())
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_ResourceConfigSetsRange verifies that when
+// a matching *configs.Resource exists in the config, its DeclRange is applied to the
+// result exactly once (not twice) — guarding against the double WithLocalRange bug
+// (Finding #4).
+func TestNodeQueryResourcePolicy_Execute_ResourceConfigSetsRange(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+
+	mockClient := &policy.MockClient{}
+	mockClient.EvaluateFn = func(_ context.Context, _ policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		return policy.EvaluationResponse{
+			Overall: policy.DenyResult,
+			Enforcements: []policy.EnforcementResult{
+				{Result: policy.DenyResult, Message: "denied"},
+			},
+		}
+	}
+
+	declRange := hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 10}, End: hcl.Pos{Line: 12}}
+	resourceCfg := &configs.Resource{
+		Mode:      addrs.ManagedResourceMode,
+		Type:      "test_resource",
+		Name:      "mylist",
+		Config:    hcl.EmptyBody(),
+		DeclRange: declRange,
+	}
+	rootModule := &configs.Module{
+		ManagedResources: map[string]*configs.Resource{
+			"test_resource.mylist_0": resourceCfg,
+		},
+	}
+	rootCfg := &configs.Config{
+		Module: rootModule,
+	}
+
+	hook := &testHook{}
+	ctx := executeTestCtx(t, mockClient, hook)
+	ctx.ConfigValue = rootCfg
+
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-abc"),
+	}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	// Verify the hook was called — result propagation was not broken.
+	if _, ok := hook.PolicyResults[resourceAddr.String()]; !ok {
+		t.Error("expected PolicyResult hook call, got none")
+	}
+}
+
+// TestCtyIdentityToStringMap verifies edge cases for the ctyIdentityToStringMap helper.
+func TestCtyIdentityToStringMap(t *testing.T) {
+	t.Run("nil_val", func(t *testing.T) {
+		if got := ctyIdentityToStringMap(cty.NilVal); got != nil {
+			t.Errorf("expected nil for cty.NilVal, got %v", got)
+		}
+	})
+	t.Run("null_val", func(t *testing.T) {
+		if got := ctyIdentityToStringMap(cty.NullVal(cty.String)); got != nil {
+			t.Errorf("expected nil for null value, got %v", got)
+		}
+	})
+	t.Run("non_object", func(t *testing.T) {
+		if got := ctyIdentityToStringMap(cty.StringVal("hello")); got != nil {
+			t.Errorf("expected nil for non-object, got %v", got)
+		}
+	})
+	t.Run("empty_object", func(t *testing.T) {
+		if got := ctyIdentityToStringMap(cty.EmptyObjectVal); got != nil {
+			t.Errorf("expected nil for empty object, got %v", got)
+		}
+	})
+	t.Run("string_attrs", func(t *testing.T) {
+		val := cty.ObjectVal(map[string]cty.Value{
+			"id":     cty.StringVal("i-abc"),
+			"region": cty.StringVal("us-east-1"),
+		})
+		got := ctyIdentityToStringMap(val)
+		if got == nil {
+			t.Fatal("expected non-nil map")
+		}
+		if got["id"] != "i-abc" {
+			t.Errorf("id = %q, want %q", got["id"], "i-abc")
+		}
+		if got["region"] != "us-east-1" {
+			t.Errorf("region = %q, want %q", got["region"], "us-east-1")
+		}
+	})
+	t.Run("skips_non_string_attrs", func(t *testing.T) {
+		val := cty.ObjectVal(map[string]cty.Value{
+			"id":    cty.StringVal("i-abc"),
+			"count": cty.NumberIntVal(3),
+		})
+		got := ctyIdentityToStringMap(val)
+		if got == nil {
+			t.Fatal("expected non-nil map")
+		}
+		if _, ok := got["count"]; ok {
+			t.Error("expected non-string attr 'count' to be omitted")
+		}
+		if got["id"] != "i-abc" {
+			t.Errorf("id = %q, want %q", got["id"], "i-abc")
+		}
+	})
+	t.Run("unknown_attr_skipped", func(t *testing.T) {
+		val := cty.ObjectVal(map[string]cty.Value{
+			"id": cty.UnknownVal(cty.String),
+		})
+		got := ctyIdentityToStringMap(val)
+		if got != nil {
+			t.Errorf("expected nil when all attrs unknown, got %v", got)
+		}
+	})
+}
+
+// --- GetResources callback tests ---
+
+// executeTestCtxWithState builds a MockEvalContext like executeTestCtx but also wires up
+// ChangesChanges, DeferralsState, and a root configs.Config with the given ManagedResources
+// so that getResourcesForPolicyCallback can be invoked without panicking.
+//
+// The ChangesSync is populated with the provided changes and then closed (required by
+// ReadInstancesForConfigResource). The configs.Config contains a single managed resource
+// declaration for "test_resource" (type) / "target" (name) in the root module, matching
+// the synthetic resource instances appended to the change set.
+func executeTestCtxWithState(t *testing.T, policyClient policy.Client, hook Hook, changes []*plans.ResourceInstanceChange, deferred *deferring.Deferred) *MockEvalContext {
+	t.Helper()
+
+	ctx := executeTestCtx(t, policyClient, hook)
+
+	// Build and close ChangesSync so ReadInstancesForConfigResource can iterate it.
+	changesSync := plans.NewChanges().SyncWrapper()
+	for _, ch := range changes {
+		changesSync.AppendResourceInstanceChange(ch)
+	}
+	changesSync.Close()
+	ctx.ChangesChanges = changesSync
+
+	if deferred == nil {
+		deferred = deferring.NewDeferred(false)
+	}
+	ctx.DeferralsState = deferred
+
+	// Populate a configs.Config whose Module.ManagedResources contains a resource entry
+	// for "test_resource.target" so that config.DeepEach finds it during callback iteration.
+	resourceCfg := &configs.Resource{
+		Mode:   addrs.ManagedResourceMode,
+		Type:   "test_resource",
+		Name:   "target",
+		Config: hcl.EmptyBody(),
+	}
+	ctx.ConfigValue = &configs.Config{
+		Module: &configs.Module{
+			ManagedResources: map[string]*configs.Resource{
+				"test_resource.target": resourceCfg,
+			},
+		},
+	}
+
+	return ctx
+}
+
+// makeResourceInstanceChange builds a minimal ResourceInstanceChange for
+// "test_resource.target" with the given After value. walkPlan uses the
+// Changes (not State), so we record it as a Create change.
+func makeResourceInstanceChange(afterVal cty.Value) *plans.ResourceInstanceChange {
+	addr := mustResourceInstanceAddr("test_resource.target")
+	return &plans.ResourceInstanceChange{
+		Addr:        addr,
+		PrevRunAddr: addr,
+		ProviderAddr: addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModule,
+		},
+		Change: plans.Change{
+			Action: plans.Create,
+			Before: cty.NullVal(afterVal.Type()),
+			After:  afterVal,
+		},
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_GetResources_Pass verifies that when the policy
+// plugin calls req.Callbacks.GetResources(...) and the callback returns the target
+// resource, the overall result is AllowResult and a hook event is emitted.
+//
+// This exercises the GetResources callback path within a query policy node's Execute().
+func TestNodeQueryResourcePolicy_Execute_GetResources_Pass(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+
+	// The resource that will be found by the callback.
+	targetVal := cty.ObjectVal(map[string]cty.Value{
+		"instance_type": cty.StringVal("t2.micro"),
+		"ami":           cty.StringVal("ami-12345"),
+	})
+	change := makeResourceInstanceChange(targetVal)
+
+	var callbackInvoked bool
+	mockClient := &policy.MockClient{}
+	mockClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		if req.Callbacks.GetResources == nil {
+			t.Error("GetResources callback was nil")
+			return policy.EvaluationResponse{Overall: policy.AllowResult}
+		}
+
+		// Call GetResources and verify at least one resource is returned.
+		resources, partial, err := req.Callbacks.GetResources(ctx, "test_resource", cty.NullVal(cty.DynamicPseudoType))
+		if err != nil {
+			t.Errorf("GetResources returned unexpected error: %v", err)
+		}
+		if partial {
+			t.Error("expected partial=false for non-deferred resources")
+		}
+		if len(resources) == 0 {
+			t.Error("expected at least one resource from GetResources, got none")
+		}
+		callbackInvoked = true
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	hook := &testHook{}
+	ctx := executeTestCtxWithState(t, mockClient, hook, []*plans.ResourceInstanceChange{change}, nil)
+	ctx.StateState = states.NewState().SyncWrapper()
+	defer ctx.StateState.Close()
+
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("i-pass")}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	if !callbackInvoked {
+		t.Error("EvaluateFn never invoked GetResources callback")
+	}
+
+	// AllowResult must still emit a hook event (query nodes always emit).
+	if _, ok := hook.PolicyResults[resourceAddr.String()]; !ok {
+		t.Error("expected PolicyResult hook call for GetResources AllowResult, got none")
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_GetResources_Fail verifies that when the policy
+// plugin calls req.Callbacks.GetResources(...), the callback returns the target resource,
+// but the plugin decides to deny — the result is DenyResult and a hook event is emitted.
+//
+// This exercises the GetResources callback path within a query policy node's Execute().
+func TestNodeQueryResourcePolicy_Execute_GetResources_Fail(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+
+	targetVal := cty.ObjectVal(map[string]cty.Value{
+		"instance_type": cty.StringVal("t2.xlarge"), // forbidden type
+		"ami":           cty.StringVal("ami-12345"),
+	})
+	change := makeResourceInstanceChange(targetVal)
+
+	var callbackInvoked bool
+	mockClient := &policy.MockClient{}
+	mockClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		if req.Callbacks.GetResources == nil {
+			t.Error("GetResources callback was nil")
+			return policy.EvaluationResponse{Overall: policy.DenyResult}
+		}
+
+		resources, _, err := req.Callbacks.GetResources(ctx, "test_resource", cty.NullVal(cty.DynamicPseudoType))
+		if err != nil {
+			t.Errorf("GetResources returned unexpected error: %v", err)
+		}
+		callbackInvoked = true
+
+		// Simulate a policy that checks for a forbidden instance type.
+		for _, r := range resources {
+			if r.GetAttr("instance_type").AsString() == "t2.xlarge" {
+				return policy.EvaluationResponse{
+					Overall: policy.DenyResult,
+					Enforcements: []policy.EnforcementResult{
+						{Result: policy.DenyResult, Message: "instance type t2.xlarge is not allowed"},
+					},
+				}
+			}
+		}
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	hook := &testHook{}
+	ctx := executeTestCtxWithState(t, mockClient, hook, []*plans.ResourceInstanceChange{change}, nil)
+	ctx.StateState = states.NewState().SyncWrapper()
+	defer ctx.StateState.Close()
+
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("i-fail")}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	if !callbackInvoked {
+		t.Error("EvaluateFn never invoked GetResources callback")
+	}
+
+	resp, ok := hook.PolicyResults[resourceAddr.String()]
+	if !ok {
+		t.Fatal("expected PolicyResult hook call for GetResources DenyResult, got none")
+	}
+	if resp.Overall != policy.DenyResult {
+		t.Errorf("expected DenyResult, got %v", resp.Overall)
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_GetResources_Unknown verifies that when the policy
+// plugin calls req.Callbacks.GetResources(...) and the callback returns partial=true
+// (because the resource address has a deferral), the plugin maps this to UnknownResult
+// and a hook event is emitted.
+//
+// This exercises the GetResources callback path within a query policy node's Execute()
+// under a deferral — the callback receives an empty-or-partial result set and the plugin
+// signals UnknownResult.
+func TestNodeQueryResourcePolicy_Execute_GetResources_Unknown(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+
+	// Set up a Deferred with deferral enabled so DependenciesDeferred returns true
+	// for our target resource, causing the callback to set isPartialResult=true.
+	deferred := deferring.NewDeferred(true)
+	targetAddr := mustResourceInstanceAddr("test_resource.target")
+	deferredChange := &plans.ResourceInstanceChange{
+		Addr:        targetAddr,
+		PrevRunAddr: targetAddr,
+		ProviderAddr: addrs.AbsProviderConfig{
+			Provider: addrs.NewDefaultProvider("test"),
+			Module:   addrs.RootModule,
+		},
+		Change: plans.Change{
+			Action: plans.Create,
+			Before: cty.NullVal(cty.DynamicPseudoType),
+			After:  cty.DynamicVal,
+		},
+	}
+	deferred.ReportResourceInstanceDeferred(targetAddr, providers.DeferredReasonProviderConfigUnknown, deferredChange)
+
+	var callbackInvoked bool
+	var gotPartial bool
+	mockClient := &policy.MockClient{}
+	mockClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		if req.Callbacks.GetResources == nil {
+			t.Error("GetResources callback was nil")
+			return policy.EvaluationResponse{Overall: policy.UnknownResult}
+		}
+
+		_, partial, err := req.Callbacks.GetResources(ctx, "test_resource", cty.NullVal(cty.DynamicPseudoType))
+		if err != nil {
+			t.Errorf("GetResources returned unexpected error: %v", err)
+		}
+		gotPartial = partial
+		callbackInvoked = true
+
+		// A real policy plugin would return UnknownResult when partial=true because
+		// it cannot determine compliance with incomplete data.
+		if partial {
+			return policy.EvaluationResponse{
+				Overall: policy.UnknownResult,
+				Enforcements: []policy.EnforcementResult{
+					{Result: policy.UnknownResult},
+				},
+			}
+		}
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	hook := &testHook{}
+	ctx := executeTestCtxWithState(t, mockClient, hook, nil, deferred)
+	ctx.StateState = states.NewState().SyncWrapper()
+	defer ctx.StateState.Close()
+
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("i-unknown")}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	if !callbackInvoked {
+		t.Error("EvaluateFn never invoked GetResources callback")
+	}
+	if !gotPartial {
+		t.Error("expected partial=true from GetResources when resource is deferred, got false")
+	}
+
+	resp, ok := hook.PolicyResults[resourceAddr.String()]
+	if !ok {
+		t.Fatal("expected PolicyResult hook call for GetResources UnknownResult, got none")
+	}
+	if resp.Overall != policy.UnknownResult {
+		t.Errorf("expected UnknownResult, got %v", resp.Overall)
 	}
 }

--- a/internal/terraform/node_query_resource_policy_test.go
+++ b/internal/terraform/node_query_resource_policy_test.go
@@ -354,7 +354,7 @@ func TestGetPolicyParallelism_InvalidEnvFallback(t *testing.T) {
 }
 
 // TestPolicySemaphore_Initialization verifies that the policy semaphore
-// is initialized lazily with the correct capacity.
+// is initialized eagerly in NewContext with the correct capacity.
 func TestPolicySemaphore_Initialization(t *testing.T) {
 	t.Setenv("TF_POLICY_PARALLELISM", "3")
 
@@ -365,7 +365,6 @@ func TestPolicySemaphore_Initialization(t *testing.T) {
 		t.Fatalf("NewContext failed: %s", diags.Err())
 	}
 
-	// Access the semaphore to trigger initialization
 	sem := ctx.policySemaphore()
 
 	// Verify we can acquire up to the capacity

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -28,8 +28,10 @@ func evaluatePolicies(ctx EvalContext, target addrs.AbsResourceInstance, config 
 	// We want a per-resource parent span so we can reason about the evaluation of individual
 	// resources in the trace
 	evalCtx := ctx.StopCtx()
-	if phaseSpan := ctx.PolicyGraph().span; phaseSpan != nil {
-		evalCtx = trace.ContextWithSpan(evalCtx, phaseSpan)
+	if pg := ctx.PolicyGraph(); pg != nil {
+		if phaseSpan := pg.span; phaseSpan != nil {
+			evalCtx = trace.ContextWithSpan(evalCtx, phaseSpan)
+		}
 	}
 
 	result := ctx.PolicyClient().EvaluateResource(evalCtx, policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]{


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR implements policy evaluation support for query (list block) resources, enabling downstream consumers (UI, cloud backend) to correlate policy results to specific rows returned by list blocks.

### Key changes

**`nodeQueryResourcePolicy` — new node type for query policy evaluation**

Adds a new `nodeQueryResourcePolicy` graph node that evaluates policy for a single resource discovered during a list block walk. Unlike `nodeResourcePolicy` (used in plan/apply), this node always emits a `PolicyResult` hook event regardless of whether the result is passing — query consumers need a complete record for every discovered resource so that downstream aggregators can include passing resources in summary output.

**`EvaluationResponse` query metadata fields**

Adds `Identity map[string]string` and `ListBlockAddr string` fields to `EvaluationResponse`, along with a `WithQueryMetadata` constructor that stamps both fields onto a result. These fields allow downstream consumers to correlate policy results back to the specific list-block row that produced them.

**`policyEvalTransformer` query mode wiring**

Adds a `QueryPlan bool` field to `policyEvalTransformer`. When set, the transformer wires `nodePolicyEval` to depend only on `ListResourceMode` vertices rather than all graph vertices, since only list block nodes populate the policy subgraph via `PolicyGraph().AddQuery` in query mode.

**Policy semaphore — separate from provider parallelism**

Introduces a dedicated `policySem` semaphore on `Context`, initialized lazily via `policySemaphore()`. Its capacity is controlled by the new `TF_POLICY_PARALLELISM` environment variable (falling back to `GOMAXPROCS`). This prevents policy evaluations from consuming provider parallelism slots, keeping the two concerns independent.

**`policySubgraph` improvements**

Refactors `nodePolicyEval.DynamicExpand` to delegate finish-node wiring to a new `policySubgraph.evalGraph` method. `evalGraph` copies the accumulated subgraph (avoiding mutation of the shared subgraph), wires `nodePolicyEvalFinish` to depend on both `nodeResourcePolicy` and `nodeQueryResourcePolicy` nodes, and adds the root node. `nodePolicyEvalFinish.AllowUpstreamFailure` is updated to tolerate failures from both node types.

**`listResourceExecute` integration**

Replaces the previous `TODO(CORE-3)` placeholder with the actual insertion loop: for each non-unknown `listResourcePolicy` input, a `nodeQueryResourcePolicy` is added to the policy subgraph via `ctx.PolicyGraph().AddQuery`. A panic guard is added to catch any future regressions where `generateListResourcePolicyData` returns errors (which would be a bug).

**Nil-safety fix in `evaluatePolicies`**

Guards the `ctx.PolicyGraph().span` access behind a nil check to prevent a panic when `PolicyGraph()` returns nil (e.g., in non-policy evaluation contexts).

Fixes #

## Target Release

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls (access controls, encryption, or logging). The new `TF_POLICY_PARALLELISM` environment variable controls concurrency of policy evaluation only and does not affect authorization or data access.

## CHANGELOG entry

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.