### PR TITLE
Fix race condition in OAuth callback handler

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260723-144824.yaml
+++ b/.changes/v1.17/BUG FIXES-20260723-144824.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'cli: Fixed race condition in terraform login OAuth callback handler that could cause the success message to not display in browser'
+time: 2026-07-23T14:48:24.923936-07:00
+custom:
+    Issue: "38922"

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -417,11 +417,8 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 	// codeCh will allow our temporary HTTP server to transmit the OAuth code
 	// to the main execution path that follows.
 	codeCh := make(chan string)
-	responseDone := make(chan struct{})
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			defer close(responseDone)
-
 			log.Printf("[TRACE] login: request to callback server")
 			err := req.ParseForm()
 			if err != nil {
@@ -444,10 +441,11 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 
 			log.Printf("[TRACE] login: request contains an authorization code")
 
-			// Send the code to our blocking wait below, so that the token
-			// fetching process can continue.
-			codeCh <- gotCode
-			close(codeCh)
+			// Defer sending the code to ensure response is written first
+			defer func() {
+				codeCh <- gotCode
+				close(codeCh)
+			}()
 
 			log.Printf("[TRACE] login: returning response from callback server")
 
@@ -511,9 +509,6 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 		// up, so we'll just give up.
 		return nil, diags
 	}
-
-	// Wait for response to complete before shutting down
-	<-responseDone
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	svchost "github.com/hashicorp/terraform-svchost"
@@ -419,6 +420,8 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 	responseDone := make(chan struct{})
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			defer close(responseDone)
+
 			log.Printf("[TRACE] login: request to callback server")
 			err := req.ParseForm()
 			if err != nil {
@@ -451,9 +454,6 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 			resp.Header().Add("Content-Type", "text/html")
 			resp.WriteHeader(200)
 			resp.Write([]byte(callbackSuccessMessage))
-
-			// Signal that response is complete
-			close(responseDone)
 		}),
 	}
 	go func() {
@@ -515,10 +515,10 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 	// Wait for response to complete before shutting down
 	<-responseDone
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
 
-	if err := server.Shutdown(ctx); err != nil {
+	if err := server.Shutdown(shutdownCtx); err != nil {
 		// The server will close soon enough when our process exits anyway,
 		// so we won't fuss about it for right now.
 		log.Printf("[WARN] login: callback server can't shut down: %s", err)

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -416,6 +416,7 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 	// codeCh will allow our temporary HTTP server to transmit the OAuth code
 	// to the main execution path that follows.
 	codeCh := make(chan string)
+	responseDone := make(chan struct{})
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			log.Printf("[TRACE] login: request to callback server")
@@ -445,12 +446,15 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 			codeCh <- gotCode
 			close(codeCh)
 
-			log.Printf("[TRACE] login: returning response from callback server")
+		log.Printf("[TRACE] login: returning response from callback server")
 
-			resp.Header().Add("Content-Type", "text/html")
-			resp.WriteHeader(200)
-			resp.Write([]byte(callbackSuccessMessage))
-		}),
+		resp.Header().Add("Content-Type", "text/html")
+		resp.WriteHeader(200)
+		resp.Write([]byte(callbackSuccessMessage))
+
+		// Signal that response is complete
+		close(responseDone)
+	}),
 	}
 	go func() {
 		defer logging.PanicHandler()
@@ -508,7 +512,13 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 		return nil, diags
 	}
 
-	if err := server.Close(); err != nil {
+	// Wait for response to complete before shutting down
+	<-responseDone
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
 		// The server will close soon enough when our process exits anyway,
 		// so we won't fuss about it for right now.
 		log.Printf("[WARN] login: callback server can't shut down: %s", err)

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -446,15 +446,15 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 			codeCh <- gotCode
 			close(codeCh)
 
-		log.Printf("[TRACE] login: returning response from callback server")
+			log.Printf("[TRACE] login: returning response from callback server")
 
-		resp.Header().Add("Content-Type", "text/html")
-		resp.WriteHeader(200)
-		resp.Write([]byte(callbackSuccessMessage))
+			resp.Header().Add("Content-Type", "text/html")
+			resp.WriteHeader(200)
+			resp.Write([]byte(callbackSuccessMessage))
 
-		// Signal that response is complete
-		close(responseDone)
-	}),
+			// Signal that response is complete
+			close(responseDone)
+		}),
 	}
 	go func() {
 		defer logging.PanicHandler()


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes https://github.com/hashicorp/terraform/issues/38712

The `terraform login` command has a race condition in its OAuth callback handler. The main goroutine closes the HTTP server immediately after receiving the authorization code, but the handler goroutine may still be writing the success response to the browser. This causes the connection to terminate prematurely, preventing users from seeing the success message.

This PR introduces synchronization between the HTTP response handler and server shutdown:

1. **Added `responseDone` channel** which signals when the HTTP response has been fully written
2. The callback handler closes `responseDone` after writing the success response
3. The main goroutine waits for `responseDone` before shutting down
4. **Use `Shutdown()` instead of `Close()`** to ensure active connections are gracefully closed with a 5-second timeout

Testing

- Run the test suite: `go test ./internal/command -run TestLogin -v`
- Run with race detector: `go test -race ./internal/command -run TestLogin`

All tests pass with no race conditions detected

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
