### PR TITLE
providercache: Explain prerelease-only providers

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260724-083234.yaml
+++ b/.changes/v1.17/BUG FIXES-20260724-083234.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: "Terraform now reports the newest available prerelease version when a provider has no stable releases and explains how to select it."
+time: 2026-07-24T08:32:34+07:00
+custom:
+    Issue: "38923"

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -343,7 +343,19 @@ NeedProvider:
 			lock := locks.Provider(provider)
 			err = fmt.Errorf("the previously-selected version %s is no longer available", lock.Version())
 		} else {
-			err = fmt.Errorf("no available releases match the given constraints %s", getproviders.VersionConstraintsString(reqs[provider]))
+			onlyPrereleases := len(available) > 0
+			for _, version := range available {
+				if versions.Released.Has(version) {
+					onlyPrereleases = false
+					break
+				}
+			}
+			if onlyPrereleases {
+				latestVersion := available[len(available)-1]
+				err = fmt.Errorf("provider has no stable releases, but does have a pre-release version %s; if you intend to test that version, specify an exact version constraint.", latestVersion)
+			} else {
+				err = fmt.Errorf("no available releases match the given constraints %s", getproviders.VersionConstraintsString(reqs[provider]))
+			}
 		}
 		errs[provider] = err
 		if cb := evts.QueryPackagesFailure; cb != nil {

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -2089,6 +2089,58 @@ func TestEnsureProviderVersions(t *testing.T) {
 				}
 			},
 		},
+		"only pre-release versions are available": {
+			Source: getproviders.NewMockSource(
+				[]getproviders.PackageMeta{
+					{
+						Provider:       beepProvider,
+						Version:        getproviders.MustParseVersion("0.1.0-alpha1"),
+						TargetPlatform: fakePlatform,
+						Location:       beepProviderDir,
+					},
+					{
+						Provider:       beepProvider,
+						Version:        getproviders.MustParseVersion("0.1.0-beta2"),
+						TargetPlatform: fakePlatform,
+						Location:       beepProviderDir,
+					},
+				},
+				nil,
+			),
+			Mode: InstallNewProvidersOnly,
+			Reqs: getproviders.Requirements{
+				beepProvider: nil,
+			},
+			WantErr: `some providers could not be installed:
+- example.com/foo/beep: provider has no stable releases, but does have a pre-release version 0.1.0-beta2; if you intend to test that version, specify an exact version constraint.`,
+			WantEvents: func(inst *Installer, dir *Dir) map[addrs.Provider][]*testInstallerEventLogItem {
+				return map[addrs.Provider][]*testInstallerEventLogItem{
+					noProvider: {
+						{
+							Event: "PendingProviders",
+							Args: map[addrs.Provider]getproviders.VersionConstraints{
+								beepProvider: nil,
+							},
+						},
+					},
+					beepProvider: {
+						{
+							Event:    "QueryPackagesBegin",
+							Provider: beepProvider,
+							Args: struct {
+								Constraints string
+								Locked      bool
+							}{"", false},
+						},
+						{
+							Event:    "QueryPackagesFailure",
+							Provider: beepProvider,
+							Args:     `provider has no stable releases, but does have a pre-release version 0.1.0-beta2; if you intend to test that version, specify an exact version constraint.`,
+						},
+					},
+				}
+			},
+		},
 		"version exists but doesn't support the current platform": {
 			Source: getproviders.NewMockSource(
 				[]getproviders.PackageMeta{


### PR DESCRIPTION
When a provider publishes only prerelease versions, `terraform init` currently reports that no releases match, without explaining that prereleases must be selected exactly.

This updates the provider installer to report the newest advertised prerelease and explain how to opt in. The specialized diagnostic is limited to sources whose advertised versions are all prereleases; if any stable release exists, Terraform retains the existing constraint-mismatch diagnostic.

The regression test covers both the aggregate installer error and the `QueryPackagesFailure` event. The existing stable-release mismatch test protects the fallback behavior.

AI usage disclosure: An OpenAI Codex agent was used to search the maintainer-approved backlog, draft the implementation and regression test, and run the listed verification. The human account owner reviewed the submitted changes before this PR was marked ready.

Fixes #30337

## Target Release

1.17.x

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.

The entry is in `.changes/v1.17` and links to this PR.

## Verification

- `npx --yes changie merge -u "." --dry-run`
- `go test ./internal/getproviders/... ./internal/providercache -count=1`
- `go test ./internal/command -run "^TestInit_" -count=1`
- `go vet ./internal/getproviders/... ./internal/providercache`
- `git diff --check` and `gofmt` check