### PR TITLE
refactor: Make the `version` command use views architecture for human and JSON output.

### DIFF
--- a/internal/command/e2etest/version_test.go
+++ b/internal/command/e2etest/version_test.go
@@ -108,7 +108,7 @@ func TestVersionReroutingFromOtherCommands(t *testing.T) {
 	fixturePath := filepath.Join("testdata", "full-workflow-null")
 	tf := e2e.NewBinary(t, terraformBin, fixturePath)
 
-	wantVersion := fmt.Sprintf("Terraform v%s\non %s\n", version.String(), getproviders.CurrentPlatform.String())
+	wantVersion := fmt.Sprintf("Terraform v%s\non %s\n\n", version.String(), getproviders.CurrentPlatform.String())
 
 	// Use version command directly
 	// The version command receives no arguments.

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -4,16 +4,15 @@
 package command
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // VersionCommand is a Command implementation prints the version.
@@ -24,13 +23,6 @@ type VersionCommand struct {
 	VersionPrerelease string
 	CheckFunc         VersionCheckFunc
 	Platform          getproviders.Platform
-}
-
-type VersionOutput struct {
-	Version            string            `json:"terraform_version"`
-	Platform           string            `json:"platform"`
-	ProviderSelections map[string]string `json:"provider_selections"`
-	Outdated           bool              `json:"terraform_outdated"`
 }
 
 // VersionCheckFunc is the callback called by the Version command to
@@ -60,23 +52,35 @@ Options:
 }
 
 func (c *VersionCommand) Run(rawArgs []string) int {
-	var outdated bool
-	var latest string
-	var versionString bytes.Buffer
+	var diags tfdiags.Diagnostics
 
+	// Parse and apply global view arguments
+	common, rawArgs := arguments.ParseView(rawArgs)
+	c.View.Configure(common)
+
+	// Parse command-specific arguments.
 	args, argDiags := arguments.ParseVersion(rawArgs)
-	if argDiags.HasErrors() {
-		c.showDiagnostics(argDiags)
+	diags = diags.Append(argDiags)
+
+	// Prepare the view
+	view := views.NewVersion(args.ViewType, c.View)
+
+	// Now the view is ready, process any error diagnostics from parsing arguments.
+	if diags.HasErrors() {
+		view.Diagnostics(diags)
 		return 1
 	}
-	jsonOutput := args.ViewType == arguments.ViewJSON
 
-	fmt.Fprintf(&versionString, "Terraform v%s", c.Version)
+	// Collect version information
+	var version string
 	if c.VersionPrerelease != "" {
-		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)
+		version = fmt.Sprintf("%s-%s", c.Version, c.VersionPrerelease)
+	} else {
+		version = c.Version
 	}
+	platform := c.Platform.String()
 
-	// We'll also attempt to print out the selected plugin versions. We do
+	// We attempt to print out the selected plugin versions. We do
 	// this based on the dependency lock file, and so the result might be
 	// empty or incomplete if the user hasn't successfully run "terraform init"
 	// since the most recent change to dependencies.
@@ -84,81 +88,30 @@ func (c *VersionCommand) Run(rawArgs []string) int {
 	// Generally-speaking this is a best-effort thing that will give us a good
 	// result in the usual case where the user successfully ran "terraform init"
 	// and then hit a problem running _another_ command.
-	var providerVersions []string
 	var providerLocks map[addrs.Provider]*depsfile.ProviderLock
 	if locks, err := c.lockedDependencies(); err == nil {
 		providerLocks = locks.AllProviders()
-		for providerAddr, lock := range providerLocks {
-			version := lock.Version().String()
-			if version == "0.0.0" {
-				providerVersions = append(providerVersions, fmt.Sprintf("+ provider %s (unversioned)", providerAddr))
-			} else {
-				providerVersions = append(providerVersions, fmt.Sprintf("+ provider %s v%s", providerAddr, version))
-			}
-		}
 	}
 
 	// If we have a version check function, then let's check for
 	// the latest version as well.
+	var latest string
+	var outdated bool
 	if c.CheckFunc != nil {
 		// Check the latest version
 		info, err := c.CheckFunc()
-		if err != nil && !jsonOutput {
-			c.Ui.Error(fmt.Sprintf(
+		if err != nil {
+			diags = diags.Append(fmt.Errorf(
 				"\nError checking latest version: %s", err))
 		}
 		if info.Outdated {
-			outdated = true
 			latest = info.Latest
+			outdated = true
 		}
 	}
 
-	if jsonOutput {
-		selectionsOutput := make(map[string]string)
-		for providerAddr, lock := range providerLocks {
-			version := lock.Version().String()
-			selectionsOutput[providerAddr.String()] = version
-		}
-
-		var versionOutput string
-		if c.VersionPrerelease != "" {
-			versionOutput = c.Version + "-" + c.VersionPrerelease
-		} else {
-			versionOutput = c.Version
-		}
-
-		output := VersionOutput{
-			Version:            versionOutput,
-			Platform:           c.Platform.String(),
-			ProviderSelections: selectionsOutput,
-			Outdated:           outdated,
-		}
-
-		jsonOutput, err := json.MarshalIndent(output, "", "  ")
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("\nError marshalling JSON: %s", err))
-			return 1
-		}
-		c.Ui.Output(string(jsonOutput))
-		return 0
-	} else {
-		c.Ui.Output(versionString.String())
-		c.Ui.Output(fmt.Sprintf("on %s", c.Platform))
-
-		if len(providerVersions) != 0 {
-			sort.Strings(providerVersions)
-			for _, str := range providerVersions {
-				c.Ui.Output(str)
-			}
-		}
-		if outdated {
-			c.Ui.Output(fmt.Sprintf(
-				"\nYour version of Terraform is out of date! The latest version\n"+
-					"is %s. You can update by downloading from https://developer.hashicorp.com/terraform/install",
-				latest))
-		}
-
-	}
+	// Format and print output
+	view.LogVersion(version, platform, providerLocks, outdated, latest, diags)
 
 	return 0
 }

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -39,10 +39,10 @@ func TestVersion(t *testing.T) {
 		nil,
 	)
 
-	ui := testUiWrapped(t)
+	view, done := testView(t)
 	c := &VersionCommand{
 		Meta: Meta{
-			Ui: ui,
+			View: view,
 		},
 		Version:           "4.5.6",
 		VersionPrerelease: "foo",
@@ -52,10 +52,10 @@ func TestVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 	if code := c.Run([]string{}); code != 0 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+		t.Fatalf("bad: \n%s", done(t).All())
 	}
 
-	actual := strings.TrimSpace(ui.OutputWriter.String())
+	actual := strings.TrimSpace(done(t).All())
 	expected := "Terraform v4.5.6-foo\non aros_riscv64\n+ provider registry.terraform.io/hashicorp/test1 v7.8.9-beta.2\n+ provider registry.terraform.io/hashicorp/test2 v1.2.3"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot:\n%s\nwant:\n%s", actual, expected)
@@ -66,9 +66,9 @@ func TestVersion(t *testing.T) {
 // This is because whenever a user runs `terraform <any command name> -version`, etc, main.go
 // will call the version command with all of the supplied flags and arguments.
 func TestVersion_flags(t *testing.T) {
-	ui := testUiWrapped(t)
+	view, done := testView(t)
 	m := Meta{
-		Ui: ui,
+		View: view,
 	}
 
 	// `terraform version`
@@ -80,10 +80,10 @@ func TestVersion_flags(t *testing.T) {
 	}
 
 	if code := c.Run([]string{"-v", "-version", "--version"}); code != 0 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+		t.Fatalf("bad: \n%s", done(t).All())
 	}
 
-	actual := strings.TrimSpace(ui.OutputWriter.String())
+	actual := strings.TrimSpace(done(t).All())
 	expected := "Terraform v4.5.6-foo\non aros_riscv64"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)
@@ -92,9 +92,9 @@ func TestVersion_flags(t *testing.T) {
 
 func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 	t.Run("unexpected positional arguments are ignored without error", func(t *testing.T) {
-		ui := testUiWrapped(t)
+		view, done := testView(t)
 		m := Meta{
-			Ui: ui,
+			View: view,
 		}
 
 		// `terraform version`
@@ -111,25 +111,26 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 			"bar",
 		}
 		if code := c.Run(args); code != 0 {
-			t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+			t.Fatalf("bad: \n%s", done(t).All())
 		}
 
-		actual := strings.TrimSpace(ui.OutputWriter.String())
+		output := done(t)
+		actual := strings.TrimSpace(output.Stdout())
 		expected := "Terraform v4.5.6-foo\non aros_riscv64"
 		if actual != expected {
 			t.Fatalf("wrong stdout output\ngot: %#v\nwant: %#v", actual, expected)
 		}
 
-		actual = strings.TrimSpace(ui.ErrorWriter.String())
+		actual = strings.TrimSpace(output.Stderr())
 		expected = ""
 		if actual != expected {
 			t.Fatalf("wrong stderr output\ngot: %#v\nwant: %#v", actual, expected)
 		}
 
 		// Machine-readable / JSON output
-		ui = testUiWrapped(t)
+		view, done = testView(t)
 		c.Meta = Meta{
-			Ui: ui,
+			View: view,
 		}
 		args = []string{
 			"-json",
@@ -137,10 +138,11 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 			"bar",
 		}
 		if code := c.Run(args); code != 0 {
-			t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+			t.Fatalf("bad: \n%s", done(t).All())
 		}
 
-		actual = strings.TrimSpace(ui.OutputWriter.String())
+		output = done(t)
+		actual = strings.TrimSpace(output.Stdout())
 		expected = strings.TrimSpace(`
 {
   "terraform_version": "4.5.6-foo",
@@ -153,7 +155,7 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 			t.Fatalf("wrong output\n%s", diff)
 		}
 
-		actual = strings.TrimSpace(ui.ErrorWriter.String())
+		actual = strings.TrimSpace(output.Stderr())
 		expected = ""
 		if actual != expected {
 			t.Fatalf("wrong stderr output\ngot: %#v\nwant: %#v", actual, expected)
@@ -161,9 +163,9 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 	})
 
 	t.Run("incorrect flag", func(t *testing.T) {
-		ui := testUiWrapped(t)
+		view, done := testView(t)
 		m := Meta{
-			Ui: ui,
+			View: view,
 		}
 
 		// `terraform version`
@@ -176,19 +178,22 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 
 		// Human output
 		args := []string{
+			"-no-color",
 			"-foobar",
 		}
 		if code := c.Run(args); code != 1 {
-			t.Fatalf("expected code 1 and error output, but got code %d:\nstdout: %s\nstderr: %s", code, ui.OutputWriter.String(), ui.ErrorWriter.String())
+			output := done(t)
+			t.Fatalf("expected code 1 and error output, but got code %d:\nstdout: %s\nstderr: %s", code, output.Stdout(), output.Stderr())
 		}
 
-		actual := strings.TrimSpace(ui.OutputWriter.String())
+		output := done(t)
+		actual := strings.TrimSpace(output.Stdout())
 		expected := ""
 		if actual != expected {
 			t.Fatalf("wrong stdout output\ngot: %#v\nwant: %#v", actual, expected)
 		}
 
-		actual = strings.TrimSpace(ui.ErrorWriter.String())
+		actual = strings.TrimSpace(output.Stderr())
 		expected = `Error: Failed to parse command-line flags
 
 flag provided but not defined: -foobar`
@@ -197,26 +202,28 @@ flag provided but not defined: -foobar`
 		}
 
 		// Machine-readable / JSON output
-		ui = testUiWrapped(t)
+		view, done = testView(t)
 		c.Meta = Meta{
-			Ui: ui,
+			View: view,
 		}
 		args = []string{
+			"-no-color",
 			"-json",
 			"-foobar",
 		}
 		if code := c.Run(args); code != 1 {
-			t.Fatalf("expected code 1 and error output, but got code %d:\nstdout: %s\nstderr: %s", code, ui.OutputWriter.String(), ui.ErrorWriter.String())
+			t.Fatalf("expected code 1 and error output, but got code %d:\nstdout: %s\nstderr: %s", code, done(t).Stdout(), done(t).Stderr())
 		}
 
-		actual = strings.TrimSpace(ui.OutputWriter.String())
+		output = done(t)
+		actual = strings.TrimSpace(output.Stdout())
 		expected = ""
 		if actual != expected {
 			t.Fatalf("wrong stdout output\ngot: %#v\nwant: %#v", actual, expected)
 		}
 
 		// Human error output is rendered despite -json flag when an error occurs
-		actual = strings.TrimSpace(ui.ErrorWriter.String())
+		actual = strings.TrimSpace(output.Stderr())
 		expected = `Error: Failed to parse command-line flags
 
 flag provided but not defined: -foobar`
@@ -227,9 +234,9 @@ flag provided but not defined: -foobar`
 }
 
 func TestVersion_outdated(t *testing.T) {
-	ui := testUiWrapped(t)
+	view, done := testView(t)
 	m := Meta{
-		Ui: ui,
+		View: view,
 	}
 
 	c := &VersionCommand{
@@ -240,10 +247,10 @@ func TestVersion_outdated(t *testing.T) {
 	}
 
 	if code := c.Run([]string{}); code != 0 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+		t.Fatalf("bad: \n%s", done(t).All())
 	}
 
-	actual := strings.TrimSpace(ui.OutputWriter.String())
+	actual := strings.TrimSpace(done(t).All())
 	expected := "Terraform v4.5.6\non aros_riscv64\n\nYour version of Terraform is out of date! The latest version\nis 4.5.7. You can update by downloading from https://developer.hashicorp.com/terraform/install"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)
@@ -254,9 +261,9 @@ func TestVersion_json(t *testing.T) {
 	td := t.TempDir()
 	t.Chdir(td)
 
-	ui := testUiWrapped(t)
+	view, done := testView(t)
 	meta := Meta{
-		Ui: ui,
+		View: view,
 	}
 
 	// `terraform version -json` without prerelease
@@ -266,10 +273,10 @@ func TestVersion_json(t *testing.T) {
 		Platform: getproviders.Platform{OS: "aros", Arch: "riscv64"},
 	}
 	if code := c.Run([]string{"-json"}); code != 0 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+		t.Fatalf("bad: \n%s", done(t).All())
 	}
 
-	actual := strings.TrimSpace(ui.OutputWriter.String())
+	actual := strings.TrimSpace(done(t).All())
 	expected := strings.TrimSpace(`
 {
   "terraform_version": "4.5.6",
@@ -281,9 +288,6 @@ func TestVersion_json(t *testing.T) {
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Fatalf("wrong output\n%s", diff)
 	}
-
-	// flush the output from the mock ui
-	ui.OutputWriter.Reset()
 
 	// Now we'll create a fixed dependency lock file in our working directory
 	// so we can verify that the version command shows the information
@@ -303,6 +307,8 @@ func TestVersion_json(t *testing.T) {
 	)
 
 	// `terraform version -json` with prerelease and provider dependencies
+	view, done = testView(t)
+	meta.View = view
 	c = &VersionCommand{
 		Meta:              meta,
 		Version:           "4.5.6",
@@ -313,10 +319,10 @@ func TestVersion_json(t *testing.T) {
 		t.Fatal(err)
 	}
 	if code := c.Run([]string{"-json"}); code != 0 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+		t.Fatalf("bad: \n%s", done(t).All())
 	}
 
-	actual = strings.TrimSpace(ui.OutputWriter.String())
+	actual = strings.TrimSpace(done(t).All())
 	expected = strings.TrimSpace(`
 {
   "terraform_version": "4.5.6-foo",
@@ -334,9 +340,9 @@ func TestVersion_json(t *testing.T) {
 }
 
 func TestVersion_jsonoutdated(t *testing.T) {
-	ui := testUiWrapped(t)
+	view, done := testView(t)
 	m := Meta{
-		Ui: ui,
+		View: view,
 	}
 
 	c := &VersionCommand{
@@ -347,10 +353,10 @@ func TestVersion_jsonoutdated(t *testing.T) {
 	}
 
 	if code := c.Run([]string{"-json"}); code != 0 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+		t.Fatalf("bad: \n%s", done(t).All())
 	}
 
-	actual := strings.TrimSpace(ui.OutputWriter.String())
+	actual := strings.TrimSpace(done(t).All())
 	expected := "{\n  \"terraform_version\": \"4.5.6\",\n  \"platform\": \"aros_riscv64\",\n  \"provider_selections\": {},\n  \"terraform_outdated\": true\n}"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)

--- a/internal/command/views/version.go
+++ b/internal/command/views/version.go
@@ -1,0 +1,121 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+type Version interface {
+	LogVersion(version string, platform string, providerSelections map[addrs.Provider]*depsfile.ProviderLock, outdated bool, latest string, diags tfdiags.Diagnostics)
+	Diagnostics(diags tfdiags.Diagnostics)
+}
+
+// VersionOutput contains the information that is output by the version command.
+// Either it's rendered as JSON or as a human-readable string, depending on the view type.
+type VersionOutput struct {
+	Version            string            `json:"terraform_version"`
+	Platform           string            `json:"platform"`
+	ProviderSelections map[string]string `json:"provider_selections"`
+	Outdated           bool              `json:"terraform_outdated"`
+}
+
+func NewVersion(vt arguments.ViewType, view *View) Version {
+	switch vt {
+	case arguments.ViewJSON:
+		return &VersionJSON{
+			view: view,
+		}
+	case arguments.ViewHuman:
+		return &VersionHuman{
+			view: view,
+		}
+	default:
+		panic(fmt.Sprintf("unknown view type %v", vt))
+	}
+}
+
+type VersionHuman struct {
+	view *View
+}
+
+func (v *VersionHuman) Diagnostics(diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
+}
+
+func (v *VersionHuman) LogVersion(version string, platform string, providerSelections map[addrs.Provider]*depsfile.ProviderLock, outdated bool, latest string, diags tfdiags.Diagnostics) {
+	// Log any diagnostics first, so they appear above the version output.
+	// Calling code should have handled errors, so we expect only warnings here.
+	v.Diagnostics(diags)
+
+	var outputString bytes.Buffer
+
+	// Terraform version and platform
+	fmt.Fprintf(&outputString, "Terraform v%s\n", version) // May include prerelease if relevant
+	fmt.Fprintf(&outputString, "on %s\n", platform)
+
+	// For each provider selection, print the provider and version
+	// The list is sorted to make output deterministic.
+	var providerVersions []string
+	for provider, lock := range providerSelections {
+		version := lock.Version().String()
+		if version == "0.0.0" {
+			providerVersions = append(providerVersions, fmt.Sprintf("+ provider %s (unversioned)", provider))
+		} else {
+			providerVersions = append(providerVersions, fmt.Sprintf("+ provider %s v%s", provider, version))
+		}
+	}
+	slices.Sort(providerVersions)
+	for _, str := range providerVersions {
+		fmt.Fprintln(&outputString, str)
+	}
+
+	if outdated {
+		fmt.Fprintf(&outputString, "\nYour version of Terraform is out of date! The latest version\nis %s. You can update by downloading from https://developer.hashicorp.com/terraform/install\n", latest)
+	}
+
+	v.view.streams.Println(outputString.String())
+}
+
+type VersionJSON struct {
+	view *View
+}
+
+func (v *VersionJSON) Diagnostics(diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
+}
+
+func (v *VersionJSON) LogVersion(version string, platform string, providerSelections map[addrs.Provider]*depsfile.ProviderLock, outdated bool, latest string, diags tfdiags.Diagnostics) {
+	v.Diagnostics(diags) // Log any warnings. This is done in human-readable format, even for JSON output, as that's an existing bug in the command.
+
+	output := VersionOutput{
+		Version:            version,
+		Platform:           platform,
+		ProviderSelections: make(map[string]string),
+		Outdated:           outdated,
+	}
+
+	for provider, lock := range providerSelections {
+		output.ProviderSelections[provider.String()] = lock.Version().String()
+	}
+
+	v.view.streams.Println(v.marshal(&output))
+}
+
+func (v *VersionJSON) marshal(output *VersionOutput) string {
+	j, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		// Should never happen because we fully-control the input here
+		panic(err)
+	}
+	return string(j)
+}

--- a/internal/command/views/version.go
+++ b/internal/command/views/version.go
@@ -91,6 +91,9 @@ type VersionJSON struct {
 }
 
 func (v *VersionJSON) Diagnostics(diags tfdiags.Diagnostics) {
+	if len(diags) == 0 {
+		return
+	}
 	v.view.Diagnostics(diags)
 }
 

--- a/internal/command/views/version_test.go
+++ b/internal/command/views/version_test.go
@@ -1,0 +1,118 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/hashicorp/terraform/internal/terminal"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestVersionHuman_LogVersion(t *testing.T) {
+	testCases := map[string]struct {
+		version            string
+		platform           string
+		providerSelections map[addrs.Provider]*depsfile.ProviderLock
+		outdated           bool
+		latest             string
+		diags              tfdiags.Diagnostics
+
+		wantOutput string
+	}{
+		"basic": {
+			version:    "1.0.0",
+			platform:   "linux_amd64",
+			wantOutput: "Terraform v1.0.0\non linux_amd64\n\n",
+		},
+		"with providers": {
+			version:  "1.0.0",
+			platform: "linux_amd64",
+			providerSelections: map[addrs.Provider]*depsfile.ProviderLock{
+				addrs.NewDefaultProvider("test1"): depsfile.NewProviderLock(
+					addrs.NewDefaultProvider("test1"),
+					getproviders.MustParseVersion("1.2.3"),
+					// No constraint or hashes
+					nil,
+					nil,
+				),
+				addrs.NewDefaultProvider("test2"): depsfile.NewProviderLock(
+					addrs.NewDefaultProvider("test2"),
+					getproviders.MustParseVersion("0.0.0"), // Not sure how this would happen, but the output is special here.
+					// No constraint or hashes
+					nil,
+					nil,
+				),
+			},
+			wantOutput: `Terraform v1.0.0
+on linux_amd64
++ provider registry.terraform.io/hashicorp/test1 v1.2.3
++ provider registry.terraform.io/hashicorp/test2 (unversioned)
+
+`,
+		},
+		"with outdated + latest": {
+			version:            "1.0.0",
+			platform:           "linux_amd64",
+			providerSelections: map[addrs.Provider]*depsfile.ProviderLock{},
+			outdated:           true,
+			latest:             "1.16.0",
+			diags:              nil,
+			wantOutput: `Terraform v1.0.0
+on linux_amd64
+
+Your version of Terraform is out of date! The latest version
+is 1.16.0. You can update by downloading from https://developer.hashicorp.com/terraform/install
+
+`,
+		},
+		"with warning": {
+			version:            "1.0.0",
+			platform:           "linux_amd64",
+			providerSelections: map[addrs.Provider]*depsfile.ProviderLock{},
+			diags: tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Warning,
+					"Your shoelaces are untied",
+					"Watch out, or you'll trip!",
+				),
+			},
+			wantOutput: `
+Warning: Your shoelaces are untied
+
+Watch out, or you'll trip!
+Terraform v1.0.0
+on linux_amd64
+
+`,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			view := NewView(streams)
+			view.Configure(&arguments.View{NoColor: true})
+			v := NewVersion(arguments.ViewHuman, view)
+
+			v.LogVersion(
+				tc.version,
+				tc.platform,
+				tc.providerSelections,
+				tc.outdated,
+				tc.latest,
+				tc.diags,
+			)
+
+			got := done(t).All()
+			if diff := cmp.Diff(tc.wantOutput, got); diff != "" {
+				t.Errorf("unexpected output diff:\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/command/views/version_test.go
+++ b/internal/command/views/version_test.go
@@ -116,3 +116,124 @@ on linux_amd64
 		})
 	}
 }
+
+func TestVersionJSON_LogVersion(t *testing.T) {
+	testCases := map[string]struct {
+		version            string
+		platform           string
+		providerSelections map[addrs.Provider]*depsfile.ProviderLock
+		outdated           bool
+		latest             string
+		diags              tfdiags.Diagnostics
+
+		wantOutput string
+	}{
+		"basic": {
+			version:  "1.0.0",
+			platform: "linux_amd64",
+			wantOutput: `{
+  "terraform_version": "1.0.0",
+  "platform": "linux_amd64",
+  "provider_selections": {},
+  "terraform_outdated": false
+}
+`,
+		},
+		"with providers": {
+			version:  "1.0.0",
+			platform: "linux_amd64",
+			providerSelections: map[addrs.Provider]*depsfile.ProviderLock{
+				addrs.NewDefaultProvider("test1"): depsfile.NewProviderLock(
+					addrs.NewDefaultProvider("test1"),
+					getproviders.MustParseVersion("1.2.3"),
+					// No constraint or hashes
+					nil,
+					nil,
+				),
+				addrs.NewDefaultProvider("test2"): depsfile.NewProviderLock(
+					addrs.NewDefaultProvider("test2"),
+					getproviders.MustParseVersion("0.0.0"), // Not sure how this would happen, but the output is special here.
+					// No constraint or hashes
+					nil,
+					nil,
+				),
+			},
+			wantOutput: `{
+  "terraform_version": "1.0.0",
+  "platform": "linux_amd64",
+  "provider_selections": {
+    "registry.terraform.io/hashicorp/test1": "1.2.3",
+    "registry.terraform.io/hashicorp/test2": "0.0.0"
+  },
+  "terraform_outdated": false
+}
+`,
+		},
+		"with outdated + latest": {
+			version:            "1.0.0",
+			platform:           "linux_amd64",
+			providerSelections: map[addrs.Provider]*depsfile.ProviderLock{},
+			outdated:           true,
+			latest:             "1.16.0",
+			diags:              nil,
+			wantOutput: `{
+  "terraform_version": "1.0.0",
+  "platform": "linux_amd64",
+  "provider_selections": {},
+  "terraform_outdated": true
+}
+`,
+		},
+		"with warning": {
+			version:            "1.0.0",
+			platform:           "linux_amd64",
+			providerSelections: map[addrs.Provider]*depsfile.ProviderLock{},
+			diags: tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Warning,
+					"Your shoelaces are untied",
+					"Watch out, or you'll trip!",
+				),
+			},
+			wantOutput: `
+Warning: Your shoelaces are untied
+
+Watch out, or you'll trip!
+{
+  "terraform_version": "1.0.0",
+  "platform": "linux_amd64",
+  "provider_selections": {},
+  "terraform_outdated": false
+}
+`,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			view := NewView(streams)
+			view.Configure(&arguments.View{NoColor: true})
+			v := NewVersion(arguments.ViewJSON, view)
+
+			v.LogVersion(
+				tc.version,
+				tc.platform,
+				tc.providerSelections,
+				tc.outdated,
+				tc.latest,
+				tc.diags,
+			)
+
+			output := done(t)
+			gotErr := output.Stderr()
+			if gotErr != "" {
+				t.Errorf("unexpected stderr output:\n%s", gotErr)
+			}
+
+			got := output.Stdout()
+			if diff := cmp.Diff(tc.wantOutput, got); diff != "" {
+				t.Errorf("unexpected output diff:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Related: https://github.com/hashicorp/terraform/pull/38803

This PR moves all logic determining how version data is formatted and presented to the user/consumer into the `views` package:
* Human view implementation prints lines of output in the usual structure
* JSON view implementation populates a struct with data, marshals it into a JSON string, and logs it.

The impact of this PR is mostly code organisation, but from a user perspective they will now see colour in human output that can be disabled with `-no-color`:

Before:
<img width="388" height="85" alt="Screenshot 2026-07-24 at 17 58 30" src="https://github.com/user-attachments/assets/e5a515bf-9a2f-44aa-b18a-8f6971f2f775" />

After:
<img width="419" height="86" alt="Screenshot 2026-07-24 at 17 50 40" src="https://github.com/user-attachments/assets/46cb2500-23e6-4b06-a345-ba379385b16b" />


JSON output is impacted by the same change because prior to and after this PR `terraform version -json -foobar` will render the error diagnostic in a human format. Fixing this is outside the scope of this PR so it is preserved.


## Aside

Something this task solidified in my mind while working on it is: We only use `views.NewJSONView` when creating a JSON view implementation for long running commands with structured output and multiple logs per command. When we add static log JSON output to a command we wrap a regular View, which is the default and therefore designed for human output. This is why we have lots of commands that accidentally log diagnostics in a human way despite JSON output being configured.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
