### PR TITLE
🤖🤖🤖 Fix race condition in ephemeral resources InstanceValue (#38591)

### DIFF
--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -102,7 +102,10 @@ func (r *Resources) InstanceValue(addr addrs.AbsResourceInstance) (val cty.Value
 	}
 	// If renewal has failed then we can't assume that the object is still
 	// live, but we can still return the original value regardless.
-	return inst.value, !inst.renewDiags.HasErrors()
+	inst.renewMu.Lock()
+	live = !inst.renewDiags.HasErrors()
+	inst.renewMu.Unlock()
+	return inst.value, live
 }
 
 // CloseInstances shuts down any live ephemeral resource instances that are


### PR DESCRIPTION
### Description

Fixes #38591

**Root cause**: `InstanceValue()` reads `inst.renewDiags` without holding `inst.renewMu`, causing a data race with the `handleRenewal` goroutine which writes to `renewDiags` under the same mutex.

This race was previously masked because `r.renewDiags.Append(diags)` was silently discarding the return value, so `renewDiags` was never actually modified. After PR #38583 fixed the append pattern, the pre-existing race became visible under `-race` detection.

**Fix**: Acquire `inst.renewMu` before reading `renewDiags` in `InstanceValue()`.

### Testing

The fix is a straightforward synchronization fix — adding a mutex lock around a shared variable read. The race is reproducible by applying PR #38583's change and running `go test -race ./internal/terraform`.

### AI Disclosure

🤖 This PR was created with AI assistance. The author identified the bug, analyzed the root cause, reviewed all code changes, and verified correctness. AI was used to assist with code analysis and drafting the fix.

### CHANGELOG entry

- [x] This change is not user-facing.