### PR TITLE
version: Add `format_version` field to JSON output

### DIFF
--- a/.changes/v1.17/NOTES-20260728-130911.yaml
+++ b/.changes/v1.17/NOTES-20260728-130911.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: "version: JSON output now includes a new `format_version` field, which will enable future extensions of the command's JSON output format with new fields. This new field, and future ones, will be silently ignored by older versions of the hashicorp/terraform-json but will be supported in a future release of that tool."
+time: 2026-07-28T13:09:11.825354+01:00
+custom:
+    Issue: "38930"

--- a/.changes/v1.17/NOTES-20260728-130911.yaml
+++ b/.changes/v1.17/NOTES-20260728-130911.yaml
@@ -1,5 +1,5 @@
 kind: NOTES
-body: "version: JSON output now includes a new `format_version` field, which will enable future extensions of the command's JSON output format with new fields. This new field, and future ones, will be silently ignored by older versions of the hashicorp/terraform-json but will be supported in a future release of that tool."
+body: "version: JSON output now includes a new `format_version` field, which will enable safer future changes of the command's JSON output format. It is assumed existing tooling ignores unknown fields and therefore this change should not be breaking in itself but we advice consumers to pay attention to `format_version` in future releases and/or use latest version of hashicorp/terraform-json & hashicorp/terraform-exec which does."
 time: 2026-07-28T13:09:11.825354+01:00
 custom:
     Issue: "38930"

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -145,6 +145,7 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 		actual = strings.TrimSpace(output.Stdout())
 		expected = strings.TrimSpace(`
 {
+  "format_version": "1.0",
   "terraform_version": "4.5.6-foo",
   "platform": "aros_riscv64",
   "provider_selections": {},
@@ -279,6 +280,7 @@ func TestVersion_json(t *testing.T) {
 	actual := strings.TrimSpace(done(t).All())
 	expected := strings.TrimSpace(`
 {
+  "format_version": "1.0",
   "terraform_version": "4.5.6",
   "platform": "aros_riscv64",
   "provider_selections": {},
@@ -325,6 +327,7 @@ func TestVersion_json(t *testing.T) {
 	actual = strings.TrimSpace(done(t).All())
 	expected = strings.TrimSpace(`
 {
+  "format_version": "1.0",
   "terraform_version": "4.5.6-foo",
   "platform": "aros_riscv64",
   "provider_selections": {
@@ -357,7 +360,7 @@ func TestVersion_jsonoutdated(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(done(t).All())
-	expected := "{\n  \"terraform_version\": \"4.5.6\",\n  \"platform\": \"aros_riscv64\",\n  \"provider_selections\": {},\n  \"terraform_outdated\": true\n}"
+	expected := "{\n  \"format_version\": \"1.0\",\n  \"terraform_version\": \"4.5.6\",\n  \"platform\": \"aros_riscv64\",\n  \"provider_selections\": {},\n  \"terraform_outdated\": true\n}"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot: %#v\nwant: %#v", actual, expected)
 	}

--- a/internal/command/views/version.go
+++ b/internal/command/views/version.go
@@ -23,6 +23,9 @@ type Version interface {
 // VersionOutput contains the information that is output by the version command.
 // Either it's rendered as JSON or as a human-readable string, depending on the view type.
 type VersionOutput struct {
+	// format_version is required for us to be able to change the JSON output in future
+	FormatVersion string `json:"format_version"`
+
 	Version            string            `json:"terraform_version"`
 	Platform           string            `json:"platform"`
 	ProviderSelections map[string]string `json:"provider_selections"`
@@ -97,10 +100,18 @@ func (v *VersionJSON) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)
 }
 
+// LogVersion prints the version information in JSON format.
+// The schema of the output is versioned using the format_version field, which is standard for commands with 'static log' JSON output.
 func (v *VersionJSON) LogVersion(version string, platform string, providerSelections map[addrs.Provider]*depsfile.ProviderLock, outdated bool, latest string, diags tfdiags.Diagnostics) {
+	// FormatVersion represents the version of the json format and will be
+	// incremented for any change to this format that requires changes to a
+	// consuming parser.
+	const FormatVersion = "1.0"
+
 	v.Diagnostics(diags) // Log any warnings. This is done in human-readable format, even for JSON output, as that's an existing bug in the command.
 
 	output := VersionOutput{
+		FormatVersion:      FormatVersion,
 		Version:            version,
 		Platform:           platform,
 		ProviderSelections: make(map[string]string),

--- a/internal/command/views/version_test.go
+++ b/internal/command/views/version_test.go
@@ -132,6 +132,7 @@ func TestVersionJSON_LogVersion(t *testing.T) {
 			version:  "1.0.0",
 			platform: "linux_amd64",
 			wantOutput: `{
+  "format_version": "1.0",
   "terraform_version": "1.0.0",
   "platform": "linux_amd64",
   "provider_selections": {},
@@ -159,6 +160,7 @@ func TestVersionJSON_LogVersion(t *testing.T) {
 				),
 			},
 			wantOutput: `{
+  "format_version": "1.0",
   "terraform_version": "1.0.0",
   "platform": "linux_amd64",
   "provider_selections": {
@@ -177,6 +179,7 @@ func TestVersionJSON_LogVersion(t *testing.T) {
 			latest:             "1.16.0",
 			diags:              nil,
 			wantOutput: `{
+  "format_version": "1.0",
   "terraform_version": "1.0.0",
   "platform": "linux_amd64",
   "provider_selections": {},
@@ -200,6 +203,7 @@ Warning: Your shoelaces are untied
 
 Watch out, or you'll trip!
 {
+  "format_version": "1.0",
   "terraform_version": "1.0.0",
   "platform": "linux_amd64",
   "provider_selections": {},


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform/pull/38925
Also, this PR is preparation for addressing how the `version` command currently logs errors in human format.

Static logs produced by Terraform are versioned using a top-level `format_version` field. Different commands will have different values for this field in their output depending on how mush their output schema has evolved over time. Commands that produce structured logs do versioning in a different way, that's irrelevant here.

The version command was one of the first places where JSON output was added to the Terraform CLI, so it doesn't follow the norms that followed. This PR makes the command's output follow the norm that all static log outputs include a `format_version` field. That norm doesn't seem to be publicly documented 🤦🏻 but that's a separate issue.

In terms of the impact of this change on current users of Terraform:
* If a user upgrades to a new TF version with this change, older hashicorp/terraform-json versions will continue to parse JSON output ok. The new field would be silently ignored.
* We should publish an update to hashicorp/terraform-json to enable the new field to be parsed, but conditional on the TF version in use.
* This PR's changes should NOT BE BACKPORTED for these reasons.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
