### PR TITLE
command/show: Emit diagnostics from backend initialisation

### DIFF
--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -92,6 +92,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	lr, _, ctxDiags := local.LocalRun(context.Background(), opReq)
 
 	if ctxDiags.HasErrors() {
+		diags = diags.Append(ctxDiags)
 		return view.DisplayResourceInstanceState(jsonformat.State{}, diags)
 	}
 

--- a/internal/command/state_show_test.go
+++ b/internal/command/state_show_test.go
@@ -17,6 +17,7 @@ import (
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestStateShow(t *testing.T) {
@@ -421,6 +422,59 @@ resource "test_instance" "foo" {
     id  = "bar"
 }
 `
+
+func TestStateShow_stateStore_error(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("state-store-unchanged/provider-managed-by-terraform"), td)
+	t.Chdir(td)
+
+	// Create a mock that contains a persisted "default" state that uses the bytes from above.
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		[]byte(""),
+	)
+	mockProvider.ReadStateBytesFn = func(rsbr providers.ReadStateBytesRequest) providers.ReadStateBytesResponse {
+		var diags tfdiags.Diagnostics
+		diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "state reading failed", "test error"))
+		return providers.ReadStateBytesResponse{
+			Diagnostics: diags,
+		}
+	}
+	mockProviderAddress := addrs.NewDefaultProvider("test")
+
+	ui := testUiWrapped(t)
+	view, done := testView(t)
+	c := &StateShowCommand{
+		Meta: Meta{
+			AllowExperimentalFeatures: true,
+			testingOverrides: &testingOverrides{
+				Providers: map[addrs.Provider]providers.Factory{
+					mockProviderAddress: providers.FactoryFixed(mockProvider),
+				},
+			},
+			Ui:   ui,
+			View: view,
+		},
+	}
+
+	// `terraform show` command specifying a given resource addr
+	args := []string{"test_instance.foo", "-no-color"}
+	code := c.Run(args)
+	output := done(t)
+	if code != 1 {
+		t.Fatalf("unexpected exit code: %d (expected 1)\n\n%s", code, output.All())
+	}
+
+	// Test that error was displayed
+	expectedErr := "Error: state reading failed"
+	out := output.Stderr()
+	if !strings.Contains(out, expectedErr) {
+		t.Fatalf("Expected:\n%q\n\nTo contain: %q", out, expectedErr)
+	}
+}
 
 func TestStateShow_json(t *testing.T) {
 	state := states.BuildState(func(s *states.SyncState) {


### PR DESCRIPTION
Originally I intended to just improve code coverage as prompted in https://github.com/hashicorp/terraform/pull/38908#discussion_r3659796532 but it turned into a bug fix that goes along with the test. 😅 

This is just fixing a bug that was introduced recently [as part of introducing JSON output](https://github.com/hashicorp/terraform/pull/38341). That bug was only part of 1.16.x which has not reached a stable release yet (only alphas and beta), so I'm opting to avoid changelog entry.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
