### PR TITLE
Introduce policy_query_summary JSON record

### DIFF
--- a/internal/cloud/backend_query_test.go
+++ b/internal/cloud/backend_query_test.go
@@ -38,7 +38,7 @@ func testOperationQueryWithTimeout(t *testing.T, configDir string, timeout time.
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
 	stateLockerView := views.NewStateLocker(arguments.ViewHuman, view)
-	operationView := views.NewQueryOperation(arguments.ViewHuman, false, view)
+	operationView := views.NewQuery(arguments.ViewHuman, view).Operation()
 
 	// Many of our tests use an overridden "null" provider that's just in-memory
 	// inside the test process, not a separate plugin on disk.

--- a/internal/command/jsonformat/renderer.go
+++ b/internal/command/jsonformat/renderer.go
@@ -89,9 +89,10 @@ const (
 	LogListComplete      JSONLogType = "list_complete"
 
 	// Policy Messages
-	LogPolicyInfo       JSONLogType = "policy_info"
-	LogPolicyResult     JSONLogType = "policy_result"
-	LogPolicyDiagnostic JSONLogType = "policy_diagnostic"
+	LogPolicyInfo         JSONLogType = "policy_info"
+	LogPolicyResult       JSONLogType = "policy_result"
+	LogPolicyDiagnostic   JSONLogType = "policy_diagnostic"
+	LogPolicyQuerySummary JSONLogType = "policy_query_summary"
 )
 
 func incompatibleVersions(localVersion, remoteVersion string) bool {
@@ -176,7 +177,8 @@ func (renderer Renderer) RenderLog(log *JSONLog) error {
 		LogListComplete,
 		LogPolicyInfo,
 		LogPolicyResult,
-		LogPolicyDiagnostic:
+		LogPolicyDiagnostic,
+		LogPolicyQuerySummary:
 		// We won't display these types of logs
 		return nil
 

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -63,6 +63,7 @@ const (
 	MessagePolicyInfo             MessageType = "policy_info"
 	MessagePolicyDiagnostic       MessageType = "policy_diagnostic"
 	MessagePolicyEvaluationResult MessageType = "policy_result"
+	MessagePolicyQuerySummary     MessageType = "policy_query_summary"
 
 	// Provider installation messages
 	InstallStateStoreProviderStart MessageType = "state_store_provider_installation_start"

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -64,4 +64,5 @@ const (
 	MessagePolicyInfo             MessageType = "policy_info"
 	MessagePolicyDiagnostic       MessageType = "policy_diagnostic"
 	MessagePolicyEvaluationResult MessageType = "policy_result"
+	MessagePolicyQuerySummary     MessageType = "policy_query_summary"
 )

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -178,6 +178,18 @@ func (v *JSONView) logPolicyResult(addr string, resp policy.EvaluationResponse) 
 	}
 }
 
+func (v *JSONView) logPolicyQuerySummary(summary queryPolicySummary) {
+	v.log.Error(
+		"Policy query summary",
+		"type", json.MessagePolicyQuerySummary,
+		"@policy", "true",
+		"list_block_address", summary.ListBlockAddress,
+		"overall_result", summary.OverallResult,
+		"results", summary.Results,
+		"passed_policies", summary.PassedPolicies,
+	)
+}
+
 func (v *JSONView) PolicyResult(addr string, resp policy.EvaluationResponse) {
 	v.logPolicyResult(addr, resp)
 }

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -179,7 +179,7 @@ func (v *JSONView) logPolicyResult(addr string, resp policy.EvaluationResponse) 
 }
 
 func (v *JSONView) logPolicyQuerySummary(summary queryPolicySummary) {
-	v.log.Error(
+	v.log.Info(
 		"Policy query summary",
 		"type", json.MessagePolicyQuerySummary,
 		"@policy", "true",

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -187,7 +187,7 @@ func (v *JSONView) logPolicyResult(addr string, resp policy.EvaluationResponse) 
 }
 
 func (v *JSONView) logPolicyQuerySummary(summary queryPolicySummary) {
-	v.log.Error(
+	v.log.Info(
 		"Policy query summary",
 		"type", json.MessagePolicyQuerySummary,
 		"@policy", "true",

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -186,6 +186,18 @@ func (v *JSONView) logPolicyResult(addr string, resp policy.EvaluationResponse) 
 	}
 }
 
+func (v *JSONView) logPolicyQuerySummary(summary queryPolicySummary) {
+	v.log.Error(
+		"Policy query summary",
+		"type", json.MessagePolicyQuerySummary,
+		"@policy", "true",
+		"list_block_address", summary.ListBlockAddress,
+		"overall_result", summary.OverallResult,
+		"results", summary.Results,
+		"passed_policies", summary.PassedPolicies,
+	)
+}
+
 func (v *JSONView) PolicyResult(addr string, resp policy.EvaluationResponse) {
 	v.logPolicyResult(addr, resp)
 }

--- a/internal/command/views/query.go
+++ b/internal/command/views/query.go
@@ -5,8 +5,10 @@ package views
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -23,14 +25,16 @@ type Query interface {
 func NewQuery(vt arguments.ViewType, view *View) Query {
 	switch vt {
 	case arguments.ViewJSON:
-		return &QueryJSON{
-			view: NewJSONView(view),
-		}
+		jv := NewJSONView(view)
+		op := &QueryOperationJSON{view: jv, queryPolicy: newQueryPolicyView()}
+		return &QueryJSON{view: jv, op: op}
 	case arguments.ViewHuman:
-		return &QueryHuman{
-			view:         view,
+		op := &QueryOperationHuman{
+			view:        view,
 			inAutomation: view.RunningInAutomation(),
+			queryPolicy: newQueryPolicyView(),
 		}
+		return &QueryHuman{view: view, op: op}
 	default:
 		panic(fmt.Sprintf("unknown view type %v", vt))
 	}
@@ -38,20 +42,18 @@ func NewQuery(vt arguments.ViewType, view *View) Query {
 
 type QueryHuman struct {
 	view *View
-
-	inAutomation bool
+	op   *QueryOperationHuman
 }
 
 var _ Query = (*QueryHuman)(nil)
 
 func (v *QueryHuman) Operation() Operation {
-	return NewQueryOperation(arguments.ViewHuman, v.inAutomation, v.view)
+	return v.op
 }
 
 func (v *QueryHuman) Hooks() []terraform.Hook {
-	return []terraform.Hook{
-		NewUiHook(v.view),
-	}
+	hook := NewUiHook(v.view)
+	return []terraform.Hook{&queryUiHook{UiHook: hook, op: v.op}}
 }
 
 func (v *QueryHuman) Diagnostics(diags tfdiags.Diagnostics) {
@@ -63,18 +65,18 @@ func (v *QueryHuman) HelpPrompt() {
 
 type QueryJSON struct {
 	view *JSONView
+	op   *QueryOperationJSON
 }
 
 var _ Query = (*QueryJSON)(nil)
 
 func (v *QueryJSON) Operation() Operation {
-	return &QueryOperationJSON{view: v.view}
+	return v.op
 }
 
 func (v *QueryJSON) Hooks() []terraform.Hook {
-	return []terraform.Hook{
-		newJSONHook(v.view),
-	}
+	hook := newJSONHook(v.view)
+	return []terraform.Hook{&queryJSONHook{jsonHook: hook, op: v.op}}
 }
 
 func (v *QueryJSON) Diagnostics(diags tfdiags.Diagnostics) {
@@ -82,4 +84,33 @@ func (v *QueryJSON) Diagnostics(diags tfdiags.Diagnostics) {
 }
 
 func (v *QueryJSON) HelpPrompt() {
+}
+
+// queryUiHook wraps UiHook and routes PolicyResult through the query operation
+// so that query policy results are buffered in the queryPolicyView instead of
+// being emitted immediately as generic policy_result records.
+type queryUiHook struct {
+	*UiHook
+	op  *QueryOperationHuman
+	mu  sync.Mutex
+}
+
+func (h *queryUiHook) PolicyResult(addr string, resp policy.EvaluationResponse) (terraform.HookAction, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.op.PolicyResult(addr, resp)
+	return terraform.HookActionContinue, nil
+}
+
+// queryJSONHook wraps jsonHook and routes PolicyResult through the query
+// operation so that query policy results are buffered in the queryPolicyView
+// instead of being emitted immediately as generic policy_result records.
+type queryJSONHook struct {
+	*jsonHook
+	op *QueryOperationJSON
+}
+
+func (h *queryJSONHook) PolicyResult(addr string, resp policy.EvaluationResponse) (terraform.HookAction, error) {
+	h.op.PolicyResult(addr, resp)
+	return terraform.HookActionContinue, nil
 }

--- a/internal/command/views/query.go
+++ b/internal/command/views/query.go
@@ -5,7 +5,6 @@ package views
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/policy"
@@ -92,12 +91,9 @@ func (v *QueryJSON) HelpPrompt() {
 type queryUiHook struct {
 	*UiHook
 	op *QueryOperationHuman
-	mu sync.Mutex
 }
 
 func (h *queryUiHook) PolicyResult(addr string, resp policy.EvaluationResponse) (terraform.HookAction, error) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
 	h.op.PolicyResult(addr, resp)
 	return terraform.HookActionContinue, nil
 }

--- a/internal/command/views/query.go
+++ b/internal/command/views/query.go
@@ -30,9 +30,9 @@ func NewQuery(vt arguments.ViewType, view *View) Query {
 		return &QueryJSON{view: jv, op: op}
 	case arguments.ViewHuman:
 		op := &QueryOperationHuman{
-			view:        view,
+			view:         view,
 			inAutomation: view.RunningInAutomation(),
-			queryPolicy: newQueryPolicyView(),
+			queryPolicy:  newQueryPolicyView(),
 		}
 		return &QueryHuman{view: view, op: op}
 	default:
@@ -91,8 +91,8 @@ func (v *QueryJSON) HelpPrompt() {
 // being emitted immediately as generic policy_result records.
 type queryUiHook struct {
 	*UiHook
-	op  *QueryOperationHuman
-	mu  sync.Mutex
+	op *QueryOperationHuman
+	mu sync.Mutex
 }
 
 func (h *queryUiHook) PolicyResult(addr string, resp policy.EvaluationResponse) (terraform.HookAction, error) {

--- a/internal/command/views/query_operation.go
+++ b/internal/command/views/query_operation.go
@@ -16,6 +16,10 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
+// NewQueryOperation creates the human-readable Operation implementation for the
+// query command. The JSON path is wired separately: QueryJSON.Operation() returns
+// a *QueryOperationJSON directly without going through this constructor, so
+// ViewJSON is intentionally not handled here. Passing ViewJSON would panic.
 func NewQueryOperation(vt arguments.ViewType, inAutomation bool, view *View) Operation {
 	switch vt {
 	case arguments.ViewHuman:
@@ -65,20 +69,22 @@ func (v *QueryOperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas)
 	// The hook for individual query blocks do not display any output when the results are empty,
 	// so we will display a grouped warning message here for the empty queries.
 	emptyBlocks := []string{}
-	for _, query := range plan.Changes.Queries {
-		pSchema := schemas.ProviderSchema(query.ProviderAddr.Provider)
-		addr := query.Addr
-		schema := pSchema.ListResourceTypes[addr.Resource.Resource.Type]
+	if plan != nil && plan.Changes != nil {
+		for _, query := range plan.Changes.Queries {
+			pSchema := schemas.ProviderSchema(query.ProviderAddr.Provider)
+			addr := query.Addr
+			schema := pSchema.ListResourceTypes[addr.Resource.Resource.Type]
 
-		results, err := query.Decode(schema)
-		if err != nil {
-			v.view.streams.Eprintln(err)
-			continue
-		}
+			results, err := query.Decode(schema)
+			if err != nil {
+				v.view.streams.Eprintln(err)
+				continue
+			}
 
-		data := results.Results.Value.GetAttr("data")
-		if data.LengthInt() == 0 {
-			emptyBlocks = append(emptyBlocks, addr.String())
+			data := results.Results.Value.GetAttr("data")
+			if data.LengthInt() == 0 {
+				emptyBlocks = append(emptyBlocks, addr.String())
+			}
 		}
 	}
 

--- a/internal/command/views/query_operation.go
+++ b/internal/command/views/query_operation.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/format"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/policy"
@@ -15,19 +14,6 @@ import (
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
-
-// NewQueryOperation creates the human-readable Operation implementation for the
-// query command. The JSON path is wired separately: QueryJSON.Operation() returns
-// a *QueryOperationJSON directly without going through this constructor, so
-// ViewJSON is intentionally not handled here. Passing ViewJSON would panic.
-func NewQueryOperation(vt arguments.ViewType, inAutomation bool, view *View) Operation {
-	switch vt {
-	case arguments.ViewHuman:
-		return &QueryOperationHuman{view: view, inAutomation: inAutomation}
-	default:
-		panic(fmt.Sprintf("unknown view type %v", vt))
-	}
-}
 
 type QueryOperationHuman struct {
 	view        *View
@@ -125,7 +111,8 @@ func (v *QueryOperationHuman) PolicyDiagnostics(diags policy.Diagnostics) {
 
 func (v *QueryOperationHuman) PolicyResult(addr string, resp policy.EvaluationResponse) {
 	if v.queryPolicy == nil {
-		v.queryPolicy = newQueryPolicyView()
+		v.view.PolicyResult(addr, resp)
+		return
 	}
 	if v.queryPolicy.AddResult(addr, resp) {
 		return
@@ -186,7 +173,8 @@ func (v *QueryOperationJSON) PolicyDiagnostics(diags policy.Diagnostics) {
 
 func (v *QueryOperationJSON) PolicyResult(addr string, resp policy.EvaluationResponse) {
 	if v.queryPolicy == nil {
-		v.queryPolicy = newQueryPolicyView()
+		v.view.PolicyResult(addr, resp)
+		return
 	}
 	if v.queryPolicy.AddResult(addr, resp) {
 		return

--- a/internal/command/views/query_operation.go
+++ b/internal/command/views/query_operation.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/format"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/policy"
@@ -15,19 +14,6 @@ import (
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
-
-// NewQueryOperation creates the human-readable Operation implementation for the
-// query command. The JSON path is wired separately: QueryJSON.Operation() returns
-// a *QueryOperationJSON directly without going through this constructor, so
-// ViewJSON is intentionally not handled here. Passing ViewJSON would panic.
-func NewQueryOperation(vt arguments.ViewType, inAutomation bool, view *View) Operation {
-	switch vt {
-	case arguments.ViewHuman:
-		return &QueryOperationHuman{view: view, inAutomation: inAutomation}
-	default:
-		panic(fmt.Sprintf("unknown view type %v", vt))
-	}
-}
 
 type QueryOperationHuman struct {
 	view        *View
@@ -124,9 +110,6 @@ func (v *QueryOperationHuman) PolicyDiagnostics(diags policy.Diagnostics) {
 }
 
 func (v *QueryOperationHuman) PolicyResult(addr string, resp policy.EvaluationResponse) {
-	if v.queryPolicy == nil {
-		v.queryPolicy = newQueryPolicyView()
-	}
 	if v.queryPolicy.AddResult(addr, resp) {
 		return
 	}
@@ -185,9 +168,6 @@ func (v *QueryOperationJSON) PolicyDiagnostics(diags policy.Diagnostics) {
 }
 
 func (v *QueryOperationJSON) PolicyResult(addr string, resp policy.EvaluationResponse) {
-	if v.queryPolicy == nil {
-		v.queryPolicy = newQueryPolicyView()
-	}
 	if v.queryPolicy.AddResult(addr, resp) {
 		return
 	}

--- a/internal/command/views/query_operation.go
+++ b/internal/command/views/query_operation.go
@@ -26,7 +26,8 @@ func NewQueryOperation(vt arguments.ViewType, inAutomation bool, view *View) Ope
 }
 
 type QueryOperationHuman struct {
-	view *View
+	view        *View
+	queryPolicy *queryPolicyView
 
 	// inAutomation indicates that commands are being run by an
 	// automated system rather than directly at a command prompt.
@@ -79,13 +80,24 @@ func (v *QueryOperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas)
 		if data.LengthInt() == 0 {
 			emptyBlocks = append(emptyBlocks, addr.String())
 		}
-
 	}
 
 	if len(emptyBlocks) > 0 {
 		msg := fmt.Sprintf(v.view.colorize.Color("[bold][yellow]Warning:[reset][bold] list block(s) [%s] returned 0 results.\n"), strings.Join(emptyBlocks, ", "))
 		v.view.streams.Println(format.WordWrap(msg, v.view.outputColumns()))
 	}
+
+	if v.queryPolicy == nil || !v.queryPolicy.HasResults() {
+		return
+	}
+
+	v.view.streams.Println(format.WordWrap(fmt.Sprintf("Evaluated %d policies.", queryPolicyEvaluatedCount(v.queryPolicy)), v.view.outputColumns()))
+	v.queryPolicy.Flush(func(summary queryPolicySummary) {
+		v.view.streams.Println()
+		v.view.streams.Println(renderQueryPolicySummaryHuman(summary))
+	}, func(diags tfdiags.Diagnostics) {
+		v.view.Diagnostics(diags)
+	})
 }
 
 func (v *QueryOperationHuman) PlannedChange(change *plans.ResourceInstanceChangeSrc) {
@@ -95,6 +107,9 @@ func (v *QueryOperationHuman) PlanNextStep(planPath string, genConfigPath string
 }
 
 func (v *QueryOperationHuman) Diagnostics(diags tfdiags.Diagnostics) {
+	if v.queryPolicy != nil {
+		v.queryPolicy.AddWarningDiags(diags)
+	}
 	v.view.Diagnostics(diags)
 }
 
@@ -103,11 +118,18 @@ func (v *QueryOperationHuman) PolicyDiagnostics(diags policy.Diagnostics) {
 }
 
 func (v *QueryOperationHuman) PolicyResult(addr string, resp policy.EvaluationResponse) {
+	if v.queryPolicy == nil {
+		v.queryPolicy = newQueryPolicyView()
+	}
+	if v.queryPolicy.AddResult(addr, resp) {
+		return
+	}
 	v.view.PolicyResult(addr, resp)
 }
 
 type QueryOperationJSON struct {
-	view *JSONView
+	view        *JSONView
+	queryPolicy *queryPolicyView
 }
 
 var _ Operation = (*QueryOperationJSON)(nil)
@@ -133,6 +155,10 @@ func (v *QueryOperationJSON) EmergencyDumpState(stateFile *statefile.File) error
 }
 
 func (v *QueryOperationJSON) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
+	if v.queryPolicy == nil || !v.queryPolicy.HasResults() {
+		return
+	}
+	v.queryPolicy.Flush(v.view.logPolicyQuerySummary, nil)
 }
 
 func (v *QueryOperationJSON) PlannedChange(change *plans.ResourceInstanceChangeSrc) {
@@ -142,6 +168,9 @@ func (v *QueryOperationJSON) PlanNextStep(planPath string, genConfigPath string)
 }
 
 func (v *QueryOperationJSON) Diagnostics(diags tfdiags.Diagnostics) {
+	if v.queryPolicy != nil {
+		v.queryPolicy.AddWarningDiags(diags)
+	}
 	v.view.Diagnostics(diags)
 }
 
@@ -150,5 +179,11 @@ func (v *QueryOperationJSON) PolicyDiagnostics(diags policy.Diagnostics) {
 }
 
 func (v *QueryOperationJSON) PolicyResult(addr string, resp policy.EvaluationResponse) {
+	if v.queryPolicy == nil {
+		v.queryPolicy = newQueryPolicyView()
+	}
+	if v.queryPolicy.AddResult(addr, resp) {
+		return
+	}
 	v.view.PolicyResult(addr, resp)
 }

--- a/internal/command/views/query_policy.go
+++ b/internal/command/views/query_policy.go
@@ -5,6 +5,7 @@ package views
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -31,13 +32,15 @@ type queryPolicySummary struct {
 }
 
 type queryPolicyIdentityResult struct {
-	Identity      map[string]string         `json:"identity,omitempty"`
-	TargetAddress string                    `json:"target_address"`
-	Result        queryPolicyResult         `json:"result"`
-	Policies      []queryPolicyPolicyResult `json:"policies"`
+	Identity      map[string]string       `json:"identity,omitempty"`
+	TargetAddress string                  `json:"target_address"`
+	Result        queryPolicyResult       `json:"result"`
+	Policies      []queryPolicyEvalResult `json:"policies"`
 }
 
-type queryPolicyPolicyResult struct {
+// queryPolicyEvalResult holds the per-policy outcome for a single evaluated
+// identity within a list block.
+type queryPolicyEvalResult struct {
 	PolicyMetadata viewjson.PolicyMetadata `json:"policy_metadata"`
 	Diagnostics    []viewjson.Diagnostic   `json:"diagnostics"`
 	Result         queryPolicyResult       `json:"result"`
@@ -61,6 +64,16 @@ func newQueryPolicyView() *queryPolicyView {
 	}
 }
 
+// AddWarningDiags routes warning diagnostics that carry a ListBlockAddrExtra
+// into the matching queryPolicyBlock so they are emitted together with the
+// policy summary at flush time. Diagnostics without that extra are silently
+// ignored by this function; callers are responsible for emitting them via the
+// normal diagnostic path.
+//
+// Only warning diagnostics are processed here. This is intentional: policy
+// query warnings (e.g., "policy was skipped for this identity") belong in the
+// query summary block output. Other severity levels are handled by standard
+// diagnostic paths.
 func (v *queryPolicyView) AddWarningDiags(diags tfdiags.Diagnostics) {
 	if len(diags) == 0 {
 		return
@@ -73,11 +86,11 @@ func (v *queryPolicyView) AddWarningDiags(diags tfdiags.Diagnostics) {
 		if diag.Severity() != tfdiags.Warning {
 			continue
 		}
-		addr := queryPolicyListBlockAddr(diag.Description().Detail)
-		if addr == "" {
+		extra := tfdiags.ExtraInfo[*tfdiags.ListBlockAddrExtra](diag)
+		if extra == nil || extra.ListBlockAddr == "" {
 			continue
 		}
-		block := v.block(addr)
+		block := v.block(extra.ListBlockAddr)
 		block.WarningDiags = append(block.WarningDiags, diag)
 	}
 }
@@ -94,16 +107,18 @@ func (v *queryPolicyView) AddResult(addr string, resp policy.EvaluationResponse)
 	identityResult := block.ResultsByTarget[addr]
 	if identityResult == nil {
 		identityResult = &queryPolicyIdentityResult{
-			Identity:      copyIdentity(resp.Identity),
+			Identity:      maps.Clone(resp.Identity),
 			TargetAddress: addr,
-			Policies:      make([]queryPolicyPolicyResult, 0, len(resp.Policies)),
+			Policies:      make([]queryPolicyEvalResult, 0, len(resp.Policies)),
 		}
 		block.ResultsByTarget[addr] = identityResult
 	} else if identityResult.Identity == nil {
-		identityResult.Identity = copyIdentity(resp.Identity)
+		identityResult.Identity = maps.Clone(resp.Identity)
 	}
 
 	identityResult.Result = queryPolicyResultFromEvaluation(resp.Overall)
+	// Reset the per-policy slice so that a re-evaluation of the same
+	// identity always reflects only the most-recent response.
 	identityResult.Policies = identityResult.Policies[:0]
 
 	diagsByPolicy := make(map[string][]viewjson.Diagnostic, len(resp.Policies))
@@ -122,10 +137,15 @@ func (v *queryPolicyView) AddResult(addr string, resp policy.EvaluationResponse)
 		metadata := viewjson.MetadataFromPolicy(*pol)
 		block.PolicyMetadata[pol.Address] = metadata
 		policyDiags := diagsByPolicy[pol.Address]
+		// When there is exactly one policy and no diags matched its address
+		// (e.g. the diagnostic has no extra PolicyExtra metadata), fall back to
+		// the unmatched set so they are still associated with the sole policy.
+		// This handles policy plugins that may omit PolicyExtra from diagnostics
+		// in simpler scenarios, ensuring diagnostics are not lost or orphaned.
 		if len(policyDiags) == 0 && len(unmatchedDiags) > 0 && len(resp.Policies) == 1 {
 			policyDiags = unmatchedDiags
 		}
-		identityResult.Policies = append(identityResult.Policies, queryPolicyPolicyResult{
+		identityResult.Policies = append(identityResult.Policies, queryPolicyEvalResult{
 			PolicyMetadata: metadata,
 			Diagnostics:    policyDiags,
 			Result:         queryPolicyResultFromEvaluation(pol.Result),
@@ -179,12 +199,12 @@ func (v *queryPolicyView) block(addr string) *queryPolicyBlock {
 func (b *queryPolicyBlock) summary() queryPolicySummary {
 	results := make([]queryPolicyIdentityResult, 0, len(b.ResultsByTarget))
 	for _, result := range b.ResultsByTarget {
-		policies := append([]queryPolicyPolicyResult(nil), result.Policies...)
+		policies := append([]queryPolicyEvalResult(nil), result.Policies...)
 		sort.Slice(policies, func(i, j int) bool {
 			return policies[i].PolicyMetadata.PolicyName < policies[j].PolicyMetadata.PolicyName
 		})
 		results = append(results, queryPolicyIdentityResult{
-			Identity:      copyIdentity(result.Identity),
+			Identity:      maps.Clone(result.Identity),
 			TargetAddress: result.TargetAddress,
 			Result:        result.Result,
 			Policies:      policies,
@@ -242,42 +262,6 @@ func queryPolicyResultFromEvaluation(result policy.EvaluateResult) queryPolicyRe
 	default:
 		return queryPolicyResultUnknown
 	}
-}
-
-// queryPolicyListBlockAddr extracts the list block address from a warning
-// diagnostic detail string. It looks for the literal substring "list block "
-// and returns everything up to the next space or colon.
-//
-// Terraform list block addresses use the form TYPE.NAME (and, for nested
-// modules, module.M.TYPE.NAME), so dots are part of the address and must not
-// be used as a terminator.
-func queryPolicyListBlockAddr(detail string) string {
-	const marker = "list block "
-	idx := strings.Index(detail, marker)
-	if idx == -1 {
-		return ""
-	}
-	rest := detail[idx+len(marker):]
-	if rest == "" {
-		return ""
-	}
-	for i, r := range rest {
-		if r == ' ' || r == ':' {
-			return rest[:i]
-		}
-	}
-	return rest
-}
-
-func copyIdentity(identity map[string]string) map[string]string {
-	if len(identity) == 0 {
-		return nil
-	}
-	ret := make(map[string]string, len(identity))
-	for k, v := range identity {
-		ret[k] = v
-	}
-	return ret
 }
 
 func renderQueryPolicySummaryHuman(summary queryPolicySummary) string {

--- a/internal/command/views/query_policy.go
+++ b/internal/command/views/query_policy.go
@@ -1,0 +1,322 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	viewjson "github.com/hashicorp/terraform/internal/command/views/json"
+	"github.com/hashicorp/terraform/internal/policy"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+type queryPolicyResult string
+
+const (
+	queryPolicyResultPass    queryPolicyResult = "pass"
+	queryPolicyResultFail    queryPolicyResult = "fail"
+	queryPolicyResultUnknown queryPolicyResult = "unknown"
+	queryPolicyResultError   queryPolicyResult = "error"
+)
+
+type queryPolicySummary struct {
+	ListBlockAddress string                     `json:"list_block_address"`
+	OverallResult    queryPolicyResult          `json:"overall_result"`
+	Results          []queryPolicyIdentityResult `json:"results"`
+	PassedPolicies   []viewjson.PolicyMetadata  `json:"passed_policies"`
+}
+
+type queryPolicyIdentityResult struct {
+	Identity      map[string]string          `json:"identity,omitempty"`
+	TargetAddress string                     `json:"target_address"`
+	Result        queryPolicyResult          `json:"result"`
+	Policies      []queryPolicyPolicyResult  `json:"policies"`
+}
+
+type queryPolicyPolicyResult struct {
+	PolicyMetadata viewjson.PolicyMetadata `json:"policy_metadata"`
+	Diagnostics    []viewjson.Diagnostic   `json:"diagnostics"`
+	Result         queryPolicyResult       `json:"result"`
+}
+
+type queryPolicyBlock struct {
+	ListBlockAddress string
+	ResultsByTarget  map[string]*queryPolicyIdentityResult
+	PolicyMetadata   map[string]viewjson.PolicyMetadata
+	WarningDiags     tfdiags.Diagnostics
+}
+
+type queryPolicyView struct {
+	mu     sync.Mutex
+	blocks map[string]*queryPolicyBlock
+}
+
+func newQueryPolicyView() *queryPolicyView {
+	return &queryPolicyView{
+		blocks: make(map[string]*queryPolicyBlock),
+	}
+}
+
+func (v *queryPolicyView) AddWarningDiags(diags tfdiags.Diagnostics) {
+	if len(diags) == 0 {
+		return
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	for _, diag := range diags {
+		if diag.Severity() != tfdiags.Warning {
+			continue
+		}
+		addr := queryPolicyListBlockAddr(diag.Description().Detail)
+		if addr == "" {
+			continue
+		}
+		block := v.block(addr)
+		block.WarningDiags = append(block.WarningDiags, diag)
+	}
+}
+
+func (v *queryPolicyView) AddResult(addr string, resp policy.EvaluationResponse) bool {
+	if resp.ListBlockAddr == "" {
+		return false
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	block := v.block(resp.ListBlockAddr)
+	identityResult := block.ResultsByTarget[addr]
+	if identityResult == nil {
+		identityResult = &queryPolicyIdentityResult{
+			Identity:      copyIdentity(resp.Identity),
+			TargetAddress: addr,
+			Policies:      make([]queryPolicyPolicyResult, 0, len(resp.Policies)),
+		}
+		block.ResultsByTarget[addr] = identityResult
+	} else if identityResult.Identity == nil {
+		identityResult.Identity = copyIdentity(resp.Identity)
+	}
+
+	identityResult.Result = queryPolicyResultFromEvaluation(resp.Overall)
+	identityResult.Policies = identityResult.Policies[:0]
+
+	diagsByPolicy := make(map[string][]viewjson.Diagnostic, len(resp.Policies))
+	unmatchedDiags := make([]viewjson.Diagnostic, 0)
+	for _, diag := range resp.Diagnostics {
+		jsonDiag := *viewjson.NewDiagnostic(diag, nil)
+		extra := tfdiags.ExtraInfo[*policy.PolicyExtra](diag)
+		if extra == nil || extra.Policy.Address == "" {
+			unmatchedDiags = append(unmatchedDiags, jsonDiag)
+			continue
+		}
+		diagsByPolicy[extra.Policy.Address] = append(diagsByPolicy[extra.Policy.Address], jsonDiag)
+	}
+
+	for _, pol := range resp.Policies {
+		metadata := viewjson.MetadataFromPolicy(*pol)
+		block.PolicyMetadata[pol.Address] = metadata
+		policyDiags := diagsByPolicy[pol.Address]
+		if len(policyDiags) == 0 && len(unmatchedDiags) > 0 && len(resp.Policies) == 1 {
+			policyDiags = unmatchedDiags
+		}
+		identityResult.Policies = append(identityResult.Policies, queryPolicyPolicyResult{
+			PolicyMetadata: metadata,
+			Diagnostics:    policyDiags,
+			Result:         queryPolicyResultFromEvaluation(pol.Result),
+		})
+	}
+
+	return true
+}
+
+func (v *queryPolicyView) Flush(flush func(summary queryPolicySummary), warn func(tfdiags.Diagnostics)) {
+	v.mu.Lock()
+	blocks := make([]*queryPolicyBlock, 0, len(v.blocks))
+	for _, block := range v.blocks {
+		blocks = append(blocks, block)
+	}
+	v.blocks = make(map[string]*queryPolicyBlock)
+	v.mu.Unlock()
+
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].ListBlockAddress < blocks[j].ListBlockAddress
+	})
+
+	for _, block := range blocks {
+		if warn != nil && len(block.WarningDiags) > 0 {
+			warn(block.WarningDiags)
+		}
+		flush(block.summary())
+	}
+}
+
+func (v *queryPolicyView) HasResults() bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return len(v.blocks) > 0
+}
+
+func (v *queryPolicyView) block(addr string) *queryPolicyBlock {
+	block := v.blocks[addr]
+	if block != nil {
+		return block
+	}
+	block = &queryPolicyBlock{
+		ListBlockAddress: addr,
+		ResultsByTarget:  make(map[string]*queryPolicyIdentityResult),
+		PolicyMetadata:   make(map[string]viewjson.PolicyMetadata),
+	}
+	v.blocks[addr] = block
+	return block
+}
+
+func (b *queryPolicyBlock) summary() queryPolicySummary {
+	results := make([]queryPolicyIdentityResult, 0, len(b.ResultsByTarget))
+	for _, result := range b.ResultsByTarget {
+		policies := append([]queryPolicyPolicyResult(nil), result.Policies...)
+		sort.Slice(policies, func(i, j int) bool {
+			return policies[i].PolicyMetadata.PolicyName < policies[j].PolicyMetadata.PolicyName
+		})
+		results = append(results, queryPolicyIdentityResult{
+			Identity:      copyIdentity(result.Identity),
+			TargetAddress: result.TargetAddress,
+			Result:        result.Result,
+			Policies:      policies,
+		})
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].TargetAddress < results[j].TargetAddress
+	})
+
+	passedPolicies := make([]viewjson.PolicyMetadata, 0, len(b.PolicyMetadata))
+	for _, metadata := range b.PolicyMetadata {
+		passedPolicies = append(passedPolicies, metadata)
+	}
+	sort.Slice(passedPolicies, func(i, j int) bool {
+		return passedPolicies[i].PolicyName < passedPolicies[j].PolicyName
+	})
+
+	return queryPolicySummary{
+		ListBlockAddress: b.ListBlockAddress,
+		OverallResult:    queryPolicySummaryOverall(results),
+		Results:          results,
+		PassedPolicies:   passedPolicies,
+	}
+}
+
+func queryPolicySummaryOverall(results []queryPolicyIdentityResult) queryPolicyResult {
+	overall := queryPolicyResultPass
+	for _, result := range results {
+		switch result.Result {
+		case queryPolicyResultError:
+			return queryPolicyResultError
+		case queryPolicyResultFail:
+			overall = queryPolicyResultFail
+		case queryPolicyResultUnknown:
+			if overall == queryPolicyResultPass {
+				overall = queryPolicyResultUnknown
+			}
+		}
+	}
+	return overall
+}
+
+func queryPolicyResultFromEvaluation(result policy.EvaluateResult) queryPolicyResult {
+	switch result {
+	case policy.AllowResult:
+		return queryPolicyResultPass
+	case policy.DenyResult:
+		return queryPolicyResultFail
+	case policy.PolicyErrorResult, policy.SetupErrorResult:
+		return queryPolicyResultError
+	default:
+		return queryPolicyResultUnknown
+	}
+}
+
+func queryPolicyListBlockAddr(detail string) string {
+	const marker = "list block "
+	idx := strings.Index(detail, marker)
+	if idx == -1 {
+		return ""
+	}
+	rest := detail[idx+len(marker):]
+	if rest == "" {
+		return ""
+	}
+	for i, r := range rest {
+		if r == ' ' || r == ':' || r == '.' {
+			return rest[:i]
+		}
+	}
+	return rest
+}
+
+func copyIdentity(identity map[string]string) map[string]string {
+	if len(identity) == 0 {
+		return nil
+	}
+	ret := make(map[string]string, len(identity))
+	for k, v := range identity {
+		ret[k] = v
+	}
+	return ret
+}
+
+func renderQueryPolicySummaryHuman(summary queryPolicySummary) string {
+	var buf strings.Builder
+
+	fmt.Fprintf(&buf, "Policy results for %s (%s)\n", summary.ListBlockAddress, strings.ToUpper(string(summary.OverallResult)))
+	for _, result := range summary.Results {
+		fmt.Fprintf(&buf, "  %s: %s\n", formatQueryPolicyIdentity(result.Identity), strings.ToUpper(string(result.Result)))
+		for _, pol := range result.Policies {
+			if pol.Result != queryPolicyResultFail {
+				continue
+			}
+			for _, diag := range pol.Diagnostics {
+				fmt.Fprintf(&buf, "    - %s: %s (%s)\n", pol.PolicyMetadata.PolicyName, diag.Summary, pol.PolicyMetadata.EnforcementLevel)
+			}
+		}
+	}
+
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+func formatQueryPolicyIdentity(identity map[string]string) string {
+	if len(identity) == 0 {
+		return "<unknown identity>"
+	}
+	keys := make([]string, 0, len(identity))
+	for key := range identity {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, identity[key]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func queryPolicyEvaluatedCount(view *queryPolicyView) int {
+	if view == nil {
+		return 0
+	}
+	view.mu.Lock()
+	defer view.mu.Unlock()
+
+	policies := make(map[string]struct{})
+	for _, block := range view.blocks {
+		for key := range block.PolicyMetadata {
+			policies[key] = struct{}{}
+		}
+	}
+	return len(policies)
+}
+

--- a/internal/command/views/query_policy.go
+++ b/internal/command/views/query_policy.go
@@ -24,17 +24,17 @@ const (
 )
 
 type queryPolicySummary struct {
-	ListBlockAddress string                     `json:"list_block_address"`
-	OverallResult    queryPolicyResult          `json:"overall_result"`
+	ListBlockAddress string                      `json:"list_block_address"`
+	OverallResult    queryPolicyResult           `json:"overall_result"`
 	Results          []queryPolicyIdentityResult `json:"results"`
-	PassedPolicies   []viewjson.PolicyMetadata  `json:"passed_policies"`
+	PassedPolicies   []viewjson.PolicyMetadata   `json:"passed_policies"`
 }
 
 type queryPolicyIdentityResult struct {
-	Identity      map[string]string          `json:"identity,omitempty"`
-	TargetAddress string                     `json:"target_address"`
-	Result        queryPolicyResult          `json:"result"`
-	Policies      []queryPolicyPolicyResult  `json:"policies"`
+	Identity      map[string]string         `json:"identity,omitempty"`
+	TargetAddress string                    `json:"target_address"`
+	Result        queryPolicyResult         `json:"result"`
+	Policies      []queryPolicyPolicyResult `json:"policies"`
 }
 
 type queryPolicyPolicyResult struct {
@@ -330,4 +330,3 @@ func queryPolicyEvaluatedCount(view *queryPolicyView) int {
 	}
 	return len(policies)
 }
-

--- a/internal/command/views/query_policy.go
+++ b/internal/command/views/query_policy.go
@@ -194,6 +194,10 @@ func (b *queryPolicyBlock) summary() queryPolicySummary {
 		return results[i].TargetAddress < results[j].TargetAddress
 	})
 
+	// passed_policies contains all policies evaluated against any identity in
+	// this block, regardless of whether they passed or failed. The field name
+	// is intentionally kept as "passed_policies" to match the RFC wire contract
+	// (the UI uses it for column-header counts, not to filter by pass status).
 	passedPolicies := make([]viewjson.PolicyMetadata, 0, len(b.PolicyMetadata))
 	for _, metadata := range b.PolicyMetadata {
 		passedPolicies = append(passedPolicies, metadata)
@@ -240,6 +244,13 @@ func queryPolicyResultFromEvaluation(result policy.EvaluateResult) queryPolicyRe
 	}
 }
 
+// queryPolicyListBlockAddr extracts the list block address from a warning
+// diagnostic detail string. It looks for the literal substring "list block "
+// and returns everything up to the next space or colon.
+//
+// Terraform list block addresses use the form TYPE.NAME (and, for nested
+// modules, module.M.TYPE.NAME), so dots are part of the address and must not
+// be used as a terminator.
 func queryPolicyListBlockAddr(detail string) string {
 	const marker = "list block "
 	idx := strings.Index(detail, marker)
@@ -251,7 +262,7 @@ func queryPolicyListBlockAddr(detail string) string {
 		return ""
 	}
 	for i, r := range rest {
-		if r == ' ' || r == ':' || r == '.' {
+		if r == ' ' || r == ':' {
 			return rest[:i]
 		}
 	}

--- a/internal/command/views/query_policy.go
+++ b/internal/command/views/query_policy.go
@@ -5,6 +5,7 @@ package views
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -31,13 +32,15 @@ type queryPolicySummary struct {
 }
 
 type queryPolicyIdentityResult struct {
-	Identity      map[string]string         `json:"identity,omitempty"`
-	TargetAddress string                    `json:"target_address"`
-	Result        queryPolicyResult         `json:"result"`
-	Policies      []queryPolicyPolicyResult `json:"policies"`
+	Identity      map[string]string        `json:"identity,omitempty"`
+	TargetAddress string                   `json:"target_address"`
+	Result        queryPolicyResult        `json:"result"`
+	Policies      []queryPolicyEvalResult  `json:"policies"`
 }
 
-type queryPolicyPolicyResult struct {
+// queryPolicyEvalResult holds the per-policy outcome for a single evaluated
+// identity within a list block.
+type queryPolicyEvalResult struct {
 	PolicyMetadata viewjson.PolicyMetadata `json:"policy_metadata"`
 	Diagnostics    []viewjson.Diagnostic   `json:"diagnostics"`
 	Result         queryPolicyResult       `json:"result"`
@@ -61,6 +64,11 @@ func newQueryPolicyView() *queryPolicyView {
 	}
 }
 
+// AddWarningDiags routes warning diagnostics that carry a ListBlockAddrExtra
+// into the matching queryPolicyBlock so they are emitted together with the
+// policy summary at flush time. Diagnostics without that extra are silently
+// ignored by this function; callers are responsible for emitting them via the
+// normal diagnostic path.
 func (v *queryPolicyView) AddWarningDiags(diags tfdiags.Diagnostics) {
 	if len(diags) == 0 {
 		return
@@ -73,11 +81,11 @@ func (v *queryPolicyView) AddWarningDiags(diags tfdiags.Diagnostics) {
 		if diag.Severity() != tfdiags.Warning {
 			continue
 		}
-		addr := queryPolicyListBlockAddr(diag.Description().Detail)
-		if addr == "" {
+		extra := tfdiags.ExtraInfo[*tfdiags.ListBlockAddrExtra](diag)
+		if extra == nil || extra.ListBlockAddr == "" {
 			continue
 		}
-		block := v.block(addr)
+		block := v.block(extra.ListBlockAddr)
 		block.WarningDiags = append(block.WarningDiags, diag)
 	}
 }
@@ -94,16 +102,18 @@ func (v *queryPolicyView) AddResult(addr string, resp policy.EvaluationResponse)
 	identityResult := block.ResultsByTarget[addr]
 	if identityResult == nil {
 		identityResult = &queryPolicyIdentityResult{
-			Identity:      copyIdentity(resp.Identity),
+			Identity:      maps.Clone(resp.Identity),
 			TargetAddress: addr,
-			Policies:      make([]queryPolicyPolicyResult, 0, len(resp.Policies)),
+			Policies:      make([]queryPolicyEvalResult, 0, len(resp.Policies)),
 		}
 		block.ResultsByTarget[addr] = identityResult
 	} else if identityResult.Identity == nil {
-		identityResult.Identity = copyIdentity(resp.Identity)
+		identityResult.Identity = maps.Clone(resp.Identity)
 	}
 
 	identityResult.Result = queryPolicyResultFromEvaluation(resp.Overall)
+	// Reset the per-policy slice so that a re-evaluation of the same
+	// identity always reflects only the most-recent response.
 	identityResult.Policies = identityResult.Policies[:0]
 
 	diagsByPolicy := make(map[string][]viewjson.Diagnostic, len(resp.Policies))
@@ -122,10 +132,13 @@ func (v *queryPolicyView) AddResult(addr string, resp policy.EvaluationResponse)
 		metadata := viewjson.MetadataFromPolicy(*pol)
 		block.PolicyMetadata[pol.Address] = metadata
 		policyDiags := diagsByPolicy[pol.Address]
+		// When there is exactly one policy and no diags matched its address
+		// (e.g. the diagnostic has no extra), fall back to the unmatched set
+		// so they are still associated with the sole policy.
 		if len(policyDiags) == 0 && len(unmatchedDiags) > 0 && len(resp.Policies) == 1 {
 			policyDiags = unmatchedDiags
 		}
-		identityResult.Policies = append(identityResult.Policies, queryPolicyPolicyResult{
+		identityResult.Policies = append(identityResult.Policies, queryPolicyEvalResult{
 			PolicyMetadata: metadata,
 			Diagnostics:    policyDiags,
 			Result:         queryPolicyResultFromEvaluation(pol.Result),
@@ -179,12 +192,12 @@ func (v *queryPolicyView) block(addr string) *queryPolicyBlock {
 func (b *queryPolicyBlock) summary() queryPolicySummary {
 	results := make([]queryPolicyIdentityResult, 0, len(b.ResultsByTarget))
 	for _, result := range b.ResultsByTarget {
-		policies := append([]queryPolicyPolicyResult(nil), result.Policies...)
+		policies := append([]queryPolicyEvalResult(nil), result.Policies...)
 		sort.Slice(policies, func(i, j int) bool {
 			return policies[i].PolicyMetadata.PolicyName < policies[j].PolicyMetadata.PolicyName
 		})
 		results = append(results, queryPolicyIdentityResult{
-			Identity:      copyIdentity(result.Identity),
+			Identity:      maps.Clone(result.Identity),
 			TargetAddress: result.TargetAddress,
 			Result:        result.Result,
 			Policies:      policies,
@@ -242,42 +255,6 @@ func queryPolicyResultFromEvaluation(result policy.EvaluateResult) queryPolicyRe
 	default:
 		return queryPolicyResultUnknown
 	}
-}
-
-// queryPolicyListBlockAddr extracts the list block address from a warning
-// diagnostic detail string. It looks for the literal substring "list block "
-// and returns everything up to the next space or colon.
-//
-// Terraform list block addresses use the form TYPE.NAME (and, for nested
-// modules, module.M.TYPE.NAME), so dots are part of the address and must not
-// be used as a terminator.
-func queryPolicyListBlockAddr(detail string) string {
-	const marker = "list block "
-	idx := strings.Index(detail, marker)
-	if idx == -1 {
-		return ""
-	}
-	rest := detail[idx+len(marker):]
-	if rest == "" {
-		return ""
-	}
-	for i, r := range rest {
-		if r == ' ' || r == ':' {
-			return rest[:i]
-		}
-	}
-	return rest
-}
-
-func copyIdentity(identity map[string]string) map[string]string {
-	if len(identity) == 0 {
-		return nil
-	}
-	ret := make(map[string]string, len(identity))
-	for k, v := range identity {
-		ret[k] = v
-	}
-	return ret
 }
 
 func renderQueryPolicySummaryHuman(summary queryPolicySummary) string {

--- a/internal/command/views/query_policy_test.go
+++ b/internal/command/views/query_policy_test.go
@@ -1,0 +1,224 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/command/jsonformat"
+	viewjson "github.com/hashicorp/terraform/internal/command/views/json"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/policy"
+	"github.com/hashicorp/terraform/internal/terraform"
+	"github.com/hashicorp/terraform/internal/terminal"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestQueryOperationJSON_policySummary(t *testing.T) {
+	listBlockAddr := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "aws_instance", Name: "example"}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance).String()
+
+	tests := []struct {
+		name         string
+		responses    []policy.EvaluationResponse
+		targets      []string
+		wantOverall  string
+		wantResults  int
+		wantPolicies int
+	}{
+		{
+			name: "all pass",
+			responses: []policy.EvaluationResponse{
+				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
+				queryEvalResp(listBlockAddr, "aws_instance.example_1", map[string]string{"id": "i-2"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
+			},
+			targets:      []string{"aws_instance.example_0", "aws_instance.example_1"},
+			wantOverall:  "pass",
+			wantResults:  2,
+			wantPolicies: 1,
+		},
+		{
+			name: "all fail",
+			responses: []policy.EvaluationResponse{
+				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied", "detail", policy.DenyResult)}}}),
+			},
+			targets:      []string{"aws_instance.example_0"},
+			wantOverall:  "fail",
+			wantResults:  1,
+			wantPolicies: 1,
+		},
+		{
+			name: "mixed",
+			responses: []policy.EvaluationResponse{
+				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
+				queryEvalResp(listBlockAddr, "aws_instance.example_1", map[string]string{"id": "i-2"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied", "detail", policy.DenyResult)}}}),
+			},
+			targets:      []string{"aws_instance.example_0", "aws_instance.example_1"},
+			wantOverall:  "fail",
+			wantResults:  2,
+			wantPolicies: 2,
+		},
+		{
+			name: "unknown",
+			responses: []policy.EvaluationResponse{
+				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.EvaluateResult(999), []policyResultSpec{{address: "policy.unknown", result: policy.EvaluateResult(999)}}),
+			},
+			targets:      []string{"aws_instance.example_0"},
+			wantOverall:  "unknown",
+			wantResults:  1,
+			wantPolicies: 1,
+		},
+		{
+			name: "error",
+			responses: []policy.EvaluationResponse{
+				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.PolicyErrorResult, []policyResultSpec{{address: "policy.error", result: policy.PolicyErrorResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("errored", "detail", policy.PolicyErrorResult)}}}),
+			},
+			targets:      []string{"aws_instance.example_0"},
+			wantOverall:  "error",
+			wantResults:  1,
+			wantPolicies: 1,
+		},
+		{
+			name: "multiple list blocks",
+			responses: []policy.EvaluationResponse{
+				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
+				queryEvalResp("aws_instance.other", "aws_instance.other_0", map[string]string{"id": "i-2"}, policy.AllowResult, []policyResultSpec{{address: "policy.other", result: policy.AllowResult}}),
+			},
+			targets:      []string{"aws_instance.example_0", "aws_instance.other_0"},
+			wantOverall:  "pass",
+			wantResults:  1,
+			wantPolicies: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			v := &QueryOperationJSON{view: NewJSONView(NewView(streams)), queryPolicy: newQueryPolicyView()}
+			for i, resp := range tc.responses {
+				v.PolicyResult(tc.targets[i], resp)
+			}
+			v.Plan(nil, nil)
+
+			var lines []map[string]any
+			for _, line := range strings.Split(strings.TrimSpace(done(t).Stdout()), "\n") {
+				var decoded map[string]any
+				if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+					t.Fatalf("failed to decode json line %q: %s", line, err)
+				}
+				if decoded["type"] == string(viewjson.MessagePolicyQuerySummary) {
+					lines = append(lines, decoded)
+				}
+			}
+
+			if len(lines) == 0 {
+				t.Fatal("expected policy query summary output")
+			}
+
+			got := lines[0]
+			if got["@level"] != "error" {
+				t.Fatalf("@level = %v, want error", got["@level"])
+			}
+			if got["@policy"] != "true" {
+				t.Fatalf("@policy = %v, want true", got["@policy"])
+			}
+			if got["overall_result"] != tc.wantOverall {
+				t.Fatalf("overall_result = %v, want %s", got["overall_result"], tc.wantOverall)
+			}
+			results := got["results"].([]any)
+			if len(results) != tc.wantResults {
+				t.Fatalf("results length = %d, want %d", len(results), tc.wantResults)
+			}
+			passedPolicies := got["passed_policies"].([]any)
+			if len(passedPolicies) != tc.wantPolicies {
+				t.Fatalf("passed_policies length = %d, want %d", len(passedPolicies), tc.wantPolicies)
+			}
+			for _, rawResult := range results {
+				result := rawResult.(map[string]any)
+				if result["target_address"] == "" {
+					t.Fatal("expected target_address")
+				}
+				if result["result"] == "" {
+					t.Fatal("expected result")
+				}
+				for _, rawPolicy := range result["policies"].([]any) {
+					pol := rawPolicy.(map[string]any)
+					if pol["result"] == "" {
+						t.Fatal("expected per-policy result")
+					}
+					if _, ok := pol["policy_metadata"].(map[string]any); !ok {
+						t.Fatal("expected policy_metadata object")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestQueryOperationHuman_policySummary(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	v := &QueryOperationHuman{view: NewView(streams), queryPolicy: newQueryPolicyView()}
+
+	listBlockAddr := "aws_instance.example"
+	v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"account": "123", "id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}))
+	v.PolicyResult("aws_instance.example_1", queryEvalResp(listBlockAddr, "aws_instance.example_1", map[string]string{"account": "123", "id": "i-2"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied summary", "detail", policy.DenyResult)}}}))
+	v.Diagnostics(tfdiagsWarningForQueryTest("aws_instance.example"))
+	v.Plan(&plans.Plan{Changes: &plans.ChangesSrc{}}, &terraform.Schemas{})
+
+	output := done(t).All()
+	for _, want := range []string{
+		"Evaluated 2 policies.",
+		"Policy results for aws_instance.example (FAIL)",
+		"account=123, id=i-1: PASS",
+		"account=123, id=i-2: FAIL",
+		"policy.deny: denied summary (mandatory)",
+		"Policy evaluation skipped",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected output to contain %q, got %s", want, output)
+		}
+	}
+}
+
+func TestRenderer_ignoresPolicyQuerySummary(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	renderer := jsonformat.Renderer{Streams: streams, Colorize: NewView(streams).colorize}
+
+	err := renderer.RenderLog(&jsonformat.JSONLog{Type: jsonformat.JSONLogType(viewjson.MessagePolicyQuerySummary), Message: "ignored"})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got := done(t).All(); got != "" {
+		t.Fatalf("expected no output, got %q", got)
+	}
+}
+
+type policyResultSpec struct {
+	address     string
+	result      policy.EvaluateResult
+	diagnostics []policy.Diagnostic
+}
+
+func queryEvalResp(listBlockAddr, _ string, identity map[string]string, overall policy.EvaluateResult, specs []policyResultSpec) policy.EvaluationResponse {
+	resp := policy.EvaluationResponse{
+		Overall:       overall,
+		Identity:      identity,
+		ListBlockAddr: listBlockAddr,
+		Policies:      make([]*policy.Policy, 0, len(specs)),
+	}
+	for _, spec := range specs {
+		pol := &policy.Policy{Address: spec.address, Filename: "policy.tfpolicy.hcl", EnforcementLevel: "mandatory", Result: spec.result}
+		resp.Policies = append(resp.Policies, pol)
+		for _, diag := range spec.diagnostics {
+			resp.Diagnostics = append(resp.Diagnostics, diag)
+		}
+	}
+	return resp
+}
+
+func tfdiagsWarningForQueryTest(addr string) tfdiags.Diagnostics {
+	return tfdiags.Diagnostics{tfdiags.Sourceless(tfdiags.Warning, "Policy evaluation skipped", "1 resource(s) in list block "+addr+" have no state (include_resource = false). Policy evaluation cannot be performed without resource state.")}
+}

--- a/internal/command/views/query_policy_test.go
+++ b/internal/command/views/query_policy_test.go
@@ -21,6 +21,14 @@ import (
 func TestQueryOperationJSON_policySummary(t *testing.T) {
 	listBlockAddr := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "aws_instance", Name: "example"}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance).String()
 
+	// wantBlock carries per-record assertions for multi-block test cases.
+	type wantBlock struct {
+		addr         string
+		wantOverall  string
+		wantResults  int
+		wantPolicies int
+	}
+
 	tests := []struct {
 		name         string
 		responses    []policy.EvaluationResponse
@@ -28,12 +36,13 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 		wantOverall  string
 		wantResults  int
 		wantPolicies int
+		wantPerBlock []wantBlock
 	}{
 		{
 			name: "all pass",
 			responses: []policy.EvaluationResponse{
-				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
-				queryEvalResp(listBlockAddr, "aws_instance.example_1", map[string]string{"id": "i-2"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-2"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
 			},
 			targets:      []string{"aws_instance.example_0", "aws_instance.example_1"},
 			wantOverall:  "pass",
@@ -43,7 +52,7 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 		{
 			name: "all fail",
 			responses: []policy.EvaluationResponse{
-				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied", "detail", policy.DenyResult)}}}),
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied", "detail", policy.DenyResult)}}}),
 			},
 			targets:      []string{"aws_instance.example_0"},
 			wantOverall:  "fail",
@@ -53,8 +62,8 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 		{
 			name: "mixed",
 			responses: []policy.EvaluationResponse{
-				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
-				queryEvalResp(listBlockAddr, "aws_instance.example_1", map[string]string{"id": "i-2"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied", "detail", policy.DenyResult)}}}),
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-2"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied", "detail", policy.DenyResult)}}}),
 			},
 			targets:      []string{"aws_instance.example_0", "aws_instance.example_1"},
 			wantOverall:  "fail",
@@ -64,7 +73,7 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 		{
 			name: "unknown",
 			responses: []policy.EvaluationResponse{
-				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.EvaluateResult(999), []policyResultSpec{{address: "policy.unknown", result: policy.EvaluateResult(999)}}),
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.EvaluateResult(999), []policyResultSpec{{address: "policy.unknown", result: policy.EvaluateResult(999)}}),
 			},
 			targets:      []string{"aws_instance.example_0"},
 			wantOverall:  "unknown",
@@ -74,7 +83,7 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 		{
 			name: "error",
 			responses: []policy.EvaluationResponse{
-				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.PolicyErrorResult, []policyResultSpec{{address: "policy.error", result: policy.PolicyErrorResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("errored", "detail", policy.PolicyErrorResult)}}}),
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.PolicyErrorResult, []policyResultSpec{{address: "policy.error", result: policy.PolicyErrorResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("errored", "detail", policy.PolicyErrorResult)}}}),
 			},
 			targets:      []string{"aws_instance.example_0"},
 			wantOverall:  "error",
@@ -82,15 +91,26 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 			wantPolicies: 1,
 		},
 		{
-			name: "multiple list blocks",
-			responses: []policy.EvaluationResponse{
-				queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
-				queryEvalResp("aws_instance.other", "aws_instance.other_0", map[string]string{"id": "i-2"}, policy.AllowResult, []policyResultSpec{{address: "policy.other", result: policy.AllowResult}}),
+			name:         "multiple list blocks",
+			wantPerBlock: []wantBlock{
+				{
+					addr:         listBlockAddr,
+					wantOverall:  "pass",
+					wantResults:  1,
+					wantPolicies: 1,
+				},
+				{
+					addr:         "aws_instance.other",
+					wantOverall:  "pass",
+					wantResults:  1,
+					wantPolicies: 1,
+				},
 			},
-			targets:      []string{"aws_instance.example_0", "aws_instance.other_0"},
-			wantOverall:  "pass",
-			wantResults:  1,
-			wantPolicies: 1,
+			responses: []policy.EvaluationResponse{
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}),
+				queryEvalResp("aws_instance.other", map[string]string{"id": "i-2"}, policy.AllowResult, []policyResultSpec{{address: "policy.other", result: policy.AllowResult}}),
+			},
+			targets: []string{"aws_instance.example_0", "aws_instance.other_0"},
 		},
 	}
 
@@ -118,39 +138,60 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 				t.Fatal("expected policy query summary output")
 			}
 
-			got := lines[0]
-			if got["@level"] != "error" {
-				t.Fatalf("@level = %v, want error", got["@level"])
+			// For single-block test cases use the inline fields; for multi-block
+			// cases use the per-block want slice.
+			wants := tc.wantPerBlock
+			if len(wants) == 0 {
+				wants = []wantBlock{{
+					addr:         "",
+					wantOverall:  tc.wantOverall,
+					wantResults:  tc.wantResults,
+					wantPolicies: tc.wantPolicies,
+				}}
 			}
-			if got["@policy"] != "true" {
-				t.Fatalf("@policy = %v, want true", got["@policy"])
+
+			if len(lines) != len(wants) {
+				t.Fatalf("got %d policy_query_summary records, want %d", len(lines), len(wants))
 			}
-			if got["overall_result"] != tc.wantOverall {
-				t.Fatalf("overall_result = %v, want %s", got["overall_result"], tc.wantOverall)
-			}
-			results := got["results"].([]any)
-			if len(results) != tc.wantResults {
-				t.Fatalf("results length = %d, want %d", len(results), tc.wantResults)
-			}
-			passedPolicies := got["passed_policies"].([]any)
-			if len(passedPolicies) != tc.wantPolicies {
-				t.Fatalf("passed_policies length = %d, want %d", len(passedPolicies), tc.wantPolicies)
-			}
-			for _, rawResult := range results {
-				result := rawResult.(map[string]any)
-				if result["target_address"] == "" {
-					t.Fatal("expected target_address")
+
+			for i, want := range wants {
+				got := lines[i]
+				if got["@level"] != "error" {
+					t.Fatalf("record[%d] @level = %v, want error", i, got["@level"])
 				}
-				if result["result"] == "" {
-					t.Fatal("expected result")
+				if got["@policy"] != "true" {
+					t.Fatalf("record[%d] @policy = %v, want true", i, got["@policy"])
 				}
-				for _, rawPolicy := range result["policies"].([]any) {
-					pol := rawPolicy.(map[string]any)
-					if pol["result"] == "" {
-						t.Fatal("expected per-policy result")
+				if want.addr != "" && got["list_block_address"] != want.addr {
+					t.Fatalf("record[%d] list_block_address = %v, want %s", i, got["list_block_address"], want.addr)
+				}
+				if got["overall_result"] != want.wantOverall {
+					t.Fatalf("record[%d] overall_result = %v, want %s", i, got["overall_result"], want.wantOverall)
+				}
+				results := got["results"].([]any)
+				if len(results) != want.wantResults {
+					t.Fatalf("record[%d] results length = %d, want %d", i, len(results), want.wantResults)
+				}
+				passedPolicies := got["passed_policies"].([]any)
+				if len(passedPolicies) != want.wantPolicies {
+					t.Fatalf("record[%d] passed_policies length = %d, want %d", i, len(passedPolicies), want.wantPolicies)
+				}
+				for _, rawResult := range results {
+					result := rawResult.(map[string]any)
+					if result["target_address"] == "" {
+						t.Fatalf("record[%d] expected target_address", i)
 					}
-					if _, ok := pol["policy_metadata"].(map[string]any); !ok {
-						t.Fatal("expected policy_metadata object")
+					if result["result"] == "" {
+						t.Fatalf("record[%d] expected result", i)
+					}
+					for _, rawPolicy := range result["policies"].([]any) {
+						pol := rawPolicy.(map[string]any)
+						if pol["result"] == "" {
+							t.Fatalf("record[%d] expected per-policy result", i)
+						}
+						if _, ok := pol["policy_metadata"].(map[string]any); !ok {
+							t.Fatalf("record[%d] expected policy_metadata object", i)
+						}
 					}
 				}
 			}
@@ -159,29 +200,171 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 }
 
 func TestQueryOperationHuman_policySummary(t *testing.T) {
-	streams, done := terminal.StreamsForTesting(t)
-	v := &QueryOperationHuman{view: NewView(streams), queryPolicy: newQueryPolicyView()}
-
 	listBlockAddr := "aws_instance.example"
-	v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, "aws_instance.example_0", map[string]string{"account": "123", "id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}))
-	v.PolicyResult("aws_instance.example_1", queryEvalResp(listBlockAddr, "aws_instance.example_1", map[string]string{"account": "123", "id": "i-2"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied summary", "detail", policy.DenyResult)}}}))
-	v.Diagnostics(tfdiagsWarningForQueryTest("aws_instance.example"))
-	v.Plan(&plans.Plan{Changes: &plans.ChangesSrc{}}, &terraform.Schemas{})
 
-	output := done(t).All()
-	for _, want := range []string{
-		"Evaluated 2 policies.",
-		"Policy results for aws_instance.example (FAIL)",
-		"account=123, id=i-1: PASS",
-		"account=123, id=i-2: FAIL",
-		"policy.deny: denied summary (mandatory)",
-		"Policy evaluation skipped",
-	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("expected output to contain %q, got %s", want, output)
+	tests := []struct {
+		name    string
+		plan    *plans.Plan
+		schemas *terraform.Schemas
+		setup   func(v *QueryOperationHuman)
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "mixed_pass_and_fail",
+			setup: func(v *QueryOperationHuman) {
+				v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, map[string]string{"account": "123", "id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}))
+				v.PolicyResult("aws_instance.example_1", queryEvalResp(listBlockAddr, map[string]string{"account": "123", "id": "i-2"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied summary", "detail", policy.DenyResult)}}}))
+				v.Diagnostics(tfdiagsWarningForQueryTest("aws_instance.example"))
+			},
+			want: []string{
+				"Evaluated 2 policies.",
+				"Policy results for aws_instance.example (FAIL)",
+				"account=123, id=i-1: PASS",
+				"account=123, id=i-2: FAIL",
+				"policy.deny: denied summary (mandatory)",
+				"Policy evaluation skipped",
+			},
+		},
+		{
+			name: "all_pass",
+			setup: func(v *QueryOperationHuman) {
+				v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}))
+				v.PolicyResult("aws_instance.example_1", queryEvalResp(listBlockAddr, map[string]string{"id": "i-2"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}))
+			},
+			want: []string{
+				"Evaluated 1 policies.",
+				"Policy results for aws_instance.example (PASS)",
+				"id=i-1: PASS",
+				"id=i-2: PASS",
+			},
+		},
+		{
+			name: "all_fail",
+			setup: func(v *QueryOperationHuman) {
+				v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied", "detail", policy.DenyResult)}}}))
+				v.PolicyResult("aws_instance.example_1", queryEvalResp(listBlockAddr, map[string]string{"id": "i-2"}, policy.DenyResult, []policyResultSpec{{address: "policy.deny", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied", "detail", policy.DenyResult)}}}))
+			},
+			want: []string{
+				"Evaluated 1 policies.",
+				"Policy results for aws_instance.example (FAIL)",
+				"id=i-1: FAIL",
+				"id=i-2: FAIL",
+				"policy.deny: denied (mandatory)",
+			},
+		},
+		{
+			name: "unknown_result",
+			setup: func(v *QueryOperationHuman) {
+				v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.EvaluateResult(999), []policyResultSpec{{address: "policy.unknown", result: policy.EvaluateResult(999)}}))
+			},
+			want: []string{
+				"Evaluated 1 policies.",
+				"Policy results for aws_instance.example (UNKNOWN)",
+				"id=i-1: UNKNOWN",
+			},
+		},
+		{
+			name:    "no_policies",
+			plan:    &plans.Plan{Changes: &plans.ChangesSrc{}},
+			schemas: &terraform.Schemas{},
+			setup: func(v *QueryOperationHuman) {
+				// No PolicyResult calls; Plan should not print a policy summary section.
+			},
+			notWant: []string{
+				"Evaluated",
+				"Policy results for",
+			},
+		},
+		{
+			name:    "nil_plan",
+			plan:    nil,
+			schemas: nil,
+			setup: func(v *QueryOperationHuman) {
+				// No PolicyResult calls; Plan(nil, nil) must not panic.
+			},
+			notWant: []string{
+				"Evaluated",
+				"Policy results for",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			v := &QueryOperationHuman{view: NewView(streams), queryPolicy: newQueryPolicyView()}
+			tc.setup(v)
+			v.Plan(tc.plan, tc.schemas)
+
+			output := done(t).All()
+			for _, want := range tc.want {
+				if !strings.Contains(output, want) {
+					t.Errorf("expected output to contain %q\nfull output:\n%s", want, output)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(output, notWant) {
+					t.Errorf("expected output NOT to contain %q\nfull output:\n%s", notWant, output)
+				}
+			}
+		})
+	}
+}
+
+
+func TestQueryPolicyListBlockAddr(t *testing.T) {
+	tests := []struct {
+		detail string
+		want   string
+	}{
+		{
+			detail: "1 resource(s) in list block aws_instance.example have no state",
+			want:   "aws_instance.example",
+		},
+		{
+			detail: "1 resource(s) in list block module.vpc.aws_instance.mylist have no state",
+			want:   "module.vpc.aws_instance.mylist",
+		},
+		{
+			detail: "1 resource(s) in list block aws_instance.example: extra text",
+			want:   "aws_instance.example",
+		},
+		{
+			detail: "no marker here",
+			want:   "",
+		},
+		{
+			detail: "list block ",
+			want:   "",
+		},
+	}
+	for _, tc := range tests {
+		got := queryPolicyListBlockAddr(tc.detail)
+		if got != tc.want {
+			t.Errorf("queryPolicyListBlockAddr(%q) = %q, want %q", tc.detail, got, tc.want)
 		}
 	}
 }
+
+func TestAddWarningDiagsRoutesCorrectly(t *testing.T) {
+	// Verify that a warning diagnostic for "aws_instance.example" is routed to
+	// the block keyed "aws_instance.example", not a truncated "aws_instance".
+	v := newQueryPolicyView()
+	v.AddResult("aws_instance.example_0", queryEvalResp("aws_instance.example", map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}))
+	v.AddWarningDiags(tfdiagsWarningForQueryTest("aws_instance.example"))
+
+	var summaries []queryPolicySummary
+	v.Flush(func(s queryPolicySummary) { summaries = append(summaries, s) }, nil)
+
+	if len(summaries) != 1 {
+		t.Fatalf("got %d summaries, want 1", len(summaries))
+	}
+	if summaries[0].ListBlockAddress != "aws_instance.example" {
+		t.Fatalf("ListBlockAddress = %q, want %q", summaries[0].ListBlockAddress, "aws_instance.example")
+	}
+}
+
 
 func TestRenderer_ignoresPolicyQuerySummary(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
@@ -202,7 +385,10 @@ type policyResultSpec struct {
 	diagnostics []policy.Diagnostic
 }
 
-func queryEvalResp(listBlockAddr, _ string, identity map[string]string, overall policy.EvaluateResult, specs []policyResultSpec) policy.EvaluationResponse {
+// queryEvalResp builds a policy.EvaluationResponse for tests. The target
+// address is passed separately as the first argument to PolicyResult and is not
+// part of the response itself.
+func queryEvalResp(listBlockAddr string, identity map[string]string, overall policy.EvaluateResult, specs []policyResultSpec) policy.EvaluationResponse {
 	resp := policy.EvaluationResponse{
 		Overall:       overall,
 		Identity:      identity,

--- a/internal/command/views/query_policy_test.go
+++ b/internal/command/views/query_policy_test.go
@@ -15,8 +15,8 @@ import (
 	viewjson "github.com/hashicorp/terraform/internal/command/views/json"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/policy"
-	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/terminal"
+	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -93,7 +93,7 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 			wantPolicies: 1,
 		},
 		{
-			name:         "multiple list blocks",
+			name: "multiple list blocks",
 			wantPerBlock: []wantBlock{
 				{
 					addr:         listBlockAddr,
@@ -314,7 +314,6 @@ func TestQueryOperationHuman_policySummary(t *testing.T) {
 	}
 }
 
-
 func TestQueryPolicyListBlockAddr(t *testing.T) {
 	tests := []struct {
 		detail string
@@ -366,7 +365,6 @@ func TestAddWarningDiagsRoutesCorrectly(t *testing.T) {
 		t.Fatalf("ListBlockAddress = %q, want %q", summaries[0].ListBlockAddress, "aws_instance.example")
 	}
 }
-
 
 func TestRenderer_ignoresPolicyQuerySummary(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)

--- a/internal/command/views/query_policy_test.go
+++ b/internal/command/views/query_policy_test.go
@@ -158,8 +158,8 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 
 			for i, want := range wants {
 				got := lines[i]
-				if got["@level"] != "error" {
-					t.Fatalf("record[%d] @level = %v, want error", i, got["@level"])
+				if got["@level"] != "info" {
+					t.Fatalf("record[%d] @level = %v, want info", i, got["@level"])
 				}
 				if got["@policy"] != "true" {
 					t.Fatalf("record[%d] @policy = %v, want true", i, got["@policy"])
@@ -314,40 +314,6 @@ func TestQueryOperationHuman_policySummary(t *testing.T) {
 	}
 }
 
-func TestQueryPolicyListBlockAddr(t *testing.T) {
-	tests := []struct {
-		detail string
-		want   string
-	}{
-		{
-			detail: "1 resource(s) in list block aws_instance.example have no state",
-			want:   "aws_instance.example",
-		},
-		{
-			detail: "1 resource(s) in list block module.vpc.aws_instance.mylist have no state",
-			want:   "module.vpc.aws_instance.mylist",
-		},
-		{
-			detail: "1 resource(s) in list block aws_instance.example: extra text",
-			want:   "aws_instance.example",
-		},
-		{
-			detail: "no marker here",
-			want:   "",
-		},
-		{
-			detail: "list block ",
-			want:   "",
-		},
-	}
-	for _, tc := range tests {
-		got := queryPolicyListBlockAddr(tc.detail)
-		if got != tc.want {
-			t.Errorf("queryPolicyListBlockAddr(%q) = %q, want %q", tc.detail, got, tc.want)
-		}
-	}
-}
-
 func TestAddWarningDiagsRoutesCorrectly(t *testing.T) {
 	// Verify that a warning diagnostic for "aws_instance.example" is routed to
 	// the block keyed "aws_instance.example", not a truncated "aws_instance".
@@ -406,7 +372,12 @@ func queryEvalResp(listBlockAddr string, identity map[string]string, overall pol
 }
 
 func tfdiagsWarningForQueryTest(addr string) tfdiags.Diagnostics {
-	return tfdiags.Diagnostics{tfdiags.Sourceless(tfdiags.Warning, "Policy evaluation skipped", "1 resource(s) in list block "+addr+" have no state (include_resource = false). Policy evaluation cannot be performed without resource state.")}
+	return tfdiags.Diagnostics{tfdiags.SourcelessWithExtra(
+		tfdiags.Warning,
+		"Policy evaluation skipped",
+		"1 resource(s) in list block "+addr+" have no state (include_resource = false). Policy evaluation cannot be performed without resource state.",
+		&tfdiags.ListBlockAddrExtra{ListBlockAddr: addr},
+	)}
 }
 
 // ---------------------------------------------------------------------------
@@ -479,8 +450,8 @@ func TestNewQueryJSON_hooksRouteToOperation(t *testing.T) {
 	}
 
 	rec := summaries[0]
-	if rec["@level"] != "error" {
-		t.Errorf("@level = %v, want error", rec["@level"])
+	if rec["@level"] != "info" {
+		t.Errorf("@level = %v, want info", rec["@level"])
 	}
 	if rec["@policy"] != "true" {
 		t.Errorf("@policy = %v, want true", rec["@policy"])
@@ -886,8 +857,8 @@ func TestQueryOperationJSON_recordShape(t *testing.T) {
 			t.Errorf("missing required field %q in policy_query_summary record", f)
 		}
 	}
-	if rec["@level"] != "error" {
-		t.Errorf("@level = %v, want error", rec["@level"])
+	if rec["@level"] != "info" {
+		t.Errorf("@level = %v, want info", rec["@level"])
 	}
 	if rec["@policy"] != "true" {
 		t.Errorf("@policy = %v, want true", rec["@policy"])

--- a/internal/command/views/query_policy_test.go
+++ b/internal/command/views/query_policy_test.go
@@ -158,8 +158,8 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 
 			for i, want := range wants {
 				got := lines[i]
-				if got["@level"] != "error" {
-					t.Fatalf("record[%d] @level = %v, want error", i, got["@level"])
+				if got["@level"] != "info" {
+					t.Fatalf("record[%d] @level = %v, want info", i, got["@level"])
 				}
 				if got["@policy"] != "true" {
 					t.Fatalf("record[%d] @policy = %v, want true", i, got["@policy"])
@@ -314,40 +314,6 @@ func TestQueryOperationHuman_policySummary(t *testing.T) {
 	}
 }
 
-func TestQueryPolicyListBlockAddr(t *testing.T) {
-	tests := []struct {
-		detail string
-		want   string
-	}{
-		{
-			detail: "1 resource(s) in list block aws_instance.example have no state",
-			want:   "aws_instance.example",
-		},
-		{
-			detail: "1 resource(s) in list block module.vpc.aws_instance.mylist have no state",
-			want:   "module.vpc.aws_instance.mylist",
-		},
-		{
-			detail: "1 resource(s) in list block aws_instance.example: extra text",
-			want:   "aws_instance.example",
-		},
-		{
-			detail: "no marker here",
-			want:   "",
-		},
-		{
-			detail: "list block ",
-			want:   "",
-		},
-	}
-	for _, tc := range tests {
-		got := queryPolicyListBlockAddr(tc.detail)
-		if got != tc.want {
-			t.Errorf("queryPolicyListBlockAddr(%q) = %q, want %q", tc.detail, got, tc.want)
-		}
-	}
-}
-
 func TestAddWarningDiagsRoutesCorrectly(t *testing.T) {
 	// Verify that a warning diagnostic for "aws_instance.example" is routed to
 	// the block keyed "aws_instance.example", not a truncated "aws_instance".
@@ -406,7 +372,12 @@ func queryEvalResp(listBlockAddr string, identity map[string]string, overall pol
 }
 
 func tfdiagsWarningForQueryTest(addr string) tfdiags.Diagnostics {
-	return tfdiags.Diagnostics{tfdiags.Sourceless(tfdiags.Warning, "Policy evaluation skipped", "1 resource(s) in list block "+addr+" have no state (include_resource = false). Policy evaluation cannot be performed without resource state.")}
+	return tfdiags.Diagnostics{tfdiags.SourcelessWithExtra(
+		tfdiags.Warning,
+		"Policy evaluation skipped",
+		"1 resource(s) in list block "+addr+" have no state (include_resource = false). Policy evaluation cannot be performed without resource state.",
+		&tfdiags.ListBlockAddrExtra{ListBlockAddr: addr},
+	)}
 }
 
 // ---------------------------------------------------------------------------
@@ -479,8 +450,8 @@ func TestNewQueryJSON_hooksRouteToOperation(t *testing.T) {
 	}
 
 	rec := summaries[0]
-	if rec["@level"] != "error" {
-		t.Errorf("@level = %v, want error", rec["@level"])
+	if rec["@level"] != "info" {
+		t.Errorf("@level = %v, want info", rec["@level"])
 	}
 	if rec["@policy"] != "true" {
 		t.Errorf("@policy = %v, want true", rec["@policy"])
@@ -886,8 +857,8 @@ func TestQueryOperationJSON_recordShape(t *testing.T) {
 			t.Errorf("missing required field %q in policy_query_summary record", f)
 		}
 	}
-	if rec["@level"] != "error" {
-		t.Errorf("@level = %v, want error", rec["@level"])
+	if rec["@level"] != "info" {
+		t.Errorf("@level = %v, want info", rec["@level"])
 	}
 	if rec["@policy"] != "true" {
 		t.Errorf("@policy = %v, want true", rec["@policy"])
@@ -999,5 +970,58 @@ func TestQueryPolicyView_multiBlock(t *testing.T) {
 	}
 	if summaries[1].OverallResult != queryPolicyResultPass {
 		t.Errorf("summaries[1] OverallResult = %s, want pass", summaries[1].OverallResult)
+	}
+}
+
+func TestQueryOperation_nilQueryPolicyPolicyResult(t *testing.T) {
+	// Test that QueryOperationHuman and QueryOperationJSON do not panic
+	// when PolicyResult is called with queryPolicy == nil. This can occur if
+	// a test constructs the operation directly without going through NewQuery.
+	streams, _ := terminal.StreamsForTesting(t)
+
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "QueryOperationHuman with nil queryPolicy",
+			test: func(t *testing.T) {
+				op := &QueryOperationHuman{
+					view:        NewView(streams),
+					queryPolicy: nil,
+				}
+				// This should not panic. It should delegate to the base view.
+				resp := policy.EvaluationResponse{
+					ListBlockAddr: "",
+					Identity:      map[string]string{"id": "test"},
+					Overall:       policy.AllowResult,
+					Policies:      []*policy.Policy{},
+				}
+				// Call should complete without panic
+				op.PolicyResult("aws_instance.example", resp)
+			},
+		},
+		{
+			name: "QueryOperationJSON with nil queryPolicy",
+			test: func(t *testing.T) {
+				op := &QueryOperationJSON{
+					view:        NewJSONView(NewView(streams)),
+					queryPolicy: nil,
+				}
+				// This should not panic. It should delegate to the base view.
+				resp := policy.EvaluationResponse{
+					ListBlockAddr: "",
+					Identity:      map[string]string{"id": "test"},
+					Overall:       policy.AllowResult,
+					Policies:      []*policy.Policy{},
+				}
+				// Call should complete without panic
+				op.PolicyResult("aws_instance.example", resp)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.test)
 	}
 }

--- a/internal/command/views/query_policy_test.go
+++ b/internal/command/views/query_policy_test.go
@@ -6,9 +6,11 @@ package views
 import (
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/jsonformat"
 	viewjson "github.com/hashicorp/terraform/internal/command/views/json"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -407,4 +409,597 @@ func queryEvalResp(listBlockAddr string, identity map[string]string, overall pol
 
 func tfdiagsWarningForQueryTest(addr string) tfdiags.Diagnostics {
 	return tfdiags.Diagnostics{tfdiags.Sourceless(tfdiags.Warning, "Policy evaluation skipped", "1 resource(s) in list block "+addr+" have no state (include_resource = false). Policy evaluation cannot be performed without resource state.")}
+}
+
+// ---------------------------------------------------------------------------
+// CORE-7 Regression tests
+// The original bug: QueryHuman.Hooks() and QueryJSON.Hooks() returned raw
+// UiHook/jsonHook wired to the base view. When nodeQueryResourcePolicy fired
+// the PolicyResult hook it landed in the generic renderer, so query policy
+// results were emitted as "policy_result" records instead of being buffered
+// into the queryPolicyView and flushed as a single "policy_query_summary".
+// ---------------------------------------------------------------------------
+
+// TestNewQueryJSON_hooksRouteToOperation is the primary regression test for
+// CORE-7. It drives the full public surface (NewQuery → Hooks → PolicyResult
+// hook call → Operation().Plan) and asserts that:
+//  1. Exactly one policy_query_summary record is emitted.
+//  2. No generic policy_result records are emitted.
+//  3. The summary record carries the correct shape and field values.
+func TestNewQueryJSON_hooksRouteToOperation(t *testing.T) {
+	listBlockAddr := "aws_instance.example"
+	targetAddr := "aws_instance.example_0"
+
+	streams, done := terminal.StreamsForTesting(t)
+	q := NewQuery(arguments.ViewJSON, NewView(streams))
+
+	// Fire the PolicyResult hook as the graph walker would during query execution.
+	for _, hook := range q.Hooks() {
+		action, err := hook.PolicyResult(targetAddr, queryEvalResp(
+			listBlockAddr,
+			map[string]string{"id": "i-1"},
+			policy.AllowResult,
+			[]policyResultSpec{{address: "policy.allow", result: policy.AllowResult}},
+		))
+		if err != nil {
+			t.Fatalf("PolicyResult hook returned error: %s", err)
+		}
+		if action != terraform.HookActionContinue {
+			t.Fatalf("PolicyResult hook returned unexpected action: %v", action)
+		}
+	}
+
+	// Trigger flush (Plan is the point where Flush is called).
+	q.Operation().Plan(nil, nil)
+
+	output := done(t).Stdout()
+	var summaries []map[string]any
+	var genericResults []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+			t.Fatalf("failed to decode JSON line %q: %s", line, err)
+		}
+		switch decoded["type"] {
+		case string(viewjson.MessagePolicyQuerySummary):
+			summaries = append(summaries, decoded)
+		case string(viewjson.MessagePolicyEvaluationResult):
+			genericResults = append(genericResults, decoded)
+		}
+	}
+
+	// AC: exactly one policy_query_summary record.
+	if len(summaries) != 1 {
+		t.Fatalf("want 1 policy_query_summary record, got %d\nfull output:\n%s", len(summaries), output)
+	}
+	// AC: no duplicate generic policy_result records.
+	if len(genericResults) != 0 {
+		t.Fatalf("want 0 policy_result records, got %d (duplicate emission detected)\nfull output:\n%s", len(genericResults), output)
+	}
+
+	rec := summaries[0]
+	if rec["@level"] != "error" {
+		t.Errorf("@level = %v, want error", rec["@level"])
+	}
+	if rec["@policy"] != "true" {
+		t.Errorf("@policy = %v, want true", rec["@policy"])
+	}
+	if rec["type"] != "policy_query_summary" {
+		t.Errorf("type = %v, want policy_query_summary", rec["type"])
+	}
+	if rec["list_block_address"] != listBlockAddr {
+		t.Errorf("list_block_address = %v, want %s", rec["list_block_address"], listBlockAddr)
+	}
+	if rec["overall_result"] != "pass" {
+		t.Errorf("overall_result = %v, want pass", rec["overall_result"])
+	}
+	results := rec["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("results length = %d, want 1", len(results))
+	}
+	passedPolicies := rec["passed_policies"].([]any)
+	if len(passedPolicies) != 1 {
+		t.Fatalf("passed_policies length = %d, want 1", len(passedPolicies))
+	}
+}
+
+// TestNewQueryHuman_hooksRouteToOperation verifies that the human view's hooks
+// also route PolicyResult through the query operation, so the human summary is
+// rendered by Plan() and no raw policy output leaks.
+func TestNewQueryHuman_hooksRouteToOperation(t *testing.T) {
+	listBlockAddr := "aws_instance.example"
+	targetAddr := "aws_instance.example_0"
+
+	streams, done := terminal.StreamsForTesting(t)
+	q := NewQuery(arguments.ViewHuman, NewView(streams))
+
+	for _, hook := range q.Hooks() {
+		if _, err := hook.PolicyResult(targetAddr, queryEvalResp(
+			listBlockAddr,
+			map[string]string{"id": "i-1"},
+			policy.DenyResult,
+			[]policyResultSpec{{address: "policy.deny", result: policy.DenyResult,
+				diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied", "detail", policy.DenyResult)},
+			}},
+		)); err != nil {
+			t.Fatalf("PolicyResult hook returned error: %s", err)
+		}
+	}
+
+	q.Operation().Plan(nil, nil)
+
+	output := done(t).All()
+	if !strings.Contains(output, "Policy results for aws_instance.example (FAIL)") {
+		t.Errorf("expected human summary in output\nfull output:\n%s", output)
+	}
+	// The raw "Policy Result" log line must not appear (that would be the base UiHook path).
+	if strings.Contains(output, "Policy Result") {
+		t.Errorf("unexpected raw policy result line in human output\nfull output:\n%s", output)
+	}
+}
+
+// TestNewQueryJSON_noDuplicateRecords verifies that when a result has no
+// ListBlockAddr (i.e. not a query policy result), it falls through to the
+// generic emitter and does NOT produce a policy_query_summary.
+func TestNewQueryJSON_noDuplicateRecords(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	q := NewQuery(arguments.ViewJSON, NewView(streams))
+
+	// A response with no ListBlockAddr should NOT be buffered as query policy.
+	for _, hook := range q.Hooks() {
+		hook.PolicyResult("some.resource", queryEvalResp( //nolint:errcheck
+			"", // empty ListBlockAddr — should NOT be buffered
+			nil,
+			policy.AllowResult,
+			[]policyResultSpec{{address: "policy.allow", result: policy.AllowResult}},
+		))
+	}
+
+	q.Operation().Plan(nil, nil)
+
+	output := done(t).Stdout()
+	var summaries []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+			continue
+		}
+		if decoded["type"] == string(viewjson.MessagePolicyQuerySummary) {
+			summaries = append(summaries, decoded)
+		}
+	}
+	if len(summaries) != 0 {
+		t.Fatalf("expected no policy_query_summary for result with empty ListBlockAddr, got %d", len(summaries))
+	}
+}
+
+// TestQueryJSONHook_policyResultDelegates verifies that queryJSONHook.PolicyResult
+// calls op.PolicyResult and does not emit a generic policy_result record.
+func TestQueryJSONHook_policyResultDelegates(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	jv := NewJSONView(NewView(streams))
+	qpv := newQueryPolicyView()
+	op := &QueryOperationJSON{view: jv, queryPolicy: qpv}
+	hook := &queryJSONHook{jsonHook: newJSONHook(jv), op: op}
+
+	action, err := hook.PolicyResult("addr.target", queryEvalResp(
+		"aws_instance.block",
+		map[string]string{"id": "i-99"},
+		policy.AllowResult,
+		[]policyResultSpec{{address: "policy.p", result: policy.AllowResult}},
+	))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if action != terraform.HookActionContinue {
+		t.Fatalf("unexpected action: %v", action)
+	}
+	if !qpv.HasResults() {
+		t.Fatal("expected queryPolicyView to have results after hook call")
+	}
+
+	op.Plan(nil, nil)
+
+	output := done(t).Stdout()
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+			continue
+		}
+		if decoded["type"] == string(viewjson.MessagePolicyEvaluationResult) {
+			t.Fatalf("unexpected generic policy_result record emitted\nfull output:\n%s", output)
+		}
+	}
+}
+
+// TestQueryUiHook_policyResultDelegates verifies that queryUiHook.PolicyResult
+// calls op.PolicyResult without leaking anything to the raw stream immediately.
+func TestQueryUiHook_policyResultDelegates(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	qpv := newQueryPolicyView()
+	op := &QueryOperationHuman{view: view, queryPolicy: qpv}
+	hook := &queryUiHook{UiHook: NewUiHook(view), op: op}
+
+	action, err := hook.PolicyResult("addr.target", queryEvalResp(
+		"aws_instance.block",
+		map[string]string{"id": "i-99"},
+		policy.AllowResult,
+		[]policyResultSpec{{address: "policy.p", result: policy.AllowResult}},
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if action != terraform.HookActionContinue {
+		t.Fatalf("unexpected action: %v", action)
+	}
+	if !qpv.HasResults() {
+		t.Fatal("expected queryPolicyView to have results after hook call")
+	}
+
+	// Nothing should be written to the stream yet — output only arrives on Plan().
+	midOutput := done(t).All()
+	if midOutput != "" {
+		t.Errorf("unexpected output before Plan(): %q", midOutput)
+	}
+}
+
+// TestQueryPolicySummaryOverall covers each branch of the roll-up logic.
+func TestQueryPolicySummaryOverall(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []queryPolicyIdentityResult
+		want    queryPolicyResult
+	}{
+		{
+			name:    "no results → pass",
+			results: []queryPolicyIdentityResult{},
+			want:    queryPolicyResultPass,
+		},
+		{
+			name:    "all pass",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultPass}, {Result: queryPolicyResultPass}},
+			want:    queryPolicyResultPass,
+		},
+		{
+			name:    "any fail → fail",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultPass}, {Result: queryPolicyResultFail}},
+			want:    queryPolicyResultFail,
+		},
+		{
+			name:    "unknown with pass → unknown",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultPass}, {Result: queryPolicyResultUnknown}},
+			want:    queryPolicyResultUnknown,
+		},
+		{
+			name:    "unknown does not override fail",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultFail}, {Result: queryPolicyResultUnknown}},
+			want:    queryPolicyResultFail,
+		},
+		{
+			name:    "error short-circuits",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultFail}, {Result: queryPolicyResultError}},
+			want:    queryPolicyResultError,
+		},
+		{
+			name:    "error short-circuits even before fail",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultError}, {Result: queryPolicyResultFail}},
+			want:    queryPolicyResultError,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := queryPolicySummaryOverall(tc.results)
+			if got != tc.want {
+				t.Errorf("queryPolicySummaryOverall = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestQueryPolicyResultFromEvaluation verifies every EvaluateResult → queryPolicyResult mapping.
+func TestQueryPolicyResultFromEvaluation(t *testing.T) {
+	tests := []struct {
+		input policy.EvaluateResult
+		want  queryPolicyResult
+	}{
+		{policy.AllowResult, queryPolicyResultPass},
+		{policy.DenyResult, queryPolicyResultFail},
+		{policy.PolicyErrorResult, queryPolicyResultError},
+		{policy.SetupErrorResult, queryPolicyResultError},
+		{policy.EvaluateResult(999), queryPolicyResultUnknown},
+	}
+	for _, tc := range tests {
+		got := queryPolicyResultFromEvaluation(tc.input)
+		if got != tc.want {
+			t.Errorf("queryPolicyResultFromEvaluation(%v) = %s, want %s", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestQueryPolicyView_addResultNoListBlock verifies that AddResult returns false
+// and does not buffer a block when ListBlockAddr is empty.
+func TestQueryPolicyView_addResultNoListBlock(t *testing.T) {
+	v := newQueryPolicyView()
+	resp := queryEvalResp("", nil, policy.AllowResult, []policyResultSpec{{address: "p", result: policy.AllowResult}})
+	if v.AddResult("target", resp) {
+		t.Fatal("AddResult should return false when ListBlockAddr is empty")
+	}
+	if v.HasResults() {
+		t.Fatal("HasResults should be false when no results with a list block have been added")
+	}
+}
+
+// TestQueryPolicyView_flushEmptiesBuffer verifies that calling Flush a second
+// time does not re-emit records from a prior flush.
+func TestQueryPolicyView_flushEmptiesBuffer(t *testing.T) {
+	v := newQueryPolicyView()
+	v.AddResult("target", queryEvalResp("aws_instance.block", nil, policy.AllowResult, []policyResultSpec{{address: "p", result: policy.AllowResult}}))
+
+	var count int
+	flush := func(_ queryPolicySummary) { count++ }
+	v.Flush(flush, nil)
+	if count != 1 {
+		t.Fatalf("first Flush: got %d calls, want 1", count)
+	}
+	v.Flush(flush, nil)
+	if count != 1 {
+		t.Fatalf("second Flush: got %d total calls, want still 1 (buffer should have been drained)", count)
+	}
+}
+
+// TestQueryPolicyView_concurrentAddResult verifies that concurrent AddResult
+// calls from multiple goroutines do not race (use with -race).
+func TestQueryPolicyView_concurrentAddResult(t *testing.T) {
+	const goroutines = 20
+	v := newQueryPolicyView()
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			addr := "aws_instance.block"
+			target := "aws_instance.target_" + string(rune('a'+i))
+			v.AddResult(target, queryEvalResp(addr, map[string]string{"id": string(rune('a' + i))}, policy.AllowResult, []policyResultSpec{{address: "p.allow", result: policy.AllowResult}}))
+		}(i)
+	}
+	wg.Wait()
+
+	var summaries []queryPolicySummary
+	v.Flush(func(s queryPolicySummary) { summaries = append(summaries, s) }, nil)
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary (one block), got %d", len(summaries))
+	}
+	if len(summaries[0].Results) != goroutines {
+		t.Fatalf("expected %d results in summary, got %d", goroutines, len(summaries[0].Results))
+	}
+}
+
+// TestQueryPolicyEvaluatedCount verifies that queryPolicyEvaluatedCount counts
+// unique policy addresses across all blocks.
+func TestQueryPolicyEvaluatedCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*queryPolicyView)
+		want  int
+	}{
+		{
+			name:  "nil view",
+			setup: func(_ *queryPolicyView) {},
+			want:  0,
+		},
+		{
+			name: "single block single policy",
+			setup: func(v *queryPolicyView) {
+				v.AddResult("t0", queryEvalResp("block.a", nil, policy.AllowResult, []policyResultSpec{{address: "p.one", result: policy.AllowResult}}))
+			},
+			want: 1,
+		},
+		{
+			name: "two blocks same policy address",
+			setup: func(v *queryPolicyView) {
+				v.AddResult("t0", queryEvalResp("block.a", nil, policy.AllowResult, []policyResultSpec{{address: "p.one", result: policy.AllowResult}}))
+				v.AddResult("t1", queryEvalResp("block.b", nil, policy.AllowResult, []policyResultSpec{{address: "p.one", result: policy.AllowResult}}))
+			},
+			want: 1, // same address; deduplicated
+		},
+		{
+			name: "two blocks different policies",
+			setup: func(v *queryPolicyView) {
+				v.AddResult("t0", queryEvalResp("block.a", nil, policy.AllowResult, []policyResultSpec{{address: "p.one", result: policy.AllowResult}}))
+				v.AddResult("t1", queryEvalResp("block.b", nil, policy.AllowResult, []policyResultSpec{{address: "p.two", result: policy.AllowResult}}))
+			},
+			want: 2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := newQueryPolicyView()
+			tc.setup(v)
+			got := queryPolicyEvaluatedCount(v)
+			if got != tc.want {
+				t.Errorf("queryPolicyEvaluatedCount = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestQueryOperationJSON_recordShape verifies the exact JSON shape of the
+// policy_query_summary record against the RFC wire contract.
+func TestQueryOperationJSON_recordShape(t *testing.T) {
+	listBlockAddr := "aws_instance.web"
+
+	streams, done := terminal.StreamsForTesting(t)
+	v := &QueryOperationJSON{view: NewJSONView(NewView(streams)), queryPolicy: newQueryPolicyView()}
+
+	// Two identities: one pass, one fail with a diagnostic.
+	v.PolicyResult("aws_instance.web_0", queryEvalResp(
+		listBlockAddr,
+		map[string]string{"account": "111", "id": "i-aaa"},
+		policy.AllowResult,
+		[]policyResultSpec{{address: "policy.allow", result: policy.AllowResult}},
+	))
+	v.PolicyResult("aws_instance.web_1", queryEvalResp(
+		listBlockAddr,
+		map[string]string{"account": "222", "id": "i-bbb"},
+		policy.DenyResult,
+		[]policyResultSpec{{
+			address:     "policy.deny",
+			result:      policy.DenyResult,
+			diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("denied summary", "denied detail", policy.DenyResult)},
+		}},
+	))
+	v.Plan(nil, nil)
+
+	output := done(t).Stdout()
+	var rec map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+			t.Fatalf("failed to decode JSON: %s", err)
+		}
+		if decoded["type"] == "policy_query_summary" {
+			rec = decoded
+			break
+		}
+	}
+	if rec == nil {
+		t.Fatalf("no policy_query_summary record found\nfull output:\n%s", output)
+	}
+
+	// Top-level field presence and values.
+	requiredFields := []string{"@level", "@policy", "type", "list_block_address", "overall_result", "results", "passed_policies"}
+	for _, f := range requiredFields {
+		if _, ok := rec[f]; !ok {
+			t.Errorf("missing required field %q in policy_query_summary record", f)
+		}
+	}
+	if rec["@level"] != "error" {
+		t.Errorf("@level = %v, want error", rec["@level"])
+	}
+	if rec["@policy"] != "true" {
+		t.Errorf("@policy = %v, want true", rec["@policy"])
+	}
+	if rec["type"] != "policy_query_summary" {
+		t.Errorf("type = %v, want policy_query_summary", rec["type"])
+	}
+	if rec["list_block_address"] != listBlockAddr {
+		t.Errorf("list_block_address = %v, want %s", rec["list_block_address"], listBlockAddr)
+	}
+	if rec["overall_result"] != "fail" {
+		t.Errorf("overall_result = %v, want fail", rec["overall_result"])
+	}
+
+	// results[] shape.
+	results := rec["results"].([]any)
+	if len(results) != 2 {
+		t.Fatalf("results length = %d, want 2", len(results))
+	}
+	for idx, rawResult := range results {
+		r := rawResult.(map[string]any)
+		if r["target_address"] == "" {
+			t.Errorf("results[%d] missing target_address", idx)
+		}
+		if r["result"] == "" {
+			t.Errorf("results[%d] missing result", idx)
+		}
+		if _, ok := r["identity"]; !ok {
+			t.Errorf("results[%d] missing identity", idx)
+		}
+		policies := r["policies"].([]any)
+		if len(policies) == 0 {
+			t.Errorf("results[%d] policies is empty", idx)
+		}
+		for pidx, rawPol := range policies {
+			pol := rawPol.(map[string]any)
+			if _, ok := pol["policy_metadata"].(map[string]any); !ok {
+				t.Errorf("results[%d].policies[%d] missing policy_metadata object", idx, pidx)
+			}
+			if pol["result"] == "" {
+				t.Errorf("results[%d].policies[%d] missing result", idx, pidx)
+			}
+			if _, ok := pol["diagnostics"]; !ok {
+				t.Errorf("results[%d].policies[%d] missing diagnostics field", idx, pidx)
+			}
+		}
+	}
+
+	// passed_policies[] shape: 2 distinct policy addresses.
+	passedPolicies := rec["passed_policies"].([]any)
+	if len(passedPolicies) != 2 {
+		t.Fatalf("passed_policies length = %d, want 2", len(passedPolicies))
+	}
+	for pidx, rawMeta := range passedPolicies {
+		if _, ok := rawMeta.(map[string]any); !ok {
+			t.Errorf("passed_policies[%d] is not an object", pidx)
+		}
+	}
+}
+
+// TestQueryPolicyView_sortedOutput verifies that both results[] and
+// passed_policies[] are emitted in deterministic sorted order.
+func TestQueryPolicyView_sortedOutput(t *testing.T) {
+	v := newQueryPolicyView()
+	// Add targets in reverse alphabetical order.
+	v.AddResult("z_target", queryEvalResp("block.x", nil, policy.AllowResult, []policyResultSpec{{address: "p.z", result: policy.AllowResult}}))
+	v.AddResult("a_target", queryEvalResp("block.x", nil, policy.AllowResult, []policyResultSpec{{address: "p.a", result: policy.AllowResult}}))
+
+	var summaries []queryPolicySummary
+	v.Flush(func(s queryPolicySummary) { summaries = append(summaries, s) }, nil)
+
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(summaries))
+	}
+	s := summaries[0]
+
+	if s.Results[0].TargetAddress != "a_target" || s.Results[1].TargetAddress != "z_target" {
+		t.Errorf("results not sorted: got [%s, %s], want [a_target, z_target]",
+			s.Results[0].TargetAddress, s.Results[1].TargetAddress)
+	}
+	if s.PassedPolicies[0].PolicyName != "p.a" || s.PassedPolicies[1].PolicyName != "p.z" {
+		t.Errorf("passed_policies not sorted: got [%s, %s], want [p.a, p.z]",
+			s.PassedPolicies[0].PolicyName, s.PassedPolicies[1].PolicyName)
+	}
+}
+
+// TestQueryPolicyView_multiBlock verifies that results for distinct list block
+// addresses are emitted as separate records, sorted by list_block_address.
+func TestQueryPolicyView_multiBlock(t *testing.T) {
+	v := newQueryPolicyView()
+	v.AddResult("t1", queryEvalResp("block.z", nil, policy.AllowResult, []policyResultSpec{{address: "p.z", result: policy.AllowResult}}))
+	v.AddResult("t2", queryEvalResp("block.a", nil, policy.DenyResult, []policyResultSpec{{address: "p.a", result: policy.DenyResult}}))
+
+	var summaries []queryPolicySummary
+	v.Flush(func(s queryPolicySummary) { summaries = append(summaries, s) }, nil)
+
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 summaries (one per block), got %d", len(summaries))
+	}
+	// Emitted in sorted order: block.a before block.z.
+	if summaries[0].ListBlockAddress != "block.a" {
+		t.Errorf("summaries[0] ListBlockAddress = %q, want block.a", summaries[0].ListBlockAddress)
+	}
+	if summaries[1].ListBlockAddress != "block.z" {
+		t.Errorf("summaries[1] ListBlockAddress = %q, want block.z", summaries[1].ListBlockAddress)
+	}
+	if summaries[0].OverallResult != queryPolicyResultFail {
+		t.Errorf("summaries[0] OverallResult = %s, want fail", summaries[0].OverallResult)
+	}
+	if summaries[1].OverallResult != queryPolicyResultPass {
+		t.Errorf("summaries[1] OverallResult = %s, want pass", summaries[1].OverallResult)
+	}
 }

--- a/internal/terraform/node_resource_list_policy.go
+++ b/internal/terraform/node_resource_list_policy.go
@@ -137,8 +137,10 @@ func (n *NodePlannableResourceInstance) generateListResourcePolicyData(
 	}
 
 	// Emit one consolidated warning per skip category rather than one per resource.
+	// Each warning carries a ListBlockAddrExtra so AddWarningDiags can route it
+	// to the correct block without string parsing.
 	if unknownCount > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
+		diags = diags.Append(tfdiags.SourcelessWithExtra(
 			tfdiags.Warning,
 			"Policy evaluation skipped",
 			fmt.Sprintf(
@@ -146,17 +148,19 @@ func (n *NodePlannableResourceInstance) generateListResourcePolicyData(
 					"Policy evaluation cannot be performed without resource state.",
 				unknownCount, listBlockAddr.String(),
 			),
+			&tfdiags.ListBlockAddrExtra{ListBlockAddr: listBlockAddr.String()},
 		))
 	}
 	if configErrCount > 0 {
 		// Config generation errors are unexpected but possible.
-		diags = diags.Append(tfdiags.Sourceless(
+		diags = diags.Append(tfdiags.SourcelessWithExtra(
 			tfdiags.Warning,
 			"Policy evaluation skipped",
 			fmt.Sprintf(
 				"%d resource(s) in list block %s could not generate config for policy evaluation.",
 				configErrCount, listBlockAddr.String(),
 			),
+			&tfdiags.ListBlockAddrExtra{ListBlockAddr: listBlockAddr.String()},
 		))
 	}
 

--- a/internal/tfdiags/sourceless.go
+++ b/internal/tfdiags/sourceless.go
@@ -14,3 +14,21 @@ func Sourceless(severity Severity, summary, detail string) Diagnostic {
 		detail:   detail,
 	}
 }
+
+// SourcelessWithExtra is like Sourceless but also attaches an arbitrary extra
+// value that callers can retrieve with ExtraInfo.
+func SourcelessWithExtra(severity Severity, summary, detail string, extra interface{}) Diagnostic {
+	return diagnosticBase{
+		severity: severity,
+		summary:  summary,
+		detail:   detail,
+		extra:    extra,
+	}
+}
+
+// ListBlockAddrExtra is the extra value attached to warning diagnostics that
+// are produced for a specific list block. AddWarningDiags reads this field to
+// route the diagnostic into the correct queryPolicyBlock without string parsing.
+type ListBlockAddrExtra struct {
+	ListBlockAddr string
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR implements policy evaluation for query (list block) resources, fixing two related issues:

1. **Implements `nodeQueryResourcePolicy.Execute()`** to perform actual policy evaluation for resources discovered via list blocks. Previously this method was a stub (TODO comment). The implementation:
   - Evaluates policies for each discovered resource using the policy client
   - Annotates every `EvaluationResponse` with a structured identity map (`map[string]string` derived from the resource's cty identity object) and the originating list block address
   - Always emits a `PolicyResult` hook event regardless of pass/fail (unlike `nodeResourcePolicy`, query nodes must emit for passing resources too so downstream aggregators can build complete summary records)
   - Acquires a dedicated policy semaphore to limit concurrent policy evaluations without consuming provider parallelism slots

2. **Fixes a bug where `QueryHuman.Hooks()` and `QueryJSON.Hooks()`** returned raw `UiHook`/`jsonHook` instances wired directly to the base view. When `nodeQueryResourcePolicy` fired the `PolicyResult` hook, results were emitted immediately as generic `policy_result` records instead of being buffered into a `queryPolicyView` and flushed as a single aggregated `policy_query_summary` record. The fix introduces `queryUiHook` and `queryJSONHook` wrapper types that intercept `PolicyResult` calls and route them through the query operation.

**Key changes:**

- **`internal/terraform/node_query_resource_policy.go`**: Full `Execute()` implementation with identity annotation, list block address annotation, semaphore acquisition, and unconditional hook emission.
- **`internal/policy/policy.go`**: Adds `Identity map[string]string` and `ListBlockAddr string` fields to `EvaluationResponse`, plus a `WithQueryMetadata()` builder method.
- **`internal/terraform/context.go`**: Adds a dedicated `policySem` semaphore initialized from `TF_POLICY_PARALLELISM` env var (falling back to `GOMAXPROCS`).
- **`internal/terraform/eval_context.go` / `eval_context_builtin.go` / `eval_context_mock.go`**: Adds `PolicySemaphore()` to the `EvalContext` interface and implementations.
- **`internal/command/views/query_policy.go`**: New file implementing `queryPolicyView`, a thread-safe buffer that groups `EvaluationResponse` records by list block address and flushes them as `queryPolicySummary` structs. Includes human-readable and JSON rendering.
- **`internal/command/views/query.go`**: Introduces `queryUiHook` and `queryJSONHook` wrapper types; rewires `NewQuery` so both human and JSON paths share a single `queryPolicyView` between the hook and the operation.
- **`internal/command/views/json/message_types.go`** and **`internal/command/jsonformat/renderer.go`**: Adds `MessagePolicyQuerySummary` / `LogPolicyQuerySummary` message type and marks it as a no-op in the renderer (consumed by cloud backend, not rendered locally).
- **`internal/terraform/policy.go`**: Guards against nil `PolicyGraph()` before accessing its span (fixes nil-pointer panic when policy graph is not configured).
- **`internal/terraform/node_policy_resource.go`**: Removes erroneous double `WithLocalRange` call (was applied in both `evaluatePolicies` and after the call).

**Smoke testing steps:**

1. Configure a Terraform workspace with at least one `list` block referencing a resource type that has policies attached.
2. Run `terraform query` and confirm that policy results are **not** emitted as individual `policy_result` lines during execution.
3. After the query completes, confirm that a single `policy_query_summary` record is printed per list block address, grouping all policy outcomes for that block.
4. Set `TF_POLICY_PARALLELISM=2` and re-run with multiple list blocks to confirm concurrency is limited (observable via trace/debug logging or by verifying no more than 2 policy evaluations run simultaneously).
5. Run without any policy graph configured (e.g. a workspace with no policies) and confirm there is no nil-pointer panic and the command completes cleanly.
6. Run `terraform query` with a mix of passing and failing policies and confirm both are captured in the summary (i.e. passing resources are not silently dropped from the output).

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

Policy evaluation parallelism is now controlled by a dedicated semaphore (`TF_POLICY_PARALLELISM` env var, defaulting to `GOMAXPROCS`). This is a resource-management change, not a security control change. No changes to access controls, encryption, or audit logging.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.