### PR TITLE
fix: prevent provider plugin shutdown hang by adding timeout to Kill()

### DIFF
--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/zclconf/go-cty/cty"
@@ -1671,7 +1672,26 @@ func (p *GRPCProvider) Close() error {
 		return nil
 	}
 
-	p.PluginClient.Kill()
+	// Use a timeout to prevent indefinite hangs during plugin shutdown.
+	// In rare cases, the gRPC connection's HTTP/2 reader goroutine can get
+	// stuck in a blocking syscall.read that cannot be interrupted by
+	// ClientConn.Close. When this happens, Kill() never returns because
+	// it waits for the reader goroutine to finish.
+	// See https://github.com/hashicorp/terraform/issues/38939
+	done := make(chan struct{}, 1)
+	go func() {
+		p.PluginClient.Kill()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+		logger.Trace("GRPCProvider: plugin client killed successfully")
+	case <-time.After(30 * time.Second):
+		logger.Warn("GRPCProvider: plugin client Kill timed out after 30s, " +
+			"the gRPC reader goroutine may be stuck in a blocking syscall")
+	}
+
 	return nil
 }
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/hcl/v2"
@@ -1899,7 +1900,26 @@ func (p *GRPCProvider) Close() error {
 		return nil
 	}
 
-	p.PluginClient.Kill()
+	// Use a timeout to prevent indefinite hangs during plugin shutdown.
+	// In rare cases, the gRPC connection's HTTP/2 reader goroutine can get
+	// stuck in a blocking syscall.read that cannot be interrupted by
+	// ClientConn.Close. When this happens, Kill() never returns because
+	// it waits for the reader goroutine to finish.
+	// See https://github.com/hashicorp/terraform/issues/38939
+	done := make(chan struct{}, 1)
+	go func() {
+		p.PluginClient.Kill()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+		logger.Trace("GRPCProvider.v6: plugin client killed successfully")
+	case <-time.After(30 * time.Second):
+		logger.Warn("GRPCProvider.v6: plugin client Kill timed out after 30s, " +
+			"the gRPC reader goroutine may be stuck in a blocking syscall")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

This fix prevents Terraform from hanging indefinitely during provider plugin shutdown after an operation completes.

### Problem

In rare cases, Terraform hangs forever during provider plugin shutdown. The root cause is a deadlock in the gRPC connection close path:

1. **goroutine 72** — `ClientConn.Close` blocks on `WaitGroup.Wait` waiting for the HTTP/2 transport to finish
2. **goroutine 217** — Transport teardown blocks in `FD.Close` waiting for the reader goroutine to release the file descriptor
3. **goroutine 251** — The HTTP/2 reader goroutine is stuck in a raw blocking `syscall.read` on the plugin socket, which cannot be interrupted by `FD.Close`

Because the reader goroutine is parked in a direct syscall.read (not registered with Go's netpoller), `FD.Close` cannot unblock it, and the entire `ClientConn.Close` chain waits indefinitely.

### Fix

Wrap the `p.PluginClient.Kill()` call in a goroutine with a 30-second timeout. If the `Kill()` call completes normally, the function returns immediately. If it hangs (due to the gRPC reader deadlock), the timeout fires after 30 seconds, a warning is logged, and the function returns.

This is applied to both the gRPC v5 (internal/plugin/grpc_provider.go) and gRPC v6 (internal/plugin6/grpc_provider.go) implementations.

### Testing

- The fix is a non-functional change for the normal case. Kill() completes in milliseconds, and the goroutine sends on the channel before the select reaches the timeout case.
- The timeout path is a safety net for the rare deadlock scenario described in the issue.

### Related Issues

Fixes #38939