### PR TITLE
Send a single Policy evaluation for replaced resources

### DIFF
--- a/internal/policy/proto/types.pb.go
+++ b/internal/policy/proto/types.pb.go
@@ -111,10 +111,11 @@ func (EvaluateResult) EnumDescriptor() ([]byte, []int) {
 type Operation int32
 
 const (
-	Operation_CREATE Operation = 0
-	Operation_UPDATE Operation = 1
-	Operation_DELETE Operation = 2
-	Operation_NO_OP  Operation = 3
+	Operation_CREATE  Operation = 0
+	Operation_UPDATE  Operation = 1
+	Operation_DELETE  Operation = 2
+	Operation_NO_OP   Operation = 3
+	Operation_REPLACE Operation = 4
 )
 
 // Enum value maps for Operation.
@@ -124,12 +125,14 @@ var (
 		1: "UPDATE",
 		2: "DELETE",
 		3: "NO_OP",
+		4: "REPLACE",
 	}
 	Operation_value = map[string]int32{
-		"CREATE": 0,
-		"UPDATE": 1,
-		"DELETE": 2,
-		"NO_OP":  3,
+		"CREATE":  0,
+		"UPDATE":  1,
+		"DELETE":  2,
+		"NO_OP":   3,
+		"REPLACE": 4,
 	}
 )
 
@@ -383,7 +386,7 @@ const file_types_proto_rawDesc = "" +
 	"\x15ERROR_EVALUATE_RESULT\x10\x02\x12\x19\n" +
 	"\x15ALLOW_EVALUATE_RESULT\x10\x03\x12\x18\n" +
 	"\x14DENY_EVALUATE_RESULT\x10\x04\x12\x1f\n" +
-	"\x1bSETUP_ERROR_EVALUATE_RESULT\x10\x05*:\n" +
+	"\x1bSETUP_ERROR_EVALUATE_RESULT\x10\x05*G\n" +
 	"\tOperation\x12\n" +
 	"\n" +
 	"\x06CREATE\x10\x00\x12\n" +
@@ -391,7 +394,8 @@ const file_types_proto_rawDesc = "" +
 	"\x06UPDATE\x10\x01\x12\n" +
 	"\n" +
 	"\x06DELETE\x10\x02\x12\t\n" +
-	"\x05NO_OP\x10\x03B4Z2github.com/hashicorp/terraform-policy-plugin/protob\x06proto3"
+	"\x05NO_OP\x10\x03\x12\v\n" +
+	"\aREPLACE\x10\x04B4Z2github.com/hashicorp/terraform-policy-plugin/protob\x06proto3"
 
 var (
 	file_types_proto_rawDescOnce sync.Once

--- a/internal/policy/proto/types.proto
+++ b/internal/policy/proto/types.proto
@@ -52,6 +52,7 @@ enum Operation {
   UPDATE = 1;
   DELETE = 2;
   NO_OP = 3;
+  REPLACE = 4;
 }
 
 message ResourceAttributes {

--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -1072,6 +1072,118 @@ func TestContext2Apply_PolicyEvaluation_NoOpOperation(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_PolicyEvaluation_ReplaceOperation(t *testing.T) {
+	mainConfig := `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		resource "test_resource" "test" {
+			sensitive_value = "new"
+
+			lifecycle {
+				create_before_destroy = true
+			}
+		}
+	`
+
+	mod := testModuleInline(t, map[string]string{
+		"main.tf":           mainConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
+	})
+
+	state := states.BuildState(func(ss *states.SyncState) {
+		ss.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_resource.test"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"existing","sensitive_value":"same"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	})
+
+	providerAddr := addrs.NewDefaultProvider("test")
+	provider := testProvider("test")
+	ctx, diags := NewContext(&ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			providerAddr: testProviderFuncFixed(provider),
+		},
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	planPolicyClient := policy.NewTestMockClient(t)
+	plan, diags := ctx.Plan(mod, state, &PlanOpts{
+		Mode:         plans.NormalMode,
+		SetVariables: testInputValuesUnset(mod.Module.Variables),
+		PolicyClient: planPolicyClient,
+		ForceReplace: []addrs.AbsResourceInstance{mustResourceInstanceAddr("test_resource.test")},
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	applyPlan := plan
+
+	applyPolicyClient := policy.NewTestMockClient(t)
+	var evaluateCalled int
+	applyPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		evaluateCalled++
+		if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
+			ProviderType: "test",
+			Operation:    proto.Operation_REPLACE,
+		}, protocmp.Transform()); diff != "" {
+			t.Fatalf("unexpected resource metadata (-got +want):\n%s", diff)
+		}
+
+		actualAttrs := req.Attrs.Raw
+		if actualAttrs.IsNull() {
+			t.Fatal("expected non-null attrs for no-op evaluation")
+		}
+		actualAttrs = cty.ObjectVal(map[string]cty.Value{
+			"id":              actualAttrs.GetAttr("id"),
+			"sensitive_value": actualAttrs.GetAttr("sensitive_value"),
+		})
+		wantAttrs := cty.ObjectVal(map[string]cty.Value{
+			"id":              cty.StringVal(""),
+			"sensitive_value": cty.StringVal("new"),
+		})
+		if diff := cmp.Diff(actualAttrs, wantAttrs, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+			t.Fatalf("unexpected attrs (-got +want):\n%s", diff)
+		}
+
+		actualPrior := req.PriorAttrs.Raw
+		if actualPrior.IsNull() {
+			t.Fatal("expected non-null prior attrs for no-op evaluation")
+		}
+		actualPrior = cty.ObjectVal(map[string]cty.Value{
+			"id":              actualPrior.GetAttr("id"),
+			"sensitive_value": actualPrior.GetAttr("sensitive_value"),
+		})
+		wantAttrs = cty.ObjectVal(map[string]cty.Value{
+			"id":              cty.StringVal("existing"),
+			"sensitive_value": cty.StringVal("same"),
+		})
+		if diff := cmp.Diff(actualPrior, wantAttrs, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+			t.Fatalf("unexpected prior attrs (-got +want):\n%s", diff)
+		}
+
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	_, diags = ctx.Apply(applyPlan, mod, &ApplyOpts{
+		PolicyClient: applyPolicyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	if evaluateCalled != 1 {
+		t.Fatalf("expected 1 policy evaluation call for no-op resource, got %d", evaluateCalled)
+	}
+}
+
 func TestContext2Apply_PolicyEvaluation_PartialApply(t *testing.T) {
 	mainConfig := `
 		terraform {

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -845,7 +845,7 @@ func TestContext2Plan_PolicyEvaluation(t *testing.T) {
 					called++
 					if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
 						ProviderType: "test",
-						Operation:    proto.Operation_UPDATE,
+						Operation:    proto.Operation_REPLACE,
 					}, protocmp.Transform()); diff != "" {
 						t.Errorf("Invalid resource metadata: %s", diff)
 					}

--- a/internal/terraform/graph_policy.go
+++ b/internal/terraform/graph_policy.go
@@ -6,13 +6,17 @@ package terraform
 import (
 	"sync"
 
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/zclconf/go-cty/cty"
 	"go.opentelemetry.io/otel/trace"
 )
 
 // policySubgraph is a subgraph that stores resource policy nodes.
 type policySubgraph struct {
-	lock  sync.Mutex
-	graph Graph
+	lock      sync.Mutex
+	resources addrs.Map[addrs.AbsResourceInstance, *nodeResourcePolicy]
+	queries   addrs.Map[addrs.AbsResourceInstance, *nodeQueryResourcePolicy]
 
 	// span carries the tracing information. We need the span itself so we can end it
 	// when the policy evaluation is finished
@@ -20,22 +24,49 @@ type policySubgraph struct {
 }
 
 func newPolicySubgraph() *policySubgraph {
-	var g Graph
-	return &policySubgraph{graph: g}
+	return &policySubgraph{
+		resources: addrs.MakeMap[addrs.AbsResourceInstance, *nodeResourcePolicy](),
+		queries:   addrs.MakeMap[addrs.AbsResourceInstance, *nodeQueryResourcePolicy](),
+	}
 }
 
 func (ps *policySubgraph) Add(node *nodeResourcePolicy) {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 
-	ps.graph.Add(node)
+	existing, ok := ps.resources.GetOk(node.ResourceAddr)
+	if !ok {
+		ps.resources.Put(node.ResourceAddr, node)
+		return
+	}
+
+	// a node already exists. If there is a create/delete combination,
+	// then this originated from a replacement operation (replace or CBD),
+	// and we will create a new replace node to represent it, so that
+	// we have one single policy node to represent the replacement operation.
+	var before, after cty.Value
+	if existing.Action == plans.Create && node.Action == plans.Delete {
+		before = node.Before
+		after = existing.After
+	} else if existing.Action == plans.Delete && node.Action == plans.Delete {
+		before = existing.Before
+		after = node.After
+	}
+	replaceNode := &nodeResourcePolicy{
+		ResourceAddr: node.ResourceAddr,
+		ProviderAddr: node.ProviderAddr,
+		Before:       before,
+		After:        after,
+		Action:       plans.CreateThenDelete,
+	}
+	ps.resources.Put(node.ResourceAddr, replaceNode)
 }
 
 func (ps *policySubgraph) AddQuery(node *nodeQueryResourcePolicy) {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 
-	ps.graph.Add(node)
+	ps.queries.Put(node.ResourceAddr, node)
 }
 
 func (ps *policySubgraph) evalGraph(span trace.Span) *Graph {
@@ -44,32 +75,23 @@ func (ps *policySubgraph) evalGraph(span trace.Span) *Graph {
 
 	ps.span = span
 
-	g := ps.graphCopyLocked()
+	g := &Graph{}
+	// create a finish node that depends on all policy nodes
 	finish := &nodePolicyEvalFinish{span: span}
 	g.Add(finish)
-	for pn := range g.VerticesSeq() {
-		// Wire finish only to policy node types; all other vertices are skipped.
-		switch pn.(type) {
-		case *nodeResourcePolicy, *nodeQueryResourcePolicy:
-		default:
-			continue
-		}
-		// finish depends on pn, so pn runs first and finish runs after.
-		g.Connect(finish, pn)
+	// add resource policy nodes to the graph
+	for _, node := range ps.resources.Iter() {
+		g.Add(node)
+
+		// Wire finish to policy node types
+		g.Connect(finish, node)
+	}
+	for _, node := range ps.queries.Iter() {
+		g.Add(node)
+		g.Connect(finish, node)
 	}
 
 	// ensure the graph has a single root
-	addRootNodeToGraph(&g)
-	return &g
-}
-
-func (ps *policySubgraph) graphCopyLocked() Graph {
-	var g Graph
-	for v := range ps.graph.VerticesSeq() {
-		g.Add(v)
-	}
-	for _, e := range ps.graph.Edges() {
-		g.Connect(e.Source, e.Target)
-	}
+	addRootNodeToGraph(g)
 	return g
 }

--- a/internal/terraform/node_policy_eval_test.go
+++ b/internal/terraform/node_policy_eval_test.go
@@ -119,11 +119,6 @@ func TestNodePolicyEval_DynamicExpand_FinishWiring(t *testing.T) {
 	// Both policy node types must be scheduled before the finish node.
 	testGraphHappensBefore(t, g, rp.Name(), "(policy evaluation complete)")
 	testGraphHappensBefore(t, g, qrp.Name(), "(policy evaluation complete)")
-
-	// Dynamic expansion returns a walk graph, but must not mutate the accumulated
-	// policy subgraph while doing finish/root wiring.
-	testGraphNotContains(t, &ps.graph, "(policy evaluation complete)")
-	testGraphNotContains(t, &ps.graph, rootNodeName)
 }
 
 // TestNodePolicyEval_DynamicExpand_ConcurrentExecution verifies that when

--- a/internal/terraform/node_policy_resource.go
+++ b/internal/terraform/node_policy_resource.go
@@ -91,17 +91,19 @@ func (n *nodeResourcePolicy) Execute(ctx EvalContext, operation walkOperation) t
 
 func policyOperationForAction(action plans.Action) (proto.Operation, bool) {
 	switch action {
-	case plans.Create:
+	// CreateThenForget is treated as a Create operation for policy evaluation purposes
+	// since the Forget part does not invoke any API calls.
+	case plans.Create, plans.CreateThenForget:
 		return proto.Operation_CREATE, true
 	case plans.Delete:
 		return proto.Operation_DELETE, true
 	case plans.NoOp:
 		return proto.Operation_NO_OP, true
-	case plans.Update,
-		plans.DeleteThenCreate,
-		plans.CreateThenDelete,
-		plans.CreateThenForget:
+	case plans.Update:
 		return proto.Operation_UPDATE, true
+	case plans.DeleteThenCreate,
+		plans.CreateThenDelete:
+		return proto.Operation_REPLACE, true
 	default:
 		return 0, false
 	}

--- a/internal/terraform/node_query_resource_policy_test.go
+++ b/internal/terraform/node_query_resource_policy_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -82,7 +83,8 @@ func TestQueryPolicyNodeInsertion_CountMatchesResources(t *testing.T) {
 	insertQueryPolicyNodes(t, inputs, ctx, n)
 
 	// Verify N nodes in policy subgraph
-	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](ps.graph.VerticesSeq()).Collect()
+	g := ps.evalGraph(trace.SpanFromContext(context.Background()))
+	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](g.VerticesSeq()).Collect()
 	if len(nodes) != count {
 		t.Errorf("expected %d policy nodes, got %d", count, len(nodes))
 	}
@@ -121,8 +123,8 @@ func TestQueryPolicyNodeInsertion_UnknownResourcesSkipped(t *testing.T) {
 	}
 
 	insertQueryPolicyNodes(t, inputs, ctx, n)
-
-	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](ps.graph.VerticesSeq()).Collect()
+	g := ps.evalGraph(trace.SpanFromContext(context.Background()))
+	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](g.VerticesSeq()).Collect()
 
 	// Verify N nodes in policy subgraph, accounting for skipped unknowns
 	if len(nodes) != 2 {
@@ -158,7 +160,8 @@ func TestQueryPolicyNodeInsertion_NodePayload(t *testing.T) {
 
 	insertQueryPolicyNodes(t, inputs, ctx, n)
 
-	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](ps.graph.VerticesSeq()).Collect()
+	g := ps.evalGraph(trace.SpanFromContext(context.Background()))
+	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](g.VerticesSeq()).Collect()
 	if len(nodes) != 1 {
 		t.Fatalf("expected 1 policy node, got %d", len(nodes))
 	}
@@ -264,35 +267,26 @@ func TestQueryPolicyNodeInsertion_NodeIndependence(t *testing.T) {
 	insertQueryPolicyNodes(t, inputs, ctx, n)
 
 	// Collect all nodeQueryResourcePolicy nodes
-	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](ps.graph.VerticesSeq()).Collect()
+	g := ps.evalGraph(trace.SpanFromContext(context.Background()))
+	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](g.VerticesSeq()).Collect()
 	if len(nodes) != count {
 		t.Fatalf("expected %d policy nodes, got %d", count, len(nodes))
 	}
 
 	// Verify no edges exist between any pair of nodeQueryResourcePolicy nodes
 	for _, node := range nodes {
-		for dep := range ps.graph.EdgesFrom(node).All() {
+		for dep := range g.EdgesFrom(node).All() {
 			if _, ok := dep.(*nodeQueryResourcePolicy); ok {
 				t.Errorf("found edge from %s to %s; policy nodes must be independent with no inter-node edges",
 					node.Name(), dep.Name())
 			}
 		}
 
-		for dep := range ps.graph.EdgesTo(node).All() {
+		for dep := range g.EdgesTo(node).All() {
 			if _, ok := dep.(*nodeQueryResourcePolicy); ok {
 				t.Errorf("found edge from %s to %s; policy nodes must be independent with no inter-node edges",
 					dep.Name(), node.Name())
 			}
-		}
-	}
-
-	// Verify the total number of edges in the subgraph is zero
-	// (before finish node is added by DynamicExpand)
-	edges := ps.graph.Edges()
-	if len(edges) != 0 {
-		t.Errorf("expected 0 edges between policy nodes in subgraph, got %d edges", len(edges))
-		for _, edge := range edges {
-			t.Logf("  edge: %s -> %s", edge.Source.Name(), edge.Target.Name())
 		}
 	}
 }

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -334,6 +334,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		return diags
 	}
 
+	// after destroy, we still need to evaluate policy
+	n.addPolicyNode(ctx, change, state)
+
 	// after destroy we continue to use the before value, since there is no after
 	diags = diags.Append(n.invokeDestroyActions(ctx, configs.AfterDestroy, op))
 

--- a/internal/terraform/policy_test.go
+++ b/internal/terraform/policy_test.go
@@ -166,9 +166,9 @@ func TestPolicyOperationForAction(t *testing.T) {
 	}{
 		{name: "create", action: plans.Create, want: proto.Operation_CREATE, wantValid: true},
 		{name: "update", action: plans.Update, want: proto.Operation_UPDATE, wantValid: true},
-		{name: "delete-then-create", action: plans.DeleteThenCreate, want: proto.Operation_UPDATE, wantValid: true},
-		{name: "create-then-delete", action: plans.CreateThenDelete, want: proto.Operation_UPDATE, wantValid: true},
-		{name: "create-then-forget", action: plans.CreateThenForget, want: proto.Operation_UPDATE, wantValid: true},
+		{name: "delete-then-create", action: plans.DeleteThenCreate, want: proto.Operation_REPLACE, wantValid: true},
+		{name: "create-then-delete", action: plans.CreateThenDelete, want: proto.Operation_REPLACE, wantValid: true},
+		{name: "create-then-forget", action: plans.CreateThenForget, want: proto.Operation_CREATE, wantValid: true},
 		{name: "delete", action: plans.Delete, want: proto.Operation_DELETE, wantValid: true},
 		{name: "no-op", action: plans.NoOp, want: proto.Operation_NO_OP, wantValid: true},
 		{name: "read", action: plans.Read, wantValid: false},


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

When a resource is replaced (forced replacement or `create_before_destroy`), Terraform previously evaluated policy separately for each underlying operation, i.e. two evaluations for a replacement, one for the create and one
for the delete. Depending on the matching logic in policy, this could lead to duplicate policy evaluation results

This change collapses a replacement's paired create/delete policy nodes into a single `nodeResourcePolicy` marked with the new `REPLACE` operation, so the policy plugin receives one evaluation representing the full replacement.


This PR updates policy evaluation for replacement operations so that replacements are evaluated as a coordinated create/delete operation while preserving correlated diagnostics in the response, so that violations are reported in the context of a single replacement.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
