### PR TITLE
refactor: Rename`views.ProviderInstaller` to `views.ProviderInstallationLogger`

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -929,14 +929,14 @@ func (c *InitCommand) Synopsis() string {
 }
 
 // Returns a reused callback function for the ProviderAlreadyInstalled event in a providercache.InstallerEvents struct.
-func providerAlreadyInstalledCallback(view views.ProviderInstaller) func(provider addrs.Provider, selectedVersion getproviders.Version) {
+func providerAlreadyInstalledCallback(view views.ProviderInstallationLogger) func(provider addrs.Provider, selectedVersion getproviders.Version) {
 	return func(provider addrs.Provider, selectedVersion getproviders.Version) {
 		view.LogProviderVersionAlreadyInstalled(provider, selectedVersion)
 	}
 }
 
 // Returns a reused callback function for the BuiltInProviderAvailable event in a providercache.InstallerEvents struct.
-func builtInProviderAvailableCallback(view views.ProviderInstaller) func(provider addrs.Provider) {
+func builtInProviderAvailableCallback(view views.ProviderInstallationLogger) func(provider addrs.Provider) {
 	return func(provider addrs.Provider) {
 		view.LogBuiltInProviderAvailable(provider)
 	}
@@ -954,14 +954,14 @@ func builtInProviderFailureCallback(diags *tfdiags.Diagnostics) func(provider ad
 }
 
 // Returns a reused callback function for the LinkFromCacheBegin event in a providercache.InstallerEvents struct.
-func linkFromCacheBeginCallback(view views.ProviderInstaller) func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
+func linkFromCacheBeginCallback(view views.ProviderInstallationLogger) func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
 	return func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
 		view.LogUsingProviderVersionFromCacheDir(provider, version)
 	}
 }
 
 // Returns a reused callback function for the FetchPackageBegin event in a providercache.InstallerEvents struct.
-func fetchPackageBeginCallback(view views.ProviderInstaller) func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
+func fetchPackageBeginCallback(view views.ProviderInstallationLogger) func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
 	return func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
 		view.LogInstallingProviderVersion(provider, version)
 	}
@@ -1202,7 +1202,7 @@ func fetchPackageFailureCallback(diags *tfdiags.Diagnostics, reqs getproviders.R
 }
 
 // Returns a reused callback function for the FetchPackageSuccess event in a providercache.InstallerEvents struct.
-func fetchPackageSuccessCallback(view views.ProviderInstaller) func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {
+func fetchPackageSuccessCallback(view views.ProviderInstallationLogger) func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {
 	return func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {
 		var keyID string
 		if authResult != nil && authResult.ThirdPartySigned() {
@@ -1257,7 +1257,7 @@ func providersLockUpdatedCallback(incompleteProviders *[]string) func(provider a
 }
 
 // Returns a reused callback function for the ProvidersFetched event in a providercache.InstallerEvents struct.
-func providersFetchedCallback(view views.ProviderInstaller) func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
+func providersFetchedCallback(view views.ProviderInstallationLogger) func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
 	return func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
 		thirdPartySigned := false
 		for _, authResult := range authResults {

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -3104,7 +3104,7 @@ func (m *Meta) determineSafeProviderInstallAction(provider addrs.Provider, provi
 // handleSafeProviderInstallAction takes the action determined by `determineSafeProviderInstallAction` and either prompts the user for approval, or returns an error if something has gone wrong with pre-supplied locks when Terraform was run in automation.
 //
 // NOTE: the command parameter is used to determine which command is being run, so that we can provide more specific guidance to the user. Do not use that parameter for any other purpose!
-func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInstallAction, provider addrs.Provider, stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult, stateStoreProviderLock, locksBeforeInstall *depsfile.Locks, flagLockfilePath string, command cli.Command, view views.ProviderInstaller) tfdiags.Diagnostics {
+func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInstallAction, provider addrs.Provider, stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult, stateStoreProviderLock, locksBeforeInstall *depsfile.Locks, flagLockfilePath string, command cli.Command, view views.ProviderInstallationLogger) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	switch action {

--- a/internal/command/meta_dependencies.go
+++ b/internal/command/meta_dependencies.go
@@ -143,7 +143,7 @@ func (m *Meta) annotateDependencyLocksWithOverrides(ret *depsfile.Locks) *depsfi
 // saveDependencyLockFile can overwrite the contents of the dependency lock file.
 // If the locks match the previous locks, then the file is not updated and no output is produced.
 // If a "readonly" -lockfile flag is supplied then changing the file is blocked.
-func (m *Meta) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, incompleteProviders []string, flagLockfile string, view views.ProviderInstaller) (output bool, diags tfdiags.Diagnostics) {
+func (m *Meta) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, incompleteProviders []string, flagLockfile string, view views.ProviderInstallationLogger) (output bool, diags tfdiags.Diagnostics) {
 	// If the provider dependencies have changed since the last run then we'll
 	// say a little about that in case the reader wasn't expecting a change.
 	// (When we later integrate module dependencies into the lock file we'll

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -23,7 +23,7 @@ type Init interface {
 	Output(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
 
-	ProviderInstaller
+	ProviderInstallationLogger
 
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
@@ -53,8 +53,8 @@ type InitHuman struct {
 }
 
 var (
-	_ Init              = (*InitHuman)(nil)
-	_ ProviderInstaller = (*InitHuman)(nil)
+	_ Init                       = (*InitHuman)(nil)
+	_ ProviderInstallationLogger = (*InitHuman)(nil)
 )
 
 func (v *InitHuman) Diagnostics(diags tfdiags.Diagnostics) {
@@ -162,8 +162,8 @@ type InitJSON struct {
 }
 
 var (
-	_ Init              = (*InitJSON)(nil)
-	_ ProviderInstaller = (*InitJSON)(nil)
+	_ Init                       = (*InitJSON)(nil)
+	_ ProviderInstallationLogger = (*InitJSON)(nil)
 )
 
 func (v *InitJSON) Diagnostics(diags tfdiags.Diagnostics) {

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -8,11 +8,11 @@ import (
 	"github.com/hashicorp/terraform/internal/getproviders"
 )
 
-// ProviderInstaller is an interface that describes the methods required by a view that's used
+// ProviderInstallationLogger is an interface that describes the methods required by a view that's used
 // with provider installation methods.
 //
 // The `Output` method is a constraint from the Init view interface, which will be refactored away soon.
-type ProviderInstaller interface {
+type ProviderInstallationLogger interface {
 	Output(messageCode InitMessageCode, params ...any)
 
 	// LogProviderVersionSuccess describes a successfully installed provider along with its version

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -49,7 +49,7 @@ type StateMigrate interface {
 	Log(message string, params ...any)
 	Diagnostics(diags tfdiags.Diagnostics)
 
-	ProviderInstaller
+	ProviderInstallationLogger
 	Spacer // The `state migrate` command logs empty lines to space-out different sections of human-readable output
 }
 
@@ -63,9 +63,9 @@ func NewStateMigrate(viewType arguments.ViewType, view *View) StateMigrate {
 }
 
 var (
-	_ StateMigrate      = (*StateMigrateHuman)(nil)
-	_ ProviderInstaller = (*StateMigrateHuman)(nil)
-	_ Spacer            = (*StateMigrateHuman)(nil)
+	_ StateMigrate               = (*StateMigrateHuman)(nil)
+	_ ProviderInstallationLogger = (*StateMigrateHuman)(nil)
+	_ Spacer                     = (*StateMigrateHuman)(nil)
 )
 
 type StateMigrateHuman struct {
@@ -90,7 +90,7 @@ func (s *StateMigrateHuman) Spacer() {
 	s.view.Spacer()
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 	msg, ok := MessageRegistry[code]
 	if !ok {
@@ -99,7 +99,7 @@ func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 	s.Log(msg.HumanValue, params...)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogInitializingStateStoreProviderPlugin(pAddr tfaddr.Provider, cons getproviders.VersionConstraints, storeType string) {
 	consSuffix := ""
 	if len(cons) > 0 {
@@ -110,63 +110,63 @@ func (s *StateMigrateHuman) LogInitializingStateStoreProviderPlugin(pAddr tfaddr
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints) {
 	params := []any{providerAddr.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints)}
 	msg := s.prepareMessage(FindingMatchingVersionMessage, params...)
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogFindingLatestVersion(providerAddr addrs.Provider) {
 	params := []any{providerAddr.ForDisplay()}
 	msg := s.prepareMessage(FindingLatestVersionMessage, params...)
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogProviderVersionAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	msg := s.prepareMessage(ProviderAlreadyInstalledMessage, params...)
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogUsingProviderVersionFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	msg := s.prepareMessage(UsingProviderFromCacheDirInfo, params...)
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
 	params := []any{providerAddr.ForDisplay()}
 	msg := s.prepareMessage(BuiltInProviderAvailableMessage, params...)
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogInstallingProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	msg := s.prepareMessage(InstallingProviderMessage, params...)
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogReusingPreviousProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{version, providerAddr.ForDisplay()}
 	msg := s.prepareMessage(ReusingPreviousVersionInfo, params...)
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
 	keyDetails := fmt.Sprintf(", key ID [reset][bold]%s[reset]", keyID) // key id needs to be formatted for human output
 	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
@@ -175,13 +175,13 @@ func (s *StateMigrateHuman) LogProviderVersionSuccessWithKeyID(providerAddr addr
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) LogPartnerAndCommunityProviders() {
 	msg := s.prepareMessage(PartnerAndCommunityProvidersMessage)
 	s.log(msg)
 }
 
-// Implements ProviderInstaller interface.
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateHuman) prepareMessage(code InitMessageCode, params ...any) string {
 	message, ok := MessageRegistry[code]
 	if !ok {


### PR DESCRIPTION
Addresses feedback at https://github.com/hashicorp/terraform/pull/38871#discussion_r3621210247

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
