### PR TITLE
terraform test: support nested collection mock values

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260730-120000.yaml
+++ b/.changes/v1.17/BUG FIXES-20260730-120000.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'terraform test: Support overriding nested collection attributes in Plugin Framework provider schemas'
+time: 2026-07-30T12:00:00+09:00
+custom:
+    Issue: "38369"

--- a/internal/moduletest/mocking/fill.go
+++ b/internal/moduletest/mocking/fill.go
@@ -23,14 +23,14 @@ func FillAttribute(in cty.Value, attribute *configschema.Attribute) (cty.Value, 
 
 func fillAttribute(in cty.Value, attribute *configschema.Attribute, path cty.Path) (cty.Value, error) {
 	if attribute.NestedType != nil {
-
-		// Then the in value must be an object.
-		if !in.Type().IsObjectType() {
-			return cty.NilVal, path.NewErrorf("incompatible types; expected object type, found %s", in.Type().FriendlyName())
-		}
-
 		switch attribute.NestedType.Nesting {
 		case configschema.NestingSingle, configschema.NestingGroup:
+			// Single nested attributes represent one object, so their mocked
+			// value must also be an object.
+			if !in.Type().IsObjectType() {
+				return cty.NilVal, path.NewErrorf("incompatible types; expected object type, found %s", in.Type().FriendlyName())
+			}
+
 			var names []string
 			for name := range attribute.NestedType.Attributes {
 				names = append(names, name)
@@ -57,12 +57,25 @@ func fillAttribute(in cty.Value, attribute *configschema.Attribute, path cty.Pat
 				children[name] = GenerateValueForAttribute(attribute.NestedType.Attributes[name])
 			}
 			return cty.ObjectVal(children), nil
-		case configschema.NestingSet:
-			return cty.SetValEmpty(attribute.ImpliedType().ElementType()), nil
-		case configschema.NestingList:
-			return cty.ListValEmpty(attribute.ImpliedType().ElementType()), nil
-		case configschema.NestingMap:
-			return cty.MapValEmpty(attribute.ImpliedType().ElementType()), nil
+		case configschema.NestingSet, configschema.NestingList, configschema.NestingMap:
+			// An object mock is a legacy shorthand for an element template. There
+			// are no collection elements to apply it to here, so preserve the
+			// existing empty-collection behavior.
+			if in.Type().IsObjectType() {
+				switch attribute.NestedType.Nesting {
+				case configschema.NestingSet:
+					return cty.SetValEmpty(attribute.ImpliedType().ElementType()), nil
+				case configschema.NestingList:
+					return cty.ListValEmpty(attribute.ImpliedType().ElementType()), nil
+				default:
+					return cty.MapValEmpty(attribute.ImpliedType().ElementType()), nil
+				}
+			}
+
+			// HCL collection literals have tuple/object types. Reuse fillType so
+			// they are coerced to the nested collection type and each object is
+			// filled using the nested attribute schema.
+			return fillType(in, attribute.NestedType.ConfigType(), path)
 		default:
 			panic(fmt.Errorf("unknown nesting mode: %d", attribute.NestedType.Nesting))
 		}

--- a/internal/moduletest/mocking/fill_test.go
+++ b/internal/moduletest/mocking/fill_test.go
@@ -8,7 +8,70 @@ import (
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 )
+
+func TestFillAttributeNestedCollections(t *testing.T) {
+	nestedAttributes := map[string]*configschema.Attribute{
+		"id": {
+			Type: cty.String,
+		},
+	}
+
+	tests := map[string]struct {
+		nesting  configschema.NestingMode
+		in       cty.Value
+		expected cty.Value
+	}{
+		"list accepts an HCL tuple": {
+			nesting: configschema.NestingList,
+			in: cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("first")}),
+			}),
+			expected: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("first")}),
+			}),
+		},
+		"set accepts an HCL tuple": {
+			nesting: configschema.NestingSet,
+			in: cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("first")}),
+			}),
+			expected: cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("first")}),
+			}),
+		},
+		"map accepts a map": {
+			nesting: configschema.NestingMap,
+			in: cty.MapVal(map[string]cty.Value{
+				"first": cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("first")}),
+			}),
+			expected: cty.MapVal(map[string]cty.Value{
+				"first": cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("first")}),
+			}),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			attribute := &configschema.Attribute{
+				NestedType: &configschema.Object{
+					Attributes: nestedAttributes,
+					Nesting:    test.nesting,
+				},
+			}
+
+			actual, err := FillAttribute(test.in, attribute)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !test.expected.RawEquals(actual) {
+				t.Errorf("expected:%s\nactual:   %s", test.expected.GoString(), actual.GoString())
+			}
+		})
+	}
+}
 
 func TestFillType(t *testing.T) {
 	tcs := map[string]struct {

--- a/internal/moduletest/mocking/values_test.go
+++ b/internal/moduletest/mocking/values_test.go
@@ -566,6 +566,43 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				})),
 			}),
 		},
+		"nested_list_attribute_computed_overridden": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				}))),
+			}),
+			with: cty.ObjectVal(map[string]cty.Value{
+				// HCL list literals are represented as tuples before they are
+				// coerced against the provider schema.
+				"nested": cty.TupleVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"id":    cty.StringVal("myvalue"),
+						"value": cty.StringVal("one"),
+					}),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Attributes: computedAttributes,
+							Nesting:    configschema.NestingList,
+						},
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"id":    cty.StringVal("myvalue"),
+						"value": cty.StringVal("one"),
+					}),
+				}),
+			}),
+		},
 		"nested_set_attribute": {
 			target: cty.ObjectVal(map[string]cty.Value{
 				"nested": cty.SetVal([]cty.Value{


### PR DESCRIPTION
## Problem

override_data values for Plugin Framework nested_type list and set attributes are represented as HCL tuples. Terraform rejected them before coercing them to the provider schema, so terraform test could not use these overrides.

## Change

Nested single and group attributes still require object values. Nested list, set, and map attributes now use the existing collection conversion path with the nested schema ConfigType, which converts supported collection values and fills nested objects.

## Tests

- go test ./internal/moduletest/mocking — passed

Focused regression coverage exercises a data-source override containing an HCL tuple for a nested list attribute, as well as list, set, and map conversion cases.

Not run: the full Terraform test suite.

## Notes

Object inputs for nested collection attributes retain the existing empty-collection element-template behavior.

Fixes #38369.

## Changelog

Included a 1.17 bug-fix entry.