### PR TITLE
communicator/ssh: redact certificate authentication errors

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260730-164636.yaml
+++ b/.changes/v1.17/BUG FIXES-20260730-164636.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'communicator/ssh: prevent private key and certificate data from appearing in SSH authentication errors'
+time: 2026-07-30T16:46:36+09:00
+custom:
+    Issue: "38949"

--- a/internal/communicator/ssh/provisioner.go
+++ b/internal/communicator/ssh/provisioner.go
@@ -397,22 +397,22 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 func signCertWithPrivateKey(pk string, certificate string) (ssh.AuthMethod, error) {
 	rawPk, err := ssh.ParseRawPrivateKey([]byte(pk))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse private key %q: %s", pk, err)
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
 	}
 
 	pcert, _, _, _, err := ssh.ParseAuthorizedKey([]byte(certificate))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse certificate %q: %s", certificate, err)
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
 	}
 
 	usigner, err := ssh.NewSignerFromKey(rawPk)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create signer from raw private key %q: %s", rawPk, err)
+		return nil, fmt.Errorf("failed to create signer from raw private key: %w", err)
 	}
 
 	ucertSigner, err := ssh.NewCertSigner(pcert.(*ssh.Certificate), usigner)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cert signer %q: %s", usigner, err)
+		return nil, fmt.Errorf("failed to create cert signer: %w", err)
 	}
 
 	return ssh.PublicKeys(ucertSigner), nil

--- a/internal/communicator/ssh/provisioner_test.go
+++ b/internal/communicator/ssh/provisioner_test.go
@@ -4,10 +4,36 @@
 package ssh
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
 )
+
+func TestSignCertWithPrivateKeyRedactsCredentials(t *testing.T) {
+	const privateKey = "private key that must not be included in errors"
+	const certificate = "certificate that must not be included in errors"
+
+	t.Run("private key", func(t *testing.T) {
+		_, err := signCertWithPrivateKey(privateKey, certificate)
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if strings.Contains(err.Error(), privateKey) {
+			t.Fatalf("private key leaked in error: %s", err)
+		}
+	})
+
+	t.Run("certificate", func(t *testing.T) {
+		_, err := signCertWithPrivateKey(SERVER_PEM, certificate)
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if strings.Contains(err.Error(), certificate) {
+			t.Fatalf("certificate leaked in error: %s", err)
+		}
+	})
+}
 
 func TestProvisioner_connInfo(t *testing.T) {
 	v := cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
## Problem
SSH certificate authentication errors include private-key or certificate material in terminal and CI logs.

## Change
Return the underlying SSH parsing and signer errors without formatting credential values into the error message. Add a 1.17 changelog entry for the user-visible security fix.

## Tests
- C:/Program Files/Go/bin/go.exe test ./internal/communicator/ssh -count=1 — passed

## Target Release
1.17.x

## Rollback Plan
Revert this PR to restore the previous error-message formatting.

## Changes to Security Controls
SSH authentication errors no longer include private key or certificate material in terminal and CI logs.

Fixes #38577