### PR TITLE
Support referencing modules with dynamic sources in Terraform Test

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260730-122835.yaml
+++ b/.changes/v1.16/BUG FIXES-20260730-122835.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Support referencing modules containing dynamic sources in Terraform Test
+time: 2026-07-30T12:28:35.476948+02:00
+custom:
+    Issue: "38950"

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/internal/terraform"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/hashicorp/terraform/version"
 )
 
@@ -181,7 +182,7 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false)
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
@@ -209,6 +210,12 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 	}
 
 	return config, snap
+}
+
+func testModuleInstallerInitializer(loader *configload.Loader) initwd.Initializer {
+	return func(rootMod *configs.Module, walker configs.ModuleWalker) (*configs.Config, tfdiags.Diagnostics) {
+		return terraform.BuildConfigWithGraph(rootMod, walker, nil, configs.MockDataLoaderFunc(loader.LoadExternalMockData))
+	}
 }
 
 // testPlan returns a non-nil noop plan.

--- a/internal/command/graph_mermaid_test.go
+++ b/internal/command/graph_mermaid_test.go
@@ -62,7 +62,7 @@ func TestGraph_resourcesOnly_mermaid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	inst := initwd.NewModuleInstaller(".terraform/modules", loader, registry.NewClient(nil, nil), nil)
+	inst := initwd.NewModuleInstaller(".terraform/modules", loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	_, instDiags := inst.InstallModules(context.Background(), ".", "tests", true, false)
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -225,7 +225,7 @@ func TestGraph_resourcesOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	inst := initwd.NewModuleInstaller(".terraform/modules", loader, registry.NewClient(nil, nil), nil)
+	inst := initwd.NewModuleInstaller(".terraform/modules", loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	_, instDiags := inst.InstallModules(context.Background(), ".", "tests", true, false)
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())

--- a/internal/command/init2_test.go
+++ b/internal/command/init2_test.go
@@ -8,6 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/modsdir"
+	"github.com/hashicorp/terraform/internal/terminal"
 )
 
 func TestInit2_dynamicSourceErrors(t *testing.T) {
@@ -204,6 +208,76 @@ func TestInit2_dynamicSourceSuccess(t *testing.T) {
 			testOutput := done(t)
 			if code != 0 {
 				t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, testOutput.Stderr(), testOutput.Stdout())
+			}
+		})
+	}
+}
+
+func TestInit2_dynamicSourceInTestModule(t *testing.T) {
+	tests := map[string]struct {
+		fixture     string
+		args        []string
+		manifestKey string
+	}{
+		"required variable": {
+			fixture:     "test-module-required-variable",
+			args:        []string{"-var", "module_src=../modules/simple"},
+			manifestKey: "test.main.dynamic_source.const_var_source",
+		},
+		"module in same directory": {
+			fixture:     "test-module-same-directory",
+			manifestKey: "test.main.dynamic_source.const_var_source",
+		},
+		"local value": {
+			fixture:     "test-module-local-value",
+			manifestKey: "test.main.dynamic_source.const_var_source",
+		},
+		"nested test file": {
+			fixture:     "test-module-nested-test-file",
+			manifestKey: "test.tests.dynamic.dynamic_source.const_var_source",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			td := t.TempDir()
+			testCopyDir(t, testFixturePath(filepath.Join("dynamic-module-sources", tc.fixture)), td)
+			t.Chdir(td)
+
+			streams, done := terminal.StreamsForTesting(t)
+			meta := Meta{
+				Ui:      testUiWrapped(t),
+				View:    views.NewView(streams),
+				Streams: streams,
+			}
+
+			init := &InitCommand{Meta: meta}
+			if code := init.Run(tc.args); code != 0 {
+				output := done(t)
+				t.Fatalf("init failed with exit status %d\nstderr:\n%s\n\nstdout:\n%s", code, output.Stderr(), output.Stdout())
+			}
+			done(t)
+
+			manifest, err := modsdir.ReadManifestSnapshotForDir(filepath.Join(td, ".terraform", "modules"))
+			if err != nil {
+				t.Fatalf("failed to read module manifest: %s", err)
+			}
+			if _, exists := manifest[tc.manifestKey]; !exists {
+				t.Errorf("module manifest does not contain %q", tc.manifestKey)
+			}
+
+			streams, done = terminal.StreamsForTesting(t)
+			meta.Streams = streams
+			meta.View = views.NewView(streams)
+
+			test := &TestCommand{Meta: meta}
+			code := test.Run(append(tc.args, "-no-color"))
+			output := done(t)
+			if code != 0 {
+				t.Fatalf("test failed with exit status %d\nstderr:\n%s\n\nstdout:\n%s", code, output.Stderr(), output.Stdout())
+			}
+			if !strings.Contains(output.Stdout(), "1 passed, 0 failed.") {
+				t.Fatalf("expected test to pass, got:\n%s", output.Stdout())
 			}
 		})
 	}

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -301,17 +301,10 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 
 	initializer := func(rootMod *configs.Module, walker configs.ModuleWalker) (*configs.Config, tfdiags.Diagnostics) {
 		variables, diags := backendrun.ParseConstVariableValues(m.VariableValues, rootMod.Variables)
-		ctx, ctxDiags := terraform.NewContext(&terraform.ContextOpts{
-			Parallelism: 1,
-		})
-		diags = diags.Append(ctxDiags)
 		if diags.HasErrors() {
 			return nil, diags
 		}
-		return ctx.Init(rootMod, terraform.InitOpts{
-			Walker:       walker,
-			SetVariables: variables,
-		})
+		return terraform.BuildConfigWithGraph(rootMod, walker, variables, configs.MockDataLoaderFunc(loader.LoadExternalMockData))
 	}
 	inst := initwd.NewModuleInstaller(m.modulesDir(), loader, m.registryClient(), initializer)
 

--- a/internal/command/plan_race_test.go
+++ b/internal/command/plan_race_test.go
@@ -58,7 +58,7 @@ func TestPlan_configLoaderRace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create install loader: %s", err)
 	}
-	inst := initwd.NewModuleInstaller(modulesDir, installLoader, registry.NewClient(nil, nil), nil)
+	inst := initwd.NewModuleInstaller(modulesDir, installLoader, registry.NewClient(nil, nil), testModuleInstallerInitializer(installLoader))
 	if _, instDiags := inst.InstallModules(context.Background(), ".", "tests", true, false); instDiags.HasErrors() {
 		t.Fatalf("failed to install modules: %s", instDiags.Err())
 	}

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -5987,7 +5987,7 @@ func testModuleInline(t *testing.T, sources map[string]string) (*configs.Config,
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	_, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false)
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -5994,7 +5994,7 @@ func testModuleInline(t *testing.T, sources map[string]string) (*configs.Config,
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	_, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false)
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())

--- a/internal/command/testdata/dynamic-module-sources/test-module-local-value/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-local-value/main.tf
@@ -1,0 +1,2 @@
+# The root module is intentionally empty. The dynamic module call is in the
+# alternate module under test.

--- a/internal/command/testdata/dynamic-module-sources/test-module-local-value/main.tftest.hcl
+++ b/internal/command/testdata/dynamic-module-sources/test-module-local-value/main.tftest.hcl
@@ -1,0 +1,12 @@
+run "dynamic_source" {
+  command = plan
+
+  module {
+    source = "./testing"
+  }
+
+  assert {
+    condition     = module.const_var_source.message == "hello"
+    error_message = "unexpected message from dynamically-sourced module"
+  }
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-local-value/modules/simple/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-local-value/modules/simple/main.tf
@@ -1,0 +1,3 @@
+output "message" {
+  value = "hello"
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-local-value/testing/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-local-value/testing/main.tf
@@ -1,0 +1,13 @@
+variable "module_name" {
+  type    = string
+  default = "simple"
+  const   = true
+}
+
+locals {
+  module_src = "../modules/${var.module_name}"
+}
+
+module "const_var_source" {
+  source = local.module_src
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-nested-test-file/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-nested-test-file/main.tf
@@ -1,0 +1,2 @@
+# The root module is intentionally empty. The dynamic module call is in the
+# alternate module under test.

--- a/internal/command/testdata/dynamic-module-sources/test-module-nested-test-file/modules/simple/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-nested-test-file/modules/simple/main.tf
@@ -1,0 +1,3 @@
+output "message" {
+  value = "hello"
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-nested-test-file/testing/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-nested-test-file/testing/main.tf
@@ -1,0 +1,9 @@
+variable "module_src" {
+  type    = string
+  default = "../modules/simple"
+  const   = true
+}
+
+module "const_var_source" {
+  source = var.module_src
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-nested-test-file/tests/dynamic.tftest.hcl
+++ b/internal/command/testdata/dynamic-module-sources/test-module-nested-test-file/tests/dynamic.tftest.hcl
@@ -1,0 +1,12 @@
+run "dynamic_source" {
+  command = plan
+
+  module {
+    source = "./testing"
+  }
+
+  assert {
+    condition     = module.const_var_source.message == "hello"
+    error_message = "unexpected message from dynamically-sourced module"
+  }
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-required-variable/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-required-variable/main.tf
@@ -1,0 +1,4 @@
+variable "module_src" {
+  type  = string
+  const = true
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-required-variable/main.tftest.hcl
+++ b/internal/command/testdata/dynamic-module-sources/test-module-required-variable/main.tftest.hcl
@@ -1,0 +1,12 @@
+run "dynamic_source" {
+  command = plan
+
+  module {
+    source = "./testing"
+  }
+
+  assert {
+    condition     = module.const_var_source.message == "hello"
+    error_message = "unexpected message from dynamically-sourced module"
+  }
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-required-variable/modules/simple/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-required-variable/modules/simple/main.tf
@@ -1,0 +1,3 @@
+output "message" {
+  value = "hello"
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-required-variable/testing/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-required-variable/testing/main.tf
@@ -1,0 +1,8 @@
+variable "module_src" {
+  type  = string
+  const = true
+}
+
+module "const_var_source" {
+  source = var.module_src
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-same-directory/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-same-directory/main.tf
@@ -1,0 +1,9 @@
+variable "module_src" {
+  type    = string
+  default = "./modules/simple"
+  const   = true
+}
+
+module "const_var_source" {
+  source = var.module_src
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-same-directory/main.tftest.hcl
+++ b/internal/command/testdata/dynamic-module-sources/test-module-same-directory/main.tftest.hcl
@@ -1,0 +1,12 @@
+run "dynamic_source" {
+  command = plan
+
+  module {
+    source = "./."
+  }
+
+  assert {
+    condition     = module.const_var_source.message == "hello"
+    error_message = "unexpected message from dynamically-sourced module"
+  }
+}

--- a/internal/command/testdata/dynamic-module-sources/test-module-same-directory/modules/simple/main.tf
+++ b/internal/command/testdata/dynamic-module-sources/test-module-same-directory/modules/simple/main.tf
@@ -1,0 +1,3 @@
+output "message" {
+  value = "hello"
+}

--- a/internal/configs/config_build.go
+++ b/internal/configs/config_build.go
@@ -34,16 +34,18 @@ func BuildConfig(root *Module, walker ModuleWalker, loader MockDataLoader) (*Con
 	}
 	cfg.Root = cfg // Root module is self-referential.
 	cfg.Children, diags = buildChildModules(cfg, walker)
-	diags = append(diags, FinalizeConfig(cfg, walker, loader)...)
+	diags = append(diags, LegacyFinalizeConfig(cfg, walker, loader)...)
 
 	return cfg, diags
 }
 
-// FinalizeConfig performs the post-load validation and setup steps that are
-// shared by different configuration loaders.
+// LegacyFinalizeConfig performs the post-load validation and setup steps that are
+// shared by different configuration loaders. It should be replaced with
+// FinalizeConfig in the long term, but is kept around for now to support
+// BuildConfig.
 //
 // Callers must ensure cfg.Root is set correctly before calling this function.
-func FinalizeConfig(cfg *Config, walker ModuleWalker, loader MockDataLoader) hcl.Diagnostics {
+func LegacyFinalizeConfig(cfg *Config, walker ModuleWalker, loader MockDataLoader) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 	if cfg == nil {
 		return diags
@@ -62,6 +64,35 @@ func FinalizeConfig(cfg *Config, walker ModuleWalker, loader MockDataLoader) hcl
 			stateProviderDiags := cfg.resolveStateStoreProviderType()
 			diags = append(diags, stateProviderDiags...)
 		}
+	}
+
+	diags = append(diags, validateProviderConfigs(nil, cfg, nil)...)
+	diags = append(diags, validateProviderConfigsForTests(cfg)...)
+
+	// Final step, let's side load any external mock data into our test files.
+	diags = append(diags, installMockDataFiles(cfg, loader)...)
+
+	return diags
+}
+
+// FinalizeConfig performs the post-load validation and setup steps that are
+// shared by different configuration loaders.
+//
+// Callers must ensure cfg.Root is set correctly before calling this function.
+func FinalizeConfig(cfg *Config, loader MockDataLoader) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	if cfg == nil {
+		return diags
+	}
+
+	// Now that the config is built, we can connect the provider names to all
+	// the known types for validation.
+	providers := cfg.resolveProviderTypes()
+	cfg.resolveProviderTypesForTests(providers)
+
+	if cfg.Module != nil && cfg.Module.StateStore != nil {
+		stateProviderDiags := cfg.resolveStateStoreProviderType()
+		diags = append(diags, stateProviderDiags...)
 	}
 
 	diags = append(diags, validateProviderConfigs(nil, cfg, nil)...)

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -150,10 +150,10 @@ func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir 
 	} else {
 		cfg, instDiags = i.installDescendantModules(rootMod, walker, installErrsOnly)
 		diags = diags.Append(instDiags)
-	}
 
-	finalDiags := configs.FinalizeConfig(cfg, walker, configs.MockDataLoaderFunc(i.loader.LoadExternalMockData))
-	diags = diags.Append(finalDiags)
+		finalDiags := configs.LegacyFinalizeConfig(cfg, walker, configs.MockDataLoaderFunc(i.loader.LoadExternalMockData))
+		diags = diags.Append(finalDiags)
+	}
 
 	if diags.HasErrors() {
 		return nil, diags

--- a/internal/terraform/config_graph_build.go
+++ b/internal/terraform/config_graph_build.go
@@ -4,6 +4,10 @@
 package terraform
 
 import (
+	"path"
+	"strings"
+
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -14,18 +18,7 @@ import (
 func BuildConfigWithGraph(rootMod *configs.Module, walker configs.ModuleWalker, vars InputValues, loader configs.MockDataLoader) (*configs.Config, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ctx, ctxDiags := NewContext(&ContextOpts{
-		Parallelism: 1,
-	})
-	diags = diags.Append(ctxDiags)
-	if ctxDiags.HasErrors() {
-		return nil, diags
-	}
-
-	cfg, initDiags := ctx.Init(rootMod, InitOpts{
-		Walker:       walker,
-		SetVariables: vars,
-	})
+	cfg, initDiags := initConfigWithGraph(rootMod, walker, vars, nil)
 	diags = diags.Append(initDiags)
 	if diags.HasErrors() {
 		if cfg == nil && rootMod != nil {
@@ -35,8 +28,83 @@ func BuildConfigWithGraph(rootMod *configs.Module, walker configs.ModuleWalker, 
 		return cfg, diags
 	}
 
-	finalDiags := configs.FinalizeConfig(cfg, walker, loader)
+	testDiags := loadTestModulesWithGraph(cfg, walker, vars)
+	diags = diags.Append(testDiags)
+
+	finalDiags := configs.FinalizeConfig(cfg, loader)
 	diags = diags.Append(finalDiags)
 
 	return cfg, diags
+}
+
+func loadTestModulesWithGraph(root *configs.Config, walker configs.ModuleWalker, vars InputValues) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	for name, file := range root.Module.Tests {
+		for _, run := range file.Runs {
+			if run.Module == nil {
+				continue
+			}
+
+			// We want to make sure the path for the testing modules are unique
+			// so we create a dedicated path for them.
+			//
+			// Some examples:
+			//    - file: main.tftest.hcl, run: setup - test.main.setup
+			//    - file: tests/main.tftest.hcl, run: setup - test.tests.main.setup
+
+			dir := path.Dir(name)
+			base := path.Base(name)
+
+			path := addrs.Module{}
+			path = append(path, "test")
+			if dir != "." {
+				path = append(path, strings.Split(dir, "/")...)
+			}
+			path = append(path, strings.TrimSuffix(base, ".tftest.hcl"), run.Name)
+
+			req := &configs.ModuleRequest{
+				Name:              run.Name,
+				Path:              path,
+				SourceAddr:        run.Module.Source,
+				SourceAddrRange:   run.Module.SourceDeclRange,
+				VersionConstraint: run.Module.Version,
+				Parent:            root,
+				CallRange:         run.Module.DeclRange,
+			}
+
+			rootMod, version, loadDiags := walker.LoadModule(req)
+			diags = diags.Append(loadDiags)
+			if loadDiags.HasErrors() || rootMod == nil {
+				continue
+			}
+
+			testCfg, testDiags := initConfigWithGraph(rootMod, walker, vars, path)
+			diags = diags.Append(testDiags)
+			if testCfg != nil {
+				testCfg.CallRange = req.CallRange
+				testCfg.SourceAddr = req.SourceAddr
+				testCfg.SourceAddrRange = req.SourceAddrRange
+				testCfg.Version = version
+				run.ConfigUnderTest = testCfg
+			}
+		}
+	}
+
+	return diags
+}
+
+func initConfigWithGraph(rootMod *configs.Module, walker configs.ModuleWalker, vars InputValues, modulePathPrefix addrs.Module) (*configs.Config, tfdiags.Diagnostics) {
+	ctx, ctxDiags := NewContext(&ContextOpts{
+		Parallelism: 1,
+	})
+	if ctxDiags.HasErrors() {
+		return nil, ctxDiags
+	}
+
+	return ctx.Init(rootMod, InitOpts{
+		Walker:           walker,
+		SetVariables:     vars,
+		ModulePathPrefix: modulePathPrefix,
+	})
 }

--- a/internal/terraform/config_graph_build_test.go
+++ b/internal/terraform/config_graph_build_test.go
@@ -331,6 +331,48 @@ func TestBuildConfigWithGraph_childProviderGrandchildCount(t *testing.T) {
 	})
 }
 
+func TestBuildConfigWithGraph_testModuleWithDynamicSource(t *testing.T) {
+	fixtureDir := filepath.Clean("testdata/config-graph/test-module-dynamic-source")
+	loader, err := configload.NewLoader(&configload.Config{
+		ModulesDir: filepath.Join(fixtureDir, ".terraform/modules"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from NewLoader: %s", err)
+	}
+
+	rootMod, loadDiags := loader.LoadRootModuleWithTests(fixtureDir, "tests")
+	assertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
+
+	config, diags := BuildConfigWithGraph(
+		rootMod,
+		loader.ModuleWalker(),
+		nil,
+		configs.MockDataLoaderFunc(loader.LoadExternalMockData),
+	)
+	assertNoDiagnostics(t, diags)
+
+	run := config.Module.Tests["simple.tftest.hcl"].Runs[0]
+	if run.ConfigUnderTest == nil {
+		t.Fatal("test run configuration was not loaded")
+	}
+	if run.ConfigUnderTest.Children["const_var_source"] == nil {
+		t.Fatal("dynamic module source was not loaded in the test run configuration")
+	}
+	if got := run.ConfigUnderTest.Path.String(); got != "" {
+		t.Errorf("test configuration path is %q; want root path", got)
+	}
+	child := run.ConfigUnderTest.Children["const_var_source"]
+	if got := child.Path.String(); got != "module.const_var_source" {
+		t.Errorf("child configuration path is %q; want %q", got, "module.const_var_source")
+	}
+	if child.Parent != run.ConfigUnderTest || child.Root != run.ConfigUnderTest {
+		t.Error("child configuration is not rooted in the test configuration")
+	}
+	if got := run.ConfigUnderTest.SourceAddr.String(); got != "./testing" {
+		t.Errorf("test configuration source is %q; want %q", got, "./testing")
+	}
+}
+
 func assertNoDiagnostics[D hcl.Diagnostics | tfdiags.Diagnostics](t *testing.T, diags D) bool {
 	t.Helper()
 

--- a/internal/terraform/context_init.go
+++ b/internal/terraform/context_init.go
@@ -12,6 +12,11 @@ import (
 type InitOpts struct {
 	Walker configs.ModuleWalker
 
+	// ModulePathPrefix is prepended to module request paths without changing
+	// their addresses in the resulting configuration. This is used for test
+	// configurations installed under synthetic manifest paths.
+	ModulePathPrefix addrs.Module
+
 	// SetVariables are the raw values for root module variables as provided
 	// by the user who is requesting the run, prior to any normalization or
 	// substitution of defaults. See the documentation for the InputValue
@@ -54,6 +59,7 @@ func (c *Context) initGraph(config *configs.Config, initOpts InitOpts) (*Graph, 
 		Config:             config,
 		RootVariableValues: initOpts.SetVariables,
 		Walker:             initOpts.Walker,
+		ModulePathPrefix:   initOpts.ModulePathPrefix,
 	}).Build(addrs.RootModuleInstance)
 
 	return graph, diags

--- a/internal/terraform/graph_builder_init.go
+++ b/internal/terraform/graph_builder_init.go
@@ -19,6 +19,8 @@ type InitGraphBuilder struct {
 	RootVariableValues InputValues
 
 	Walker configs.ModuleWalker
+
+	ModulePathPrefix addrs.Module
 }
 
 // See GraphBuilder
@@ -50,8 +52,9 @@ func (b *InitGraphBuilder) Steps() []GraphTransformer {
 
 	steps = append(steps, []GraphTransformer{
 		&ModuleTransformer{
-			Config: b.Config,
-			Walker: b.Walker,
+			Config:           b.Config,
+			Walker:           b.Walker,
+			ModulePathPrefix: b.ModulePathPrefix,
 		},
 
 		&LocalTransformer{

--- a/internal/terraform/node_module_install.go
+++ b/internal/terraform/node_module_install.go
@@ -102,6 +102,8 @@ func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdia
 		return diags
 	}
 
+	// Test configurations can have synthetic manifest paths. Prepending a prefix
+	// enables correct installation/loading of these modules.
 	requestPath := n.Addr.Module()
 	requestParent := n.Parent
 	if len(n.ModulePathPrefix) != 0 {

--- a/internal/terraform/node_module_install.go
+++ b/internal/terraform/node_module_install.go
@@ -5,6 +5,7 @@ package terraform
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -26,6 +27,8 @@ type nodeInstallModule struct {
 	ModuleCall *configs.ModuleCall
 	Parent     *configs.Config
 	Walker     configs.ModuleWalker
+
+	ModulePathPrefix addrs.Module
 
 	// Stores the configuration of the installed module
 	Config *configs.Config
@@ -98,13 +101,23 @@ func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdia
 		return diags
 	}
 
+	requestPath := n.Addr.Module()
+	requestParent := n.Parent
+	if len(n.ModulePathPrefix) != 0 {
+		requestPath = append(slices.Clone(n.ModulePathPrefix), requestPath...)
+
+		parent := *n.Parent
+		parent.Path = append(slices.Clone(n.ModulePathPrefix), n.Parent.Path...)
+		requestParent = &parent
+	}
+
 	req := &configs.ModuleRequest{
 		Name:              n.ModuleCall.Name,
-		Path:              n.Addr.Module(),
+		Path:              requestPath,
 		SourceAddr:        source,
 		SourceAddrRange:   n.ModuleCall.SourceExpr.Range(),
 		VersionConstraint: version,
-		Parent:            n.Parent,
+		Parent:            requestParent,
 		CallRange:         n.ModuleCall.DeclRange,
 	}
 
@@ -159,8 +172,9 @@ func (n *nodeInstallModule) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diag
 	expander.SetModuleSingle(n.Path(), call)
 
 	graph, graphDiags := (&InitGraphBuilder{
-		Config: n.Config,
-		Walker: n.Walker,
+		Config:           n.Config,
+		Walker:           n.Walker,
+		ModulePathPrefix: n.ModulePathPrefix,
 	}).Build(n.Addr)
 	diags = diags.Append(graphDiags)
 	if graphDiags.HasErrors() {

--- a/internal/terraform/node_module_install.go
+++ b/internal/terraform/node_module_install.go
@@ -29,6 +29,8 @@ type nodeInstallModule struct {
 	Parent     *configs.Config
 	Walker     configs.ModuleWalker
 
+	ModulePathPrefix addrs.Module
+
 	// Stores the configuration of the installed module
 	Config *configs.Config
 	// Stores the version of the installed module
@@ -100,13 +102,23 @@ func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdia
 		return diags
 	}
 
+	requestPath := n.Addr.Module()
+	requestParent := n.Parent
+	if len(n.ModulePathPrefix) != 0 {
+		requestPath = append(slices.Clone(n.ModulePathPrefix), requestPath...)
+
+		parent := *n.Parent
+		parent.Path = append(slices.Clone(n.ModulePathPrefix), n.Parent.Path...)
+		requestParent = &parent
+	}
+
 	req := &configs.ModuleRequest{
 		Name:              n.ModuleCall.Name,
-		Path:              n.Addr.Module(),
+		Path:              requestPath,
 		SourceAddr:        source,
 		SourceAddrRange:   n.ModuleCall.SourceExpr.Range(),
 		VersionConstraint: version,
-		Parent:            n.Parent,
+		Parent:            requestParent,
 		CallRange:         n.ModuleCall.DeclRange,
 	}
 
@@ -196,8 +208,9 @@ func (n *nodeInstallModule) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diag
 	expander.SetModuleSingle(n.Path(), call)
 
 	graph, graphDiags := (&InitGraphBuilder{
-		Config: n.Config,
-		Walker: n.Walker,
+		Config:           n.Config,
+		Walker:           n.Walker,
+		ModulePathPrefix: n.ModulePathPrefix,
 	}).Build(n.Addr)
 	diags = diags.Append(graphDiags)
 	if graphDiags.HasErrors() {

--- a/internal/terraform/testdata/config-graph/test-module-dynamic-source/.terraform/modules/modules.json
+++ b/internal/terraform/testdata/config-graph/test-module-dynamic-source/.terraform/modules/modules.json
@@ -1,0 +1,19 @@
+{
+  "Modules": [
+    {
+      "Key": "",
+      "Source": "",
+      "Dir": "testdata/config-graph/test-module-dynamic-source"
+    },
+    {
+      "Key": "test.simple.test",
+      "Source": "./testing",
+      "Dir": "testdata/config-graph/test-module-dynamic-source/testing"
+    },
+    {
+      "Key": "test.simple.test.const_var_source",
+      "Source": "../modules/simple",
+      "Dir": "testdata/config-graph/test-module-dynamic-source/modules/simple"
+    }
+  ]
+}

--- a/internal/terraform/testdata/config-graph/test-module-dynamic-source/main.tf
+++ b/internal/terraform/testdata/config-graph/test-module-dynamic-source/main.tf
@@ -1,0 +1,2 @@
+# The root intentionally has no module calls. The test configuration's child
+# must be loaded using its test-specific installation path.

--- a/internal/terraform/testdata/config-graph/test-module-dynamic-source/modules/simple/main.tf
+++ b/internal/terraform/testdata/config-graph/test-module-dynamic-source/modules/simple/main.tf
@@ -1,0 +1,3 @@
+output "message" {
+  value = "hello"
+}

--- a/internal/terraform/testdata/config-graph/test-module-dynamic-source/simple.tftest.hcl
+++ b/internal/terraform/testdata/config-graph/test-module-dynamic-source/simple.tftest.hcl
@@ -1,0 +1,7 @@
+run "test" {
+  command = plan
+
+  module {
+    source = "./testing"
+  }
+}

--- a/internal/terraform/testdata/config-graph/test-module-dynamic-source/testing/main.tf
+++ b/internal/terraform/testdata/config-graph/test-module-dynamic-source/testing/main.tf
@@ -1,0 +1,9 @@
+variable "module_src" {
+  type    = string
+  default = "../modules/simple"
+  const   = true
+}
+
+module "const_var_source" {
+  source = var.module_src
+}

--- a/internal/terraform/transform_module_install.go
+++ b/internal/terraform/transform_module_install.go
@@ -12,8 +12,9 @@ import (
 )
 
 type ModuleTransformer struct {
-	Config *configs.Config
-	Walker configs.ModuleWalker
+	Config           *configs.Config
+	Walker           configs.ModuleWalker
+	ModulePathPrefix addrs.Module
 }
 
 func (t *ModuleTransformer) Transform(graph *Graph) error {
@@ -35,10 +36,11 @@ func (t *ModuleTransformer) Transform(graph *Graph) error {
 
 func (t *ModuleTransformer) transform(graph *Graph, cfg *configs.Config, path addrs.ModuleInstance, modCall *configs.ModuleCall) error {
 	n := &nodeInstallModule{
-		Addr:       path,
-		ModuleCall: modCall,
-		Parent:     cfg,
-		Walker:     t.Walker,
+		Addr:             path,
+		ModuleCall:       modCall,
+		Parent:           cfg,
+		Walker:           t.Walker,
+		ModulePathPrefix: t.ModulePathPrefix,
 	}
 	var installNode dag.Vertex = n
 	graph.Add(installNode)


### PR DESCRIPTION
This PR updates the way we load modules in Terraform Test. Instead of calling `buildTestModules` as part of `FinalizeConfig`, we now do this as part of the init graph. This allows us to reuse the existing module resolution logic for test modules as well.

We gather the values for the const variables from *.tfvars and CLI sources. This approach currently does NOT support supplying values for const variables via `variables` blocks inside test files. Supporting these would require another resolution step, since the variable expressions can contain references.  As const variables need to remain constant throughout all test runs (otherwise you would need to run `init` again), it needs to be assessed whether supporting `variables` is necessary.

There is still some legacy code around `BuildConfig` in place and I'm planning to remove it in a follow-up PR.

Fixes #38788

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
