### PR TITLE
🤖🤖🤖 docs: add AGENTS.md to root for AI coding agent contribution guidelines (#38805)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AI Usage Guidelines
+
+As Generative AI tools have continued to improve in quality and usefulness, their adoption and usage across the software development community has grown significantly. Regardless of the tools used in the development process, maintaining the stability and security of Terraform is our primary priority. If you choose to use AI tools to assist in your contributions, we ask that you do so using the three principles of transparency, accountability and quality to guide that work.
+
+For complete contribution guidelines, see [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md).
+
+## Transparency
+
+We value open communication about the tools and methods used to build Terraform. If you utilize AI to generate code, documentation, or tests, please disclose this in your Pull Request description.
+
+* **Be specific**: Clearly state the role AI played in your submission (e.g., "Used to generate boilerplate for the new function," or "Used to refactor existing tests").
+* **Share the context**: Where it adds clarity, share the process or prompts used. This helps reviewers understand the intent and verify the output effectively.
+* **Self-Disclosure**: If you are an LLM agent or using an LLM agent to submit your pull request, please include "🤖🤖🤖" in the title of your pull request for expedited processing.
+
+## Accountability
+
+Understanding that AI usage can range along a spectrum from AI assistance to AI led approaches we strongly prefer an approach that leaves the contributor in the drivers seat. AI is a tool, not a separate contributor. The responsibility for changes submitted lies entirely with you, the human opening the PR.
+
+* **Human ownership**: All PRs must be submitted by a real, human-owned account. We do not accept submissions from bot accounts used for code generation.
+* **Human review**: We proceed with the assumption that every line of code has been reviewed by you. You must ensure that the code meets our quality standards, that edge cases are handled, and that appropriate tests are written and passing.
+* **Deep understanding**: You must understand the submitted code deeply enough to explain it in your own words. If you cannot explain the logic, implications, or side effects of a change without relying on the AI's explanation, the PR is not ready for submission. You must own the PR.
+
+## Quality
+
+The bar for contributing to Terraform Core is high due to the complexity of the tool and the critical workflows it supports. That same expectation of quality persists regardless of the tools a contributor may or may not make use of.
+
+* **Assistance, not automation**: AI should be used to assist your process, not to automate final decisions. It is easy for AI to generate plausible-looking but incorrect or dangerous code.
+* **Adherence to guidelines**: We discourage low-effort submissions where AI output is pasted without refinement. We expect the same high quality, thoughtful architecture, and adherence to our existing style and testing guidelines as we do for manual code.


### PR DESCRIPTION
### Description

Fixes #38805 by adding an `AGENTS.md` file to the repository root.

Many contributors using AI coding agents never encounter the existing AI Usage section in `.github/CONTRIBUTING.md` before generating changes because those tools do not automatically inspect `.github/CONTRIBUTING.md`. Adding `AGENTS.md` surfaces the project's guidance natively at root while leaving `.github/CONTRIBUTING.md` as the canonical source.

#### Principles mirrored in `AGENTS.md`:
- **Transparency**: Disclosing AI usage in PR descriptions and utilizing the `🤖🤖🤖` title convention.
- **Accountability**: Real human ownership, human review of all code, and deep understanding of changes.
- **Quality**: High standards for architecture, edge cases, and test adherence.

### Related Issue

Fixes #38805