### PR TITLE
command: Send error usage output to stderr

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260730-005340.yaml
+++ b/.changes/v1.17/BUG FIXES-20260730-005340.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fixed an issue where usage information for invalid nested subcommands was written to stdout instead of stderr
+time: 2026-07-30T00:53:40+09:00
+custom:
+    Issue: "38957"

--- a/main.go
+++ b/main.go
@@ -286,11 +286,12 @@ func realMain() int {
 	// Rebuild the CLI with any modified args.
 	log.Printf("[INFO] CLI command args: %#v", args)
 	cliRunner = &cli.CLI{
-		Name:       binName,
-		Args:       args,
-		Commands:   Commands,
-		HelpFunc:   helpFunc,
-		HelpWriter: os.Stdout,
+		Name:        binName,
+		Args:        args,
+		Commands:    Commands,
+		HelpFunc:    helpFunc,
+		HelpWriter:  os.Stdout,
+		ErrorWriter: os.Stderr,
 
 		Autocomplete:          true,
 		AutocompleteInstall:   "install-autocomplete",

--- a/main_test.go
+++ b/main_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/command/ui"
+	"github.com/hashicorp/terraform/internal/terminal"
 )
 
 func TestMain_cliArgsFromEnv(t *testing.T) {
@@ -346,17 +347,87 @@ func TestMain_autoComplete(t *testing.T) {
 	}
 }
 
+func TestMain_commandHelpOutput(t *testing.T) {
+	oldArgs := os.Args
+	oldCommands := Commands
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		Commands = oldCommands
+	})
+
+	testCommandName := "unit-test-command-help-output"
+	Commands = map[string]cli.CommandFactory{
+		testCommandName: func() (cli.Command, error) {
+			return &testCommandCLI{
+				HelpText:  "command help",
+				RunResult: cli.RunResultHelp,
+			}, nil
+		},
+	}
+
+	tests := []struct {
+		Name       string
+		Args       []string
+		WantExit   int
+		WantStdout string
+		WantStderr string
+	}{
+		{
+			Name:       "explicit help",
+			Args:       []string{testCommandName, "-help"},
+			WantExit:   0,
+			WantStdout: "command help\n",
+		},
+		{
+			Name:       "command requests help",
+			Args:       []string{testCommandName, "invalid"},
+			WantExit:   1,
+			WantStderr: "command help\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			oldStdout := os.Stdout
+			oldStderr := os.Stderr
+			streams, done := terminal.StreamsForTesting(t)
+			os.Stdout = streams.Stdout.File
+			os.Stderr = streams.Stderr.File
+			defer func() {
+				os.Stdout = oldStdout
+				os.Stderr = oldStderr
+			}()
+
+			os.Args = append([]string{"terraform"}, test.Args...)
+			exit := realMain()
+			output := done(t)
+
+			if exit != test.WantExit {
+				t.Errorf("unexpected exit status %d; want %d", exit, test.WantExit)
+			}
+			if got := output.Stdout(); got != test.WantStdout {
+				t.Errorf("unexpected stdout %q; want %q", got, test.WantStdout)
+			}
+			if got := output.Stderr(); got != test.WantStderr {
+				t.Errorf("unexpected stderr %q; want %q", got, test.WantStderr)
+			}
+		})
+	}
+}
+
 type testCommandCLI struct {
-	Args []string
+	Args      []string
+	HelpText  string
+	RunResult int
 }
 
 func (c *testCommandCLI) Run(args []string) int {
 	c.Args = args
-	return 0
+	return c.RunResult
 }
 
 func (c *testCommandCLI) Synopsis() string { return "" }
-func (c *testCommandCLI) Help() string     { return "" }
+func (c *testCommandCLI) Help() string     { return c.HelpText }
 
 func TestWarnOutput(t *testing.T) {
 	mock := cli.NewMockUi()


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
This PR configures the CLI's `ErrorWriter` to use `stderr`.

Previously, Terraform configured `HelpWriter` to use `stdout` but left `ErrorWriter` unset. In that case, `hashicorp/cli` falls back to using `HelpWriter` for error-related usage output. As a result, usage information for invalid nested subcommands, such as `terraform state invalid` and `terraform workspace invalid`, was written to `stdout`.

This change preserves the existing behavior for explicit help while directing error-related usage output to the appropriate stream:

- Explicit help, such as `terraform state -help`, is written to `stdout` and exits with status 0.
- Usage requested through `cli.RunResultHelp`, such as for an invalid nested subcommand, is written to `stderr` and exits with status 1.

A regression test was added to exercise both output paths through `realMain`.

The following checks were completed:

```
go test . -run TestMain_commandHelpOutput -count=10
go test . -count=1
make fmtcheck
git diff --check
```

Manual verification confirmed the following behavior:

| Command                     | Exit | stdout | stderr |
|-----------------------------|-----:|--------|--------|
| `terraform invalid`         | 1    | empty  | error  |
| `terraform state invalid`   | 1    | empty  | usage  |
| `terraform workspace invalid` | 1  | empty  | usage  |
| `terraform state -help`     | 0    | usage  | empty  |

Codex was used to draft the regression test. I manually reviewed, understood, and verified the generated code.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->
Fixes #30783

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No. This pull request only changes which standard output stream is used for CLI usage information. It does not change access controls, encryption, logging controls, or other security controls.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.