### PR TITLE
fix performance regression by checking for deprecation before transforming cty values

### DIFF
--- a/internal/configs/configschema/implied_type.go
+++ b/internal/configs/configschema/implied_type.go
@@ -59,6 +59,29 @@ func (b *Block) ContainsSensitive() bool {
 	return false
 }
 
+// ContainsDeprecated returns true if any of the attributes of the receiving
+// block or any of its descendant blocks are marked as deprecated.
+func (b *Block) ContainsDeprecated() bool {
+	if b.Deprecated {
+		return true
+	}
+
+	for _, attrS := range b.Attributes {
+		if attrS.Deprecated {
+			return true
+		}
+		if attrS.NestedType != nil && attrS.NestedType.ContainsDeprecated() {
+			return true
+		}
+	}
+	for _, blockS := range b.BlockTypes {
+		if blockS.ContainsDeprecated() {
+			return true
+		}
+	}
+	return false
+}
+
 // ContainsWriteOnly returns true if any of the attributes of the receiving
 // block or any of its descendant blocks are considered write only
 // based on the declarations in the schema.
@@ -161,6 +184,20 @@ func (o *Object) ContainsSensitive() bool {
 			return true
 		}
 		if attrS.NestedType != nil && attrS.NestedType.ContainsSensitive() {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsDeprecated returns true if any of the attributes of the receiving
+// Object are marked as sensitive.
+func (o *Object) ContainsDeprecated() bool {
+	for _, attrS := range o.Attributes {
+		if attrS.Deprecated {
+			return true
+		}
+		if attrS.NestedType != nil && attrS.NestedType.ContainsDeprecated() {
 			return true
 		}
 	}

--- a/internal/deprecation/schema.go
+++ b/internal/deprecation/schema.go
@@ -21,6 +21,11 @@ func MarkDeprecatedValues(val cty.Value, schema *configschema.Block, origin stri
 	if schema == nil {
 		return val
 	}
+
+	if !schema.ContainsDeprecated() {
+		return val
+	}
+
 	newVal := val
 
 	// Check if the block is deprecated


### PR DESCRIPTION
Transforming cty values is very expensive, so we need to avoid it whenever it's not necessary. If a schema contains no deprecated fields at all, we can skip the `MarkDeprecatedValues` process entirely.

This brings the big graph benchmarks on my machine from ~25s each to ~3s each, and much lower allocations to match.
Before:
```
BenchmarkPlanLargeCountRefs-16     	       1	25.03 s/op	156150956848 B/op	1841713375 allocs/op
BenchmarkApplyLargeCountRefs-16    	       1	25.58 s/op	158463094144 B/op	1891365839 allocs/op
```

After 
```
BenchmarkPlanLargeCountRefs-16     	       1	2.81 s/op	15779656904 B/op	86907789 allocs/op
BenchmarkApplyLargeCountRefs-16    	       1	3.20 s/op	17886113784 B/op	133720843 allocs/op
```