### PR TITLE
refactor(init,state_migrate): Introduce new `DependencyLockingLogger` interface, use new methods for logging about events involving dependency lock files

### DIFF
--- a/internal/command/meta_dependencies.go
+++ b/internal/command/meta_dependencies.go
@@ -143,7 +143,7 @@ func (m *Meta) annotateDependencyLocksWithOverrides(ret *depsfile.Locks) *depsfi
 // saveDependencyLockFile can overwrite the contents of the dependency lock file.
 // If the locks match the previous locks, then the file is not updated and no output is produced.
 // If a "readonly" -lockfile flag is supplied then changing the file is blocked.
-func (m *Meta) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, incompleteProviders []string, flagLockfile string, view views.ProviderInstallationLogger) (output bool, diags tfdiags.Diagnostics) {
+func (m *Meta) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, incompleteProviders []string, flagLockfile string, view views.DependencyLockingLogger) (output bool, diags tfdiags.Diagnostics) {
 	// If the provider dependencies have changed since the last run then we'll
 	// say a little about that in case the reader wasn't expecting a change.
 	// (When we later integrate module dependencies into the lock file we'll
@@ -194,10 +194,10 @@ func (m *Meta) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, i
 			// say a little about what the dependency lock file is, for new
 			// users or those who are upgrading from a previous Terraform
 			// version that didn't have dependency lock files.
-			view.Output(views.LockInfo)
+			view.LogDependencyLockfileCreated()
 			output = true
 		} else {
-			view.Output(views.DependenciesLockChangesInfo)
+			view.LogDependencyLockfileUpdated()
 			output = true
 		}
 		lockFileDiags := m.replaceLockedDependencies(newLocks)

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -453,7 +453,7 @@ func (c *StateMigrateCommand) getDestinationStateStoreProviderRequirements(provi
 }
 
 // saveDependencyLockFile overwrites the contents of the dependency lock file.
-func (c *StateMigrateCommand) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, view views.StateMigrate) (output bool, diags tfdiags.Diagnostics) {
+func (c *StateMigrateCommand) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, view views.DependencyLockingLogger) (output bool, diags tfdiags.Diagnostics) {
 	// The state migrate command does not support the -lockfile=readonly flag
 	// This flag is specific to the init command, and can only take "" or "readonly" as values.
 	// As state migrate doesn't take this flag, we can safely set it to "" here.

--- a/internal/command/views/dependency_locking_logger.go
+++ b/internal/command/views/dependency_locking_logger.go
@@ -1,0 +1,26 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+type DependencyLockingLogger interface {
+	LogDependencyLockfileCreated()
+	LogDependencyLockfileUpdated()
+}
+
+const previousLockInfoHuman = `
+Terraform has created a lock file [bold].terraform.lock.hcl[reset] to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.`
+
+const previousLockInfoJSON = `
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.`
+
+const dependenciesLockChangesInfo = `
+Terraform has made some changes to the provider dependency selections recorded
+in the .terraform.lock.hcl file. Review those changes and commit them to your
+version control system if they represent changes you intended to make.`

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -24,6 +24,7 @@ type Init interface {
 	Log(message string, params ...any)
 
 	ProviderInstallationLogger
+	DependencyLockingLogger
 
 	prepareMessage(messageCode InitMessageCode, params ...any) string
 
@@ -134,6 +135,16 @@ func (v *InitHuman) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provid
 
 func (v *InitHuman) LogPartnerAndCommunityProviders() {
 	v.view.streams.Println(v.prepareMessage(PartnerAndCommunityProvidersMessage))
+}
+
+func (v *InitHuman) LogDependencyLockfileCreated() {
+	params := []any{}
+	v.view.streams.Println(v.prepareMessage(LockInfo, params...))
+}
+
+func (v *InitHuman) LogDependencyLockfileUpdated() {
+	params := []any{}
+	v.view.streams.Println(v.prepareMessage(DependenciesLockChangesInfo, params...))
 }
 
 // this implements log method for use by interfaces that need to log generic string messages, e.g used for logging in hook_module_install.go
@@ -316,6 +327,20 @@ func (v *InitJSON) LogPartnerAndCommunityProviders() {
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	v.logInitMessage(PartnerAndCommunityProvidersMessage)
+}
+
+func (v *InitJSON) LogDependencyLockfileCreated() {
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	params := []any{}
+	v.Output(LockInfo, params...)
+}
+
+func (v *InitJSON) LogDependencyLockfileUpdated() {
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	params := []any{}
+	v.Output(DependenciesLockChangesInfo, params...)
 }
 
 func (v *InitJSON) prepareMessage(messageCode InitMessageCode, params ...any) string {
@@ -623,23 +648,6 @@ see any changes that are required for your infrastructure.
 If you ever set or change modules or Terraform Settings, run "terraform init"
 again to reinitialize your working directory.
 `
-
-const previousLockInfoHuman = `
-Terraform has created a lock file [bold].terraform.lock.hcl[reset] to record the provider
-selections it made above. Include this file in your version control repository
-so that Terraform can guarantee to make the same selections by default when
-you run "terraform init" in the future.`
-
-const previousLockInfoJSON = `
-Terraform has created a lock file .terraform.lock.hcl to record the provider
-selections it made above. Include this file in your version control repository
-so that Terraform can guarantee to make the same selections by default when
-you run "terraform init" in the future.`
-
-const dependenciesLockChangesInfo = `
-Terraform has made some changes to the provider dependency selections recorded
-in the .terraform.lock.hcl file. Review those changes and commit them to your
-version control system if they represent changes you intended to make.`
 
 const partnerAndCommunityProvidersInfo = "\nPartner and community providers are signed by their developers.\n" +
 	"If you'd like to know more about provider signing, you can read about it here:\n" +

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -907,6 +907,54 @@ func TestNewInit_LogInitializingStateStoreProviderPlugin_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogDependencyLockfileCreated_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogDependencyLockfileCreated()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Terraform has created a lock file .terraform.lock.hcl to `, // ... incomplete but sufficient for test
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"message_code":"lock_info"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewInit_LogDependencyLockfileUpdated_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogDependencyLockfileUpdated()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Terraform has made some changes to the provider dependency selections `, // ... incomplete but sufficient for test
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"message_code":"dependencies_lock_changes_info"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -50,6 +50,8 @@ type StateMigrate interface {
 	Diagnostics(diags tfdiags.Diagnostics)
 
 	ProviderInstallationLogger
+	DependencyLockingLogger
+
 	Spacer // The `state migrate` command logs empty lines to space-out different sections of human-readable output
 }
 
@@ -179,6 +181,16 @@ func (s *StateMigrateHuman) LogProviderVersionSuccessWithKeyID(providerAddr addr
 func (s *StateMigrateHuman) LogPartnerAndCommunityProviders() {
 	msg := s.prepareMessage(PartnerAndCommunityProvidersMessage)
 	s.log(msg)
+}
+
+// Implements DependencyLockLogger interface.
+func (s *StateMigrateHuman) LogDependencyLockfileCreated() {
+	s.log(previousLockInfoHuman)
+}
+
+// Implements DependencyLockLogger interface.
+func (s *StateMigrateHuman) LogDependencyLockfileUpdated() {
+	s.log(dependenciesLockChangesInfo)
 }
 
 // Implements ProviderInstallationLogger interface.


### PR DESCRIPTION
This PR changes introduce new methods for logging the two terminal outputs related to dependency lock files:
* the notice when a lock file is first made
* the notice when init makes changes to an existing lock file

I put these methods in a new interface specific to events related to dep lock files, `DependencyLockingLogger`, and this meant I could update methods that take view implementations as parameters be more specific about the type of view they need. This will eventually mean we can remove the generic `Output` method from the `ProviderInstallerLogger` interface, but that's not yet possible.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
