### PR TITLE
refactor(init,get): Add new `ModuleInstallationLogger` interface and replace the old interface used to hook into the module installer

### DIFF
--- a/internal/command/hook_module_install.go
+++ b/internal/command/hook_module_install.go
@@ -8,43 +8,53 @@ import (
 
 	"github.com/hashicorp/cli"
 	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/initwd"
 )
 
-type view interface {
-	Log(message string, params ...any)
-}
+// uiModuleInstallHooks is used to log during module download and installation.
+// Currently this occurs in both the init and get commands.
+// Those commands use the struct differently:
+// * get command: provides a cli.Ui only
+// * init command: provides a View only
 type uiModuleInstallHooks struct {
 	initwd.ModuleInstallHookImpl
 	Ui             cli.Ui
 	ShowLocalPaths bool
-	View           view
+	View           views.ModuleInstallationLogger
 }
 
 var _ initwd.ModuleInstallHook = uiModuleInstallHooks{}
 
 func (h uiModuleInstallHooks) Download(modulePath, packageAddr string, v *version.Version) {
+	var message string
 	if v != nil {
-		h.log(fmt.Sprintf("Downloading %s %s for %s...", packageAddr, v, modulePath))
+		message = fmt.Sprintf("Downloading %s %s for %s...", packageAddr, v, modulePath)
 	} else {
-		h.log(fmt.Sprintf("Downloading %s for %s...", packageAddr, modulePath))
+		message = fmt.Sprintf("Downloading %s for %s...", packageAddr, modulePath)
+	}
+
+	// TODO: Make the get command use views, so this can be simplified.
+	switch h.View.(type) {
+	case views.ModuleInstallationLogger:
+		h.View.LogModuleDownload(message)
+	default:
+		h.Ui.Info(message)
 	}
 }
 
 func (h uiModuleInstallHooks) Install(modulePath string, v *version.Version, localDir string) {
+	var message string
 	if h.ShowLocalPaths {
-		h.log(fmt.Sprintf("- %s in %s", modulePath, localDir))
+		message = fmt.Sprintf("- %s in %s", modulePath, localDir)
 	} else {
-		h.log(fmt.Sprintf("- %s", modulePath))
+		message = fmt.Sprintf("- %s", modulePath)
 	}
-}
 
-func (h uiModuleInstallHooks) log(message string) {
+	// TODO: Make the get command use views, so this can be simplified.
 	switch h.View.(type) {
-	case view:
-		// there is no unformatted option for the View interface, so we need to
-		// pass message as a parameter to avoid double escaping % characters
-		h.View.Log("%s", message)
+	case views.ModuleInstallationLogger:
+		h.View.LogModuleInstallation(message)
 	default:
 		h.Ui.Info(message)
 	}

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -23,6 +23,7 @@ type Init interface {
 	Output(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
 
+	ModuleInstallationLogger
 	ProviderInstallationLogger
 	DependencyLockingLogger
 
@@ -137,14 +138,30 @@ func (v *InitHuman) LogPartnerAndCommunityProviders() {
 	v.view.streams.Println(v.prepareMessage(PartnerAndCommunityProvidersMessage))
 }
 
+// Implements DependencyLockingLogger
 func (v *InitHuman) LogDependencyLockfileCreated() {
 	params := []any{}
 	v.view.streams.Println(v.prepareMessage(LockInfo, params...))
 }
 
+// Implements DependencyLockingLogger
 func (v *InitHuman) LogDependencyLockfileUpdated() {
 	params := []any{}
 	v.view.streams.Println(v.prepareMessage(DependenciesLockChangesInfo, params...))
+}
+
+// Implements ModuleInstallationLogger
+//
+// See logging in hook_module_install.go
+func (v *InitHuman) LogModuleDownload(message string) {
+	v.view.streams.Println(strings.TrimSpace(message))
+}
+
+// Implements ModuleInstallationLogger
+//
+// See logging in hook_module_install.go
+func (v *InitHuman) LogModuleInstallation(message string) {
+	v.view.streams.Println(strings.TrimSpace(message))
 }
 
 // this implements log method for use by interfaces that need to log generic string messages, e.g used for logging in hook_module_install.go
@@ -329,6 +346,7 @@ func (v *InitJSON) LogPartnerAndCommunityProviders() {
 	v.logInitMessage(PartnerAndCommunityProvidersMessage)
 }
 
+// Implements DependencyLockingLogger
 func (v *InitJSON) LogDependencyLockfileCreated() {
 	// This was previously logged via Output, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
@@ -336,11 +354,26 @@ func (v *InitJSON) LogDependencyLockfileCreated() {
 	v.Output(LockInfo, params...)
 }
 
+// Implements DependencyLockingLogger
 func (v *InitJSON) LogDependencyLockfileUpdated() {
 	// This was previously logged via Output, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	params := []any{}
 	v.Output(DependenciesLockChangesInfo, params...)
+}
+
+// Implements ModuleInstallationLogger
+//
+// See logging in hook_module_install.go
+func (v *InitJSON) LogModuleDownload(message string) {
+	v.view.Log(message)
+}
+
+// Implements ModuleInstallationLogger
+//
+// See logging in hook_module_install.go
+func (v *InitJSON) LogModuleInstallation(message string) {
+	v.view.Log(message)
 }
 
 func (v *InitJSON) prepareMessage(messageCode InitMessageCode, params ...any) string {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -21,7 +21,6 @@ type Init interface {
 	PolicyResult(addr string, resp policy.EvaluationResponse)
 	PolicyDiagnostics(diags policy.Diagnostics)
 	Output(messageCode InitMessageCode, params ...any)
-	Log(message string, params ...any)
 
 	ModuleInstallationLogger
 	ProviderInstallationLogger
@@ -164,11 +163,6 @@ func (v *InitHuman) LogModuleInstallation(message string) {
 	v.view.streams.Println(strings.TrimSpace(message))
 }
 
-// this implements log method for use by interfaces that need to log generic string messages, e.g used for logging in hook_module_install.go
-func (v *InitHuman) Log(message string, params ...any) {
-	v.view.streams.Println(strings.TrimSpace(fmt.Sprintf(message, params...)))
-}
-
 func (v *InitHuman) prepareMessage(messageCode InitMessageCode, params ...any) string {
 	message, ok := MessageRegistry[messageCode]
 	if !ok {
@@ -248,11 +242,6 @@ func (v *InitJSON) logInitMessage(messageCode InitMessageCode, params ...any) {
 	}
 
 	v.view.Log(preppedMessage)
-}
-
-// this implements log method for use by services that need to log generic string messages, e.g usage logging in hook_module_install.go
-func (v *InitJSON) Log(message string, params ...any) {
-	v.view.Log(strings.TrimSpace(fmt.Sprintf(message, params...)))
 }
 
 func (v *InitJSON) LogInitializingStateStoreProviderPlugin(pAddr tfaddr.Provider, cons getproviders.VersionConstraints, storeType string) {

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -955,6 +955,54 @@ func TestNewInit_LogDependencyLockfileUpdated_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogModuleDownload_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	message := "foobar"
+	initView.LogModuleDownload(message)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		fmt.Sprintf(`"@message":"%s"`, message),
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewInit_LogModuleInstallation_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	message := "foobar"
+	initView.LogModuleInstallation(message)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		fmt.Sprintf(`"@message":"%s"`, message),
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"type":"log"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/module_installation_logger.go
+++ b/internal/command/views/module_installation_logger.go
@@ -1,0 +1,10 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+type ModuleInstallationLogger interface {
+	// TODO: Refactor calling code so that these methods can format the messages internally
+	LogModuleDownload(message string)
+	LogModuleInstallation(message string)
+}


### PR DESCRIPTION
This PR replaces the generic `Log` interface in the init command's view implementation with implementations of the new `ModuleInstallationLogger` interface's methods:
* LogModuleDownload
* LogModuleInstallation

We cannot change how these events are logged in the JSON output because it'd be a breaking change. Currently they're logged with `"type": "log"`, which means no additional fields can be added. However by splitting the old `Log` method into separate methods for module download and installation we enable those events to be described by different JSON objects in future.

Due to the above, we can also remove the old `Log` method. I believe this is a good change even in the short term because this method enables overly generic logging to propagate elsewhere in the command.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
