### PR TITLE
refactor: Change code related to establishing trust in providers used for PSS to use word "trust" over "safe"

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -382,7 +382,7 @@ the backend configuration is present and valid.
 // to only download a single provider, and the method will only return a single lock.
 //
 // Calling code is responsible for validating inputs to this method, e.g. mutually exclusive flags.
-func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarly *configs.Module, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInstallAction SafeStateStoreProviderInstallAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
+func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarly *configs.Module, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, trust ProviderTrust, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install providers for state store")
 	defer span.End()
 
@@ -554,9 +554,9 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 	}
 
 	// Return advice to the calling code about what to do regarding safe state store provider installation
-	safeInstallAction = c.determineSafeProviderInstallAction(rootModEarly.StateStore.ProviderAddr, providerLocations, previousLocks)
+	trust = c.determineIfProviderTrusted(rootModEarly.StateStore.ProviderAddr, providerLocations, previousLocks)
 
-	return true, lock, safeInstallAction, stateStoreProviderAuthResult, diags
+	return true, lock, trust, stateStoreProviderAuthResult, diags
 }
 
 // getProviders determines what providers are required by the config and state

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -230,10 +230,10 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		}
 
 		var getPSSProviderOutput bool
-		var safeInstallAction SafeStateStoreProviderInstallAction
+		var trust ProviderTrust
 		var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
 		var getPSSProviderDiags tfdiags.Diagnostics
-		getPSSProviderOutput, pssLock, safeInstallAction, stateStoreProviderAuthResult, getPSSProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
+		getPSSProviderOutput, pssLock, trust, stateStoreProviderAuthResult, getPSSProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
 		diags = diags.Append(getPSSProviderDiags)
 		if getPSSProviderDiags.HasErrors() {
 			view.Diagnostics(diags)
@@ -245,10 +245,10 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 			view.Spacer()
 		}
 
-		// Course of action depends on the SafeStateStoreProviderInstallAction returned from getProvidersFromPSSConfig
-		safeDiags := c.handleSafeProviderInstallAction(safeInstallAction, rootModEarly.StateStore.ProviderAddr, stateStoreProviderAuthResult, pssLock, alteredPreviousLocks, initArgs.StateStoreProviderLockFile, c, view)
-		diags = diags.Append(safeDiags)
-		if safeDiags.HasErrors() {
+		// The provider needs to be trusted to use it immediately after download. If the provider is not yet trusted we either prompt or raise an error.
+		trustDiags := c.confirmProviderIsTrusted(trust, rootModEarly.StateStore.ProviderAddr, stateStoreProviderAuthResult, pssLock, alteredPreviousLocks, initArgs.StateStoreProviderLockFile, c, view)
+		diags = diags.Append(trustDiags)
+		if trustDiags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1
 		}

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -3058,20 +3058,26 @@ func (m *Meta) StateStoreProviderFactoryFromConfigState(cfgState *workdir.StateS
 	return factory, diags
 }
 
-// SafeStateStoreProviderInstallAction describes the action that should be taken by Terraform based on whether
-// pluggable state storage is in use, if the provider is going to be downloaded via HTTP or not,
-// and whether Terraform is being run in automation or not.
-type SafeStateStoreProviderInstallAction rune
+// ProviderTrust describes whether Terraform trusts a provider to use for pluggable state storage.
+// Depending on where and how the provider is fetched trust may already be established (e.g. download controlled by lock file,
+// or download from filesystem mirror) but in other situations Terraform may need to ask a user to interactively confirm trust
+// in a provider before it's used.
+// In automation interactive confirmation is not possible. Instead we enable trust to be established before download by the
+// user supplying additional dependency lock files via CLI flags.
+type ProviderTrust rune
 
 const (
-	Invalid         SafeStateStoreProviderInstallAction = 0
-	Proceed         SafeStateStoreProviderInstallAction = 'P'
-	RequireApproval SafeStateStoreProviderInstallAction = 'A'
+	Invalid          ProviderTrust = 0 // Something's gone so wrong there's no provider to trust or mistrust.
+	Trusted          ProviderTrust = 'P'
+	RequiresApproval ProviderTrust = 'A' // Not _yet_ trusted, may be accepted or rejected later.
 )
 
-// determineSafeProviderInstallAction returns a `SafeProviderInstallAction` rune that instructs calling code about what to do following download of the state store provider.
+// determineIfProviderTrusted returns a `ProviderTrust` rune that informs calling code whether a given provider is considered to have
+// trust already established (i.e. downloaded for the first time from a trusted source, or download controlled by a dep lock file).
+// If trust isn't established, the calling code is responsible to prompt the user to establish trust or to raise an error.
+//
 // The `providerLocations` map parameter is expected to be created by the `FetchPackageBegin` callback, which is called during provider download.
-func (m *Meta) determineSafeProviderInstallAction(provider addrs.Provider, providerLocations map[addrs.Provider]getproviders.PackageLocation, previousLocks *depsfile.Locks) SafeStateStoreProviderInstallAction {
+func (m *Meta) determineIfProviderTrusted(provider addrs.Provider, providerLocations map[addrs.Provider]getproviders.PackageLocation, previousLocks *depsfile.Locks) ProviderTrust {
 	location, ok := providerLocations[provider]
 	if !ok || previousLocks.AllProviders()[provider] != nil {
 		// Either:
@@ -3080,35 +3086,35 @@ func (m *Meta) determineSafeProviderInstallAction(provider addrs.Provider, provi
 		//  - the provider isn't already downloaded to the cache BUT installation is controlled by a lock file.
 		//
 		// In both cases trust is already established; skip requesting approval.
-		log.Printf("[TRACE] init (determineSafeProviderInstallAction): the state storage provider %s (%q) was present in a dependency lock file during provider installation, so we consider it safe", provider.Type, provider)
-		return Proceed
+		log.Printf("[TRACE] init (determineIfProviderTrusted): the state storage provider %s (%q) was present in a dependency lock file during provider installation, so we consider it safe", provider.Type, provider)
+		return Trusted
 	} else {
 		// The provider wasn't in the dependency lock file so it's being download for the first time
 		// (we block upgrading the state store provider in this method).
-		log.Printf("[TRACE] init (determineSafeProviderInstallAction): the state storage provider %s (%q) will be changed in the dependency lock file during provider installation.", provider.Type, provider)
+		log.Printf("[TRACE] init (determineIfProviderTrusted): the state storage provider %s (%q) will be changed in the dependency lock file during provider installation.", provider.Type, provider)
 		switch location.(type) {
 		case getproviders.PackageLocalArchive, getproviders.PackageLocalDir:
 			// If the provider is downloaded from a local source we assume it's safe.
 			// We don't require presence of the -safe-init flag, or require input from the user to approve its usage.
-			log.Printf("[TRACE] init (determineSafeProviderInstallAction): the state storage provider %s (%q) is downloaded from a local source, so we consider it safe.", provider.Type, provider)
-			return Proceed
+			log.Printf("[TRACE] init (determineIfProviderTrusted): the state storage provider %s (%q) is downloaded from a local source, so we consider it safe.", provider.Type, provider)
+			return Trusted
 		case getproviders.PackageHTTPURL:
-			log.Printf("[DEBUG] init (determineSafeProviderInstallAction): the state storage provider %s (%q) is downloaded via HTTP, so we consider it potentially unsafe.", provider.Type, provider)
-			return RequireApproval
+			log.Printf("[DEBUG] init (determineIfProviderTrusted): the state storage provider %s (%q) is downloaded via HTTP, so we consider it potentially unsafe.", provider.Type, provider)
+			return RequiresApproval
 		default:
-			panic(fmt.Sprintf("init (determineSafeProviderInstallAction): unexpected provider location type for state storage provider %q: %T", provider, location))
+			panic(fmt.Sprintf("init (determineIfProviderTrusted): unexpected provider location type for state storage provider %q: %T", provider, location))
 		}
 	}
 }
 
-// handleSafeProviderInstallAction takes the action determined by `determineSafeProviderInstallAction` and either prompts the user for approval, or returns an error if something has gone wrong with pre-supplied locks when Terraform was run in automation.
+// confirmProviderIsTrusted takes the action determined by `determineIfProviderTrusted` and either prompts the user for approval, or returns an error if something has gone wrong with pre-supplied locks when Terraform was run in automation.
 //
 // NOTE: the command parameter is used to determine which command is being run, so that we can provide more specific guidance to the user. Do not use that parameter for any other purpose!
-func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInstallAction, provider addrs.Provider, stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult, stateStoreProviderLock, locksBeforeInstall *depsfile.Locks, flagLockfilePath string, command cli.Command, view views.ProviderInstallationLogger) tfdiags.Diagnostics {
+func (m *Meta) confirmProviderIsTrusted(trust ProviderTrust, provider addrs.Provider, stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult, stateStoreProviderLock, locksBeforeInstall *depsfile.Locks, flagLockfilePath string, command cli.Command, view views.ProviderInstallationLogger) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	switch action {
-	case Proceed:
+	switch trust {
+	case Trusted:
 		// do nothing; provider is already trusted and there's no need to notify the user.
 
 		if flagLockfilePath != "" {
@@ -3116,7 +3122,7 @@ func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInst
 			view.Output(views.StateStoreProviderAutomationApprovedMessage)
 			view.Spacer()
 		}
-	case RequireApproval:
+	case RequiresApproval:
 		if m.input {
 			// Prompt the user about trusting the provider used for state storage.
 			diags = diags.Append(m.promptStateStorageProviderApproval(provider, stateStoreProviderLock, stateStoreProviderAuthResult))
@@ -3159,7 +3165,7 @@ func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInst
 					remediationInstructions = `To fix this, create a minimal configuration(s) containing the specific provider version(s) you need and then perform "terraform init" with input enabled. Check the contents of the lock file created by that command and then retry "terraform state migrate -source-provider-lock-file=<path to lockfile> -destination-provider-lock-file=<path to lockfile>".`
 
 				default:
-					panic("Unexpected command type in handleSafeProviderInstallAction; this is a bug in Terraform and should be reported.")
+					panic("Unexpected command type in confirmProviderIsTrusted; this is a bug in Terraform and should be reported.")
 				}
 
 				diags = diags.Append(tfdiags.Sourceless(
@@ -3181,7 +3187,7 @@ func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInst
 		}
 	default:
 		// Handle Invalid or unexpected action types
-		panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", action))
+		panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", trust))
 	}
 
 	return diags

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -3187,12 +3187,12 @@ func TestMetaBackend_prepareBackend(t *testing.T) {
 //
 // This test shows all the different error messages that can be returned when the necessary lock isn't present.
 // The user is told different things based on what inputs affect finding the lock.
-func Test_handleSafeProviderInstallAction_inAutomation(t *testing.T) {
+func Test_confirmProviderIsTrusted_inAutomation(t *testing.T) {
 	// Reused in tests and unchanged
 	m := Meta{
 		input: false,
 	}
-	const action = RequireApproval
+	const action = RequiresApproval
 	const flagLockfilePath = ""
 	p := addrs.NewDefaultProvider("test")
 	providerLock := depsfile.NewLocks()
@@ -3213,7 +3213,7 @@ func Test_handleSafeProviderInstallAction_inAutomation(t *testing.T) {
 		initView := views.NewInit(arguments.ViewHuman, view)
 		workDirLocks := depsfile.NewLocks() // working directory lock file is empty
 
-		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, initView)
+		gotDiags := m.confirmProviderIsTrusted(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, initView)
 
 		// Expect an error due to the provider download not being controlled by a pre-existing lock
 		if !gotDiags.HasErrors() {
@@ -3246,7 +3246,7 @@ To fix this, create a minimal configuration containing the specific provider ver
 		smView := views.NewStateMigrate(arguments.ViewHuman, view)
 		workDirLocks := depsfile.NewLocks() // working directory lock file is empty
 
-		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, smView)
+		gotDiags := m.confirmProviderIsTrusted(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, smView)
 
 		// Expect an error due to the provider download not being controlled by a pre-existing lock
 		if !gotDiags.HasErrors() {
@@ -3285,7 +3285,7 @@ To fix this, create a minimal configuration(s) containing the specific provider 
 			nil,
 		)
 
-		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, initView)
+		gotDiags := m.confirmProviderIsTrusted(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, initView)
 
 		// Expect an error due to the provider download not being controlled by a pre-existing lock
 		if !gotDiags.HasErrors() {
@@ -3325,7 +3325,7 @@ To fix this, create a minimal configuration containing the specific provider ver
 			nil,
 		)
 
-		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, smView)
+		gotDiags := m.confirmProviderIsTrusted(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, smView)
 
 		// Expect an error due to the provider download not being controlled by a pre-existing lock
 		if !gotDiags.HasErrors() {
@@ -3365,7 +3365,7 @@ To fix this, create a minimal configuration(s) containing the specific provider 
 		)
 
 		setFlagLockfilePath := "./user-supplied-lockfile/terraform.lock.hcl"
-		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, inputLocks, setFlagLockfilePath, c, initView)
+		gotDiags := m.confirmProviderIsTrusted(action, p, auth, providerLock, inputLocks, setFlagLockfilePath, c, initView)
 
 		// Expect an error due to the provider download not being controlled by a pre-existing lock
 		if !gotDiags.HasErrors() {
@@ -3406,7 +3406,7 @@ To fix this, create a minimal configuration containing the specific provider ver
 		)
 
 		setFlagLockfilePath := "./user-supplied-lockfile/terraform.lock.hcl"
-		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, inputLocks, setFlagLockfilePath, c, smView)
+		gotDiags := m.confirmProviderIsTrusted(action, p, auth, providerLock, inputLocks, setFlagLockfilePath, c, smView)
 
 		// Expect an error due to the provider download not being controlled by a pre-existing lock
 		if !gotDiags.HasErrors() {

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -127,10 +127,10 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 
 		upgrade := false // The source provider download step will never be an upgrade. Either it's constrained by a preexisting lock or there is no lock.
 		var srcProviderDiags tfdiags.Diagnostics
-		var safeInstallAction SafeStateStoreProviderInstallAction
+		var trust ProviderTrust
 		var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
 		var output bool
-		output, sourceLock, safeInstallAction, stateStoreProviderAuthResult, srcProviderDiags = c.getSingleProvider(ctx, smi.StateStore, smi.StateStoreProvider.Requirement, srcLocks, upgrade, MigrationSource, view)
+		output, sourceLock, trust, stateStoreProviderAuthResult, srcProviderDiags = c.getSingleProvider(ctx, smi.StateStore, smi.StateStoreProvider.Requirement, srcLocks, upgrade, MigrationSource, view)
 		diags = diags.Append(srcProviderDiags)
 		if srcProviderDiags.HasErrors() {
 			view.Diagnostics(diags)
@@ -141,10 +141,10 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			view.Spacer()
 		}
 
-		// Course of action depends on the SafeStateStoreProviderInstallAction returned from getProvidersFromPSSConfig
-		safeDiags := c.handleSafeProviderInstallAction(safeInstallAction, smi.StateStore.ProviderAddr, stateStoreProviderAuthResult, sourceLock, srcLocks, args.SourceLockFilePath, c, view)
-		diags = diags.Append(safeDiags)
-		if safeDiags.HasErrors() {
+		// The provider needs to be trusted to use it immediately after download. If the provider is not yet trusted we either prompt or raise an error.
+		trustDiags := c.confirmProviderIsTrusted(trust, smi.StateStore.ProviderAddr, stateStoreProviderAuthResult, sourceLock, srcLocks, args.SourceLockFilePath, c, view)
+		diags = diags.Append(trustDiags)
+		if trustDiags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1
 		}
@@ -240,10 +240,10 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		// returned. This will be added the dependency lock file after a successful migration.
 		upgrade := args.Upgrade
 		var dstProviderDiags tfdiags.Diagnostics
-		var safeInstallAction SafeStateStoreProviderInstallAction
+		var trust ProviderTrust
 		var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
 		var output bool
-		output, destinationLock, safeInstallAction, stateStoreProviderAuthResult, dstProviderDiags = c.getSingleProvider(ctx, rootMod.StateStore, dstReq, mergedLocks, upgrade, MigrationDestination, view)
+		output, destinationLock, trust, stateStoreProviderAuthResult, dstProviderDiags = c.getSingleProvider(ctx, rootMod.StateStore, dstReq, mergedLocks, upgrade, MigrationDestination, view)
 		diags = diags.Append(dstProviderDiags)
 		if dstProviderDiags.HasErrors() {
 			view.Diagnostics(diags)
@@ -254,10 +254,10 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			view.Spacer()
 		}
 
-		// Course of action depends on the SafeStateStoreProviderInstallAction returned from getProvidersFromPSSConfig
-		safeDiags := c.handleSafeProviderInstallAction(safeInstallAction, rootMod.StateStore.ProviderAddr, stateStoreProviderAuthResult, destinationLock, mergedLocks, args.DestinationLockFilePath, c, view)
-		diags = diags.Append(safeDiags)
-		if safeDiags.HasErrors() {
+		// The provider needs to be trusted to use it immediately after download. If the provider is not yet trusted we either prompt or raise an error.
+		trustDiags := c.confirmProviderIsTrusted(trust, rootMod.StateStore.ProviderAddr, stateStoreProviderAuthResult, destinationLock, mergedLocks, args.DestinationLockFilePath, c, view)
+		diags = diags.Append(trustDiags)
+		if trustDiags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1
 		}
@@ -487,7 +487,7 @@ func (c *StateMigrateCommand) saveDependencyLockFile(previousLocks, newLocks *de
 // Download of the up to 2 providers is kept separate due to:
 // - Potential for downloading different versions of the same provider
 // - Need to keep the locks separate for source and destination providers; destination providers are added to the dependency lock file.
-func (c *StateMigrateCommand) getSingleProvider(ctx context.Context, stateStore *configs.StateStore, reqs providerreqs.Requirements, locks *depsfile.Locks, upgrade bool, location string, view views.StateMigrate) (output bool, resultingLock *depsfile.Locks, safeInstallAction SafeStateStoreProviderInstallAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
+func (c *StateMigrateCommand) getSingleProvider(ctx context.Context, stateStore *configs.StateStore, reqs providerreqs.Requirements, locks *depsfile.Locks, upgrade bool, location string, view views.StateMigrate) (output bool, resultingLock *depsfile.Locks, trust ProviderTrust, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install state migration "+location+" provider")
 	defer span.End()
 
@@ -611,7 +611,7 @@ func (c *StateMigrateCommand) getSingleProvider(ctx context.Context, stateStore 
 	}
 
 	// Return advice to the calling code about what to do regarding safe state store provider installation
-	safeInstallAction = c.determineSafeProviderInstallAction(stateStore.ProviderAddr, providerLocations, locks)
+	trust = c.determineIfProviderTrusted(stateStore.ProviderAddr, providerLocations, locks)
 
-	return true, newLocks, safeInstallAction, stateStoreProviderAuthResult, diags
+	return true, newLocks, trust, stateStoreProviderAuthResult, diags
 }


### PR DESCRIPTION
Making our language more precise and ensuring that it's clear the user has a responsibility to be involved in establishing trust when it cannot be done automatically.

The word "safe" had the risk of changing meaning from "user has to do this action safely" to "there's some inherent safety we're guaranteeing here". There's always a risk that a provider is trusted by a user but ends up being "unsafe" anyway. The user has the responsibility of vetting providers before trusting them.

Addresses feedback here: https://github.com/hashicorp/terraform/pull/38813#discussion_r3711098473

<img src="https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExenBxYWFtOGhjZDgwd2dhajE3bndpc2Fsd3dycmV5Y3B2cHA1cGc0MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/e05GB2c86qgOk/giphy.gif">

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
