### PR TITLE
test: Fix flakey test by avoiding use of `(TestOutput).All()`

### DIFF
--- a/internal/command/views/workspace_list_test.go
+++ b/internal/command/views/workspace_list_test.go
@@ -16,16 +16,18 @@ import (
 
 func TestWorkspaceListHuman(t *testing.T) {
 	testCases := map[string]struct {
-		selected string
-		list     []string
-		diags    tfdiags.Diagnostics
-		wantLog  string
+		selected   string
+		list       []string
+		diags      tfdiags.Diagnostics
+		wantStdout string
+		wantStderr string
 	}{
 		"success": {
 			"default",
 			[]string{"default", "other"},
 			nil,
 			"* default\n  other",
+			"",
 		},
 		"success with warning": {
 			"default",
@@ -38,6 +40,7 @@ func TestWorkspaceListHuman(t *testing.T) {
 				),
 			},
 			"Warning: Example warning\n\nThis is an example warning message.\n* default\n  other",
+			"",
 		},
 		"error": {
 			"foobar",
@@ -49,9 +52,9 @@ func TestWorkspaceListHuman(t *testing.T) {
 					"This is an example error message.",
 				),
 			},
-			"Error: Example error\n\nThis is an example error message.\n\n" +
-				"Warning: Terraform cannot find any existing workspaces.\n\n" +
+			"Warning: Terraform cannot find any existing workspaces.\n\n" +
 				"The \"foobar\" workspace is selected in your working directory. You can create\nthis workspace by using the \"terraform workspace new\" subcommand or including\nthe \"-or-create\" flag with the \"terraform workspace select\" subcommand.",
+			"Error: Example error\n\nThis is an example error message.\n\n",
 		},
 	}
 	for name, tc := range testCases {
@@ -63,11 +66,19 @@ func TestWorkspaceListHuman(t *testing.T) {
 
 			v.List(tc.selected, tc.list, tc.diags)
 
-			got := strings.TrimSpace(done(t).All())
-			want := strings.TrimSpace(tc.wantLog)
+			output := done(t)
 
 			// Assert contents
-			if diff := cmp.Diff(want, got); diff != "" {
+			// This must be done separately for stdout and stderr due to
+			// the interleaving of output caused in tests by (TestOutput).All()
+			gotStdout := strings.TrimSpace(output.Stdout())
+			wantStdout := strings.TrimSpace(tc.wantStdout)
+			if diff := cmp.Diff(wantStdout, gotStdout); diff != "" {
+				t.Fatalf("unexpected diff in human output:\n%s", diff)
+			}
+			gotStderr := strings.TrimSpace(output.Stderr())
+			wantStderr := strings.TrimSpace(tc.wantStderr)
+			if diff := cmp.Diff(wantStderr, gotStderr); diff != "" {
 				t.Fatalf("unexpected diff in human output:\n%s", diff)
 			}
 		})


### PR DESCRIPTION
When making assertions about stderr and stdout contents you need to handle them differently; how they're presented in `(TestOutput).All()`'s output is not deterministic.

Fixes the issue seen here (https://github.com/hashicorp/terraform/actions/runs/30835561578/job/91759757313) on main

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
