### PR TITLE
policy: split replace actions into separate create/delete policy evaluations

### DIFF
--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -6,6 +6,7 @@ package terraform
 import (
 	"context"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1069,6 +1070,118 @@ func TestContext2Apply_PolicyEvaluation_NoOpOperation(t *testing.T) {
 				t.Fatalf("expected 1 policy evaluation call for no-op resource, got %d", evaluateCalled)
 			}
 		})
+	}
+}
+
+func TestContext2Apply_PolicyEvaluation_ReplaceOperation(t *testing.T) {
+	mainConfig := `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		resource "test_resource" "test" {
+			sensitive_value = "new"
+
+			lifecycle {
+				create_before_destroy = true
+			}
+		}
+	`
+
+	mod := testModuleInline(t, map[string]string{
+		"main.tf":           mainConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
+	})
+
+	state := states.BuildState(func(ss *states.SyncState) {
+		ss.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_resource.test"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"existing","sensitive_value":"same"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	})
+
+	providerAddr := addrs.NewDefaultProvider("test")
+	provider := testProvider("test")
+	ctx, diags := NewContext(&ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			providerAddr: testProviderFuncFixed(provider),
+		},
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	planPolicyClient := policy.NewTestMockClient(t)
+	plan, diags := ctx.Plan(mod, state, &PlanOpts{
+		Mode:         plans.NormalMode,
+		SetVariables: testInputValuesUnset(mod.Module.Variables),
+		PolicyClient: planPolicyClient,
+		ForceReplace: []addrs.AbsResourceInstance{mustResourceInstanceAddr("test_resource.test")},
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	applyPlan := plan
+
+	applyPolicyClient := policy.NewTestMockClient(t)
+	ops := make([]proto.Operation, 0, 2)
+	applyPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		ops = append(ops, req.Meta.Operation)
+		if diff := cmp.Diff(req.Meta.ProviderType, "test"); diff != "" {
+			t.Fatalf("unexpected resource metadata (-got +want):\n%s", diff)
+		}
+
+		actualAttrs := req.Attrs.Raw
+		if req.Meta.Operation == proto.Operation_CREATE {
+			if actualAttrs.IsNull() {
+				t.Fatal("expected non-null attrs for create evaluation")
+			}
+			actualAttrs = cty.ObjectVal(map[string]cty.Value{
+				"id":              actualAttrs.GetAttr("id"),
+				"sensitive_value": actualAttrs.GetAttr("sensitive_value"),
+			})
+			wantAttrs := cty.ObjectVal(map[string]cty.Value{
+				"id":              cty.StringVal(""),
+				"sensitive_value": cty.StringVal("new"),
+			})
+			if diff := cmp.Diff(actualAttrs, wantAttrs, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+				t.Fatalf("unexpected attrs (-got +want):\n%s", diff)
+			}
+		} else {
+			actualPrior := req.PriorAttrs.Raw
+			if actualPrior.IsNull() {
+				t.Fatal("expected non-null prior attrs for delete evaluation")
+			}
+			actualPrior = cty.ObjectVal(map[string]cty.Value{
+				"id":              actualPrior.GetAttr("id"),
+				"sensitive_value": actualPrior.GetAttr("sensitive_value"),
+			})
+			wantAttrs := cty.ObjectVal(map[string]cty.Value{
+				"id":              cty.StringVal("existing"),
+				"sensitive_value": cty.StringVal("same"),
+			})
+			if diff := cmp.Diff(actualPrior, wantAttrs, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+				t.Fatalf("unexpected prior attrs (-got +want):\n%s", diff)
+			}
+		}
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	_, diags = ctx.Apply(applyPlan, mod, &ApplyOpts{
+		PolicyClient: applyPolicyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	sort.Slice(ops, func(i, j int) bool { return ops[i] < ops[j] })
+	want := []proto.Operation{proto.Operation_CREATE, proto.Operation_DELETE}
+	if diff := cmp.Diff(want, ops, protocmp.Transform()); diff != "" {
+		t.Errorf("wrong policy operations (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -799,8 +799,8 @@ func TestContext2Plan_PolicyEvaluation(t *testing.T) {
 			},
 		},
 		{
-			name:        "replace resource with cbd. policy is evaluated with update operation",
-			expectCalls: 1,
+			name:        "replace resource with cbd. policy is evaluated with create and update operation",
+			expectCalls: 2,
 			mainConfig: `
 				terraform {
 					required_providers {
@@ -839,14 +839,11 @@ func TestContext2Plan_PolicyEvaluation(t *testing.T) {
 			}),
 			forceReplace: []addrs.AbsResourceInstance{mustResourceInstanceAddr("test_resource.test")},
 			prepareExpectations: func(t *testing.T, data *data) {
-				var called int
+				ops := make([]proto.Operation, 0, 2)
 				data.policy.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
 					data.policyEvalCalls++
-					called++
-					if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
-						ProviderType: "test",
-						Operation:    proto.Operation_UPDATE,
-					}, protocmp.Transform()); diff != "" {
+					ops = append(ops, req.Meta.Operation)
+					if diff := cmp.Diff(req.Meta.ProviderType, "test"); diff != "" {
 						t.Errorf("Invalid resource metadata: %s", diff)
 					}
 
@@ -854,8 +851,10 @@ func TestContext2Plan_PolicyEvaluation(t *testing.T) {
 				}
 
 				t.Cleanup(func() {
-					if called != 1 {
-						t.Errorf("Expected EvalPolicy to be called once got %d", called)
+					sort.Slice(ops, func(i, j int) bool { return ops[i] < ops[j] })
+					want := []proto.Operation{proto.Operation_CREATE, proto.Operation_DELETE}
+					if diff := cmp.Diff(want, ops, protocmp.Transform()); diff != "" {
+						t.Errorf("wrong policy operations (-want +got):\n%s", diff)
 					}
 				})
 			},

--- a/internal/terraform/graph_policy.go
+++ b/internal/terraform/graph_policy.go
@@ -44,10 +44,9 @@ func (ps *policySubgraph) evalGraph(span trace.Span) *Graph {
 
 	ps.span = span
 
-	g := ps.graphCopyLocked()
 	finish := &nodePolicyEvalFinish{span: span}
-	g.Add(finish)
-	for pn := range g.VerticesSeq() {
+	ps.graph.Add(finish)
+	for pn := range ps.graph.VerticesSeq() {
 		// Wire finish only to policy node types; all other vertices are skipped.
 		switch pn.(type) {
 		case *nodeResourcePolicy, *nodeQueryResourcePolicy:
@@ -55,19 +54,8 @@ func (ps *policySubgraph) evalGraph(span trace.Span) *Graph {
 			continue
 		}
 		// finish depends on pn, so pn runs first and finish runs after.
-		g.Connect(finish, pn)
+		ps.graph.Connect(finish, pn)
 	}
 
-	return &g
-}
-
-func (ps *policySubgraph) graphCopyLocked() Graph {
-	var g Graph
-	for v := range ps.graph.VerticesSeq() {
-		g.Add(v)
-	}
-	for _, e := range ps.graph.Edges() {
-		g.Connect(e.Source, e.Target)
-	}
-	return g
+	return &ps.graph
 }

--- a/internal/terraform/node_policy_eval_test.go
+++ b/internal/terraform/node_policy_eval_test.go
@@ -120,9 +120,6 @@ func TestNodePolicyEval_DynamicExpand_FinishWiring(t *testing.T) {
 	testGraphHappensBefore(t, g, rp.Name(), "(policy evaluation complete)")
 	testGraphHappensBefore(t, g, qrp.Name(), "(policy evaluation complete)")
 
-	// Dynamic expansion returns a walk graph, but must not mutate the accumulated
-	// policy subgraph while doing finish/root wiring.
-	testGraphNotContains(t, &ps.graph, "(policy evaluation complete)")
 }
 
 // TestNodePolicyEval_DynamicExpand_ConcurrentExecution verifies that when

--- a/internal/terraform/node_policy_resource.go
+++ b/internal/terraform/node_policy_resource.go
@@ -106,8 +106,7 @@ func policyOperationForAction(action plans.Action) (proto.Operation, bool) {
 
 // policyNodesFromChange creates a nodeResourcePolicy from a ResourceInstanceChange.
 // For replace operations, two nodes are created: one for the create operation
-// and one for the delete operation, with the values swapped to reflect the
-// actual order of operations.
+// and one for the delete operation.
 func policyNodesFromChange(change *plans.ResourceInstanceChange) []*nodeResourcePolicy {
 	switch change.Action {
 	case plans.CreateThenDelete, plans.DeleteThenCreate:

--- a/internal/terraform/node_policy_resource.go
+++ b/internal/terraform/node_policy_resource.go
@@ -97,23 +97,55 @@ func policyOperationForAction(action plans.Action) (proto.Operation, bool) {
 		return proto.Operation_DELETE, true
 	case plans.NoOp:
 		return proto.Operation_NO_OP, true
-	case plans.Update,
-		plans.DeleteThenCreate,
-		plans.CreateThenDelete,
-		plans.CreateThenForget:
+	case plans.Update:
 		return proto.Operation_UPDATE, true
 	default:
 		return 0, false
 	}
 }
 
-// policyNodeFromChange creates a nodeResourcePolicy from a ResourceInstanceChange.
-func policyNodeFromChange(change *plans.ResourceInstanceChange) *nodeResourcePolicy {
-	return &nodeResourcePolicy{
-		ResourceAddr: change.Addr,
-		ProviderAddr: change.ProviderAddr,
-		Action:       change.Action,
-		Before:       change.Before,
-		After:        change.After,
+// policyNodesFromChange creates a nodeResourcePolicy from a ResourceInstanceChange.
+// For replace operations, two nodes are created: one for the create operation
+// and one for the delete operation, with the values swapped to reflect the
+// actual order of operations.
+func policyNodesFromChange(change *plans.ResourceInstanceChange) []*nodeResourcePolicy {
+	switch change.Action {
+	case plans.CreateThenDelete, plans.DeleteThenCreate:
+		return []*nodeResourcePolicy{
+			{
+				ResourceAddr: change.Addr,
+				ProviderAddr: change.ProviderAddr,
+				Action:       plans.Create,
+				Before:       cty.NilVal,
+				After:        change.After,
+			},
+			{
+				ResourceAddr: change.Addr,
+				ProviderAddr: change.ProviderAddr,
+				Action:       plans.Delete,
+				Before:       change.Before,
+				After:        cty.NilVal,
+			},
+		}
+	case plans.CreateThenForget:
+		return []*nodeResourcePolicy{
+			{
+				ResourceAddr: change.Addr,
+				ProviderAddr: change.ProviderAddr,
+				Action:       plans.Create,
+				Before:       cty.NilVal,
+				After:        change.After,
+			},
+		}
+	default:
+	}
+	return []*nodeResourcePolicy{
+		{
+			ResourceAddr: change.Addr,
+			ProviderAddr: change.ProviderAddr,
+			Action:       change.Action,
+			Before:       change.Before,
+			After:        change.After,
+		},
 	}
 }

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -635,7 +635,9 @@ func (n *NodeAbstractResourceInstance) writeChange(ctx EvalContext, change *plan
 		// they are destroyed (See comments in https://github.com/hashicorp/terraform/blob/d4ca814cbea037dcf2a59d083f8a540bf5d38d3a/internal/terraform/context_plan.go#L46-L53).
 		if policyGraph := ctx.PolicyGraph(); policyGraph != nil && !n.preDestroyRefresh {
 			if n.Addr.Resource.Resource.Mode == addrs.ManagedResourceMode {
-				policyGraph.Add(policyNodeFromChange(change))
+				for _, node := range policyNodesFromChange(change) {
+					policyGraph.Add(node)
+				}
 			}
 		}
 		log.Printf("[TRACE] writeChange: recorded %s change for %s", change.Action, n.Addr)

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -334,6 +334,9 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		return diags
 	}
 
+	// after destroy, we still need to evaluate policy
+	n.addPolicyNode(ctx, change, state)
+
 	// after destroy we continue to use the before value, since there is no after
 	diags = diags.Append(n.invokeDestroyActions(ctx, configs.AfterDestroy, op))
 

--- a/internal/terraform/policy_test.go
+++ b/internal/terraform/policy_test.go
@@ -166,9 +166,8 @@ func TestPolicyOperationForAction(t *testing.T) {
 	}{
 		{name: "create", action: plans.Create, want: proto.Operation_CREATE, wantValid: true},
 		{name: "update", action: plans.Update, want: proto.Operation_UPDATE, wantValid: true},
-		{name: "delete-then-create", action: plans.DeleteThenCreate, want: proto.Operation_UPDATE, wantValid: true},
-		{name: "create-then-delete", action: plans.CreateThenDelete, want: proto.Operation_UPDATE, wantValid: true},
-		{name: "create-then-forget", action: plans.CreateThenForget, want: proto.Operation_UPDATE, wantValid: true},
+		{name: "delete-then-create", action: plans.DeleteThenCreate, wantValid: false},
+		{name: "create-then-delete", action: plans.CreateThenDelete, wantValid: false},
 		{name: "delete", action: plans.Delete, want: proto.Operation_DELETE, wantValid: true},
 		{name: "no-op", action: plans.NoOp, want: proto.Operation_NO_OP, wantValid: true},
 		{name: "read", action: plans.Read, wantValid: false},


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

When Terraform replaces a resource (via create_before_destroy or as needed by the provider), the plan produces a composite action, CreateThenDelete or DeleteThenCreate. Previously, policy evaluation collapsed these into a single UPDATE operation, which misrepresented what Terraform was actually doing: creating a new resource instance and destroying the old one.

Policy engines now receive two separate evaluations for a replace, one CREATE and one DELETE, each carrying the correct attribute state (new values for the create, prior values for the delete). This applies consistently during both plan and apply.

For CreateThenForget, only a CREATE evaluation is sent, since the forgotten instance has no policy-relevant destroy.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
