### PR TITLE
refactor(init): Add `LogModuleUpgrade` and `LogModuleInitialization` methods to the `ModuleInstallationLogger` interface, refactor `init` command to use methods.

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -98,9 +98,9 @@ func (c *InitCommand) getModules(ctx context.Context, path, testsDir string, ear
 	defer span.End()
 
 	if upgrade {
-		view.Output(views.UpgradingModulesMessage)
+		view.LogModuleUpgrade()
 	} else {
-		view.Output(views.InitializingModulesMessage)
+		view.LogModuleInitialization()
 	}
 
 	uiHook := uiModuleInstallHooks{

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -163,6 +163,22 @@ func (v *InitHuman) LogModuleInstallation(message string) {
 	v.view.streams.Println(strings.TrimSpace(message))
 }
 
+// Implements ModuleInstallationLogger
+func (v *InitHuman) LogModuleUpgrade() {
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	params := []any{}
+	v.view.streams.Println(v.prepareMessage(UpgradingModulesMessage, params...))
+}
+
+// Implements ModuleInstallationLogger
+func (v *InitHuman) LogModuleInitialization() {
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	params := []any{}
+	v.view.streams.Println(v.prepareMessage(InitializingModulesMessage, params...))
+}
+
 func (v *InitHuman) prepareMessage(messageCode InitMessageCode, params ...any) string {
 	message, ok := MessageRegistry[messageCode]
 	if !ok {
@@ -363,6 +379,22 @@ func (v *InitJSON) LogModuleDownload(message string) {
 // See logging in hook_module_install.go
 func (v *InitJSON) LogModuleInstallation(message string) {
 	v.view.Log(message)
+}
+
+// Implements ModuleInstallationLogger
+func (v *InitJSON) LogModuleUpgrade() {
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	params := []any{}
+	v.Output(UpgradingModulesMessage, params...)
+}
+
+// Implements ModuleInstallationLogger
+func (v *InitJSON) LogModuleInitialization() {
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	params := []any{}
+	v.Output(InitializingModulesMessage, params...)
 }
 
 func (v *InitJSON) prepareMessage(messageCode InitMessageCode, params ...any) string {

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -1003,6 +1003,54 @@ func TestNewInit_LogModuleInstallation_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogModuleUpgrade_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogModuleUpgrade()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Upgrading modules..."`,
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"message_code":"upgrading_modules_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewInit_LogModuleInitialization_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogModuleInitialization()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Initializing modules..."`,
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"message_code":"initializing_modules_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/module_installation_logger.go
+++ b/internal/command/views/module_installation_logger.go
@@ -7,4 +7,7 @@ type ModuleInstallationLogger interface {
 	// TODO: Refactor calling code so that these methods can format the messages internally
 	LogModuleDownload(message string)
 	LogModuleInstallation(message string)
+
+	LogModuleUpgrade()
+	LogModuleInitialization()
 }


### PR DESCRIPTION
This eliminates two instances of using the init view's `Output` method in the `init` command.

Because these messages used to be logged via the `Output` method that means the JSON output for these messages were`"type":"init_output","message_code":<code>`. This PR adds tests asserting that the `init` command still produces JSON objects with those fields.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
