### PR TITLE
command/init: Update backend prompt wording

### DIFF
--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -1161,7 +1161,7 @@ Enter "yes" to copy and "no" to start with an empty state.
 const inputBackendMigrateNonEmpty = `
 Pre-existing state was found while migrating the previous %[1]q %[2]s to the
 newly configured %[4]q %[5]s. An existing non-empty state already exists in
-the new %[5]. The two states have been saved to temporary files that will be
+the new %[5]s. The two states have been saved to temporary files that will be
 removed after responding to this query.
 
 Previous (%[2]s %[1]q): %[3]s

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/backend"
+	"github.com/hashicorp/terraform/internal/backend/pluggable"
 	"github.com/hashicorp/terraform/internal/backend/remote"
 	"github.com/hashicorp/terraform/internal/cloud"
 	"github.com/hashicorp/terraform/internal/command/arguments"
@@ -164,6 +165,9 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 func (m *Meta) backendMigrateState_S_S(opts *backendMigrateOpts) error {
 	log.Print("[INFO] backendMigrateState: migrating all named workspaces")
 
+	srcWord := backendHumanName(opts.Source)
+	dstWord := backendHumanName(opts.Destination)
+
 	migrate := opts.force
 	if !migrate {
 		var err error
@@ -171,11 +175,11 @@ func (m *Meta) backendMigrateState_S_S(opts *backendMigrateOpts) error {
 		migrate, err = m.confirm(&terraform.InputOpts{
 			Id: "backend-migrate-multistate-to-multistate",
 			Query: fmt.Sprintf(
-				"Do you want to migrate all workspaces to %q?",
-				opts.DestinationType),
+				"Do you want to migrate all workspaces to %s %q?",
+				dstWord, opts.DestinationType),
 			Description: fmt.Sprintf(
 				strings.TrimSpace(inputBackendMigrateMultiToMulti),
-				opts.SourceType, opts.DestinationType),
+				opts.SourceType, srcWord, opts.DestinationType, dstWord),
 		})
 		if err != nil {
 			return fmt.Errorf(
@@ -190,7 +194,7 @@ func (m *Meta) backendMigrateState_S_S(opts *backendMigrateOpts) error {
 	sourceWorkspaces, wDiags := opts.Source.Workspaces()
 	if wDiags.HasErrors() {
 		return fmt.Errorf(strings.TrimSpace(
-			errMigrateLoadStates), opts.SourceType, wDiags.Err())
+			errMigrateLoadStates), opts.SourceType, srcWord, wDiags.Err())
 	}
 	if wDiags.HasWarnings() {
 		log.Printf("[WARN] backendMigrateState_S_S: warning(s) returned when getting workspaces from source backend: %s", wDiags.ErrWithWarnings())
@@ -211,7 +215,9 @@ func (m *Meta) backendMigrateState_S_S(opts *backendMigrateOpts) error {
 		// Perform the migration
 		if err := m.backendMigrateState_s_s(opts); err != nil {
 			return fmt.Errorf(strings.TrimSpace(
-				errMigrateMulti), name, opts.SourceType, opts.DestinationType, err)
+				errMigrateMulti), name,
+				opts.SourceType, srcWord,
+				opts.DestinationType, dstWord, err)
 		}
 	}
 
@@ -230,16 +236,20 @@ func (m *Meta) backendMigrateState_S_s(opts *backendMigrateOpts) error {
 	migrate := opts.force
 	if !migrate {
 		var err error
+
+		srcWord := backendHumanName(opts.Source)
+		dstWord := backendHumanName(opts.Destination)
+
 		// Ask the user if they want to migrate their existing remote state
 		migrate, err = m.confirm(&terraform.InputOpts{
 			Id: "backend-migrate-multistate-to-single",
 			Query: fmt.Sprintf(
-				"Destination state %q doesn't support workspaces.\n"+
+				"Destination %s %q doesn't support workspaces.\n"+
 					"Do you want to copy only your current workspace?",
-				opts.DestinationType),
+				dstWord, opts.DestinationType),
 			Description: fmt.Sprintf(
 				strings.TrimSpace(inputBackendMigrateMultiToSingle),
-				opts.SourceType, opts.DestinationType, currentWorkspace),
+				opts.SourceType, srcWord, opts.DestinationType, dstWord, currentWorkspace),
 		})
 		if err != nil {
 			return fmt.Errorf(
@@ -280,6 +290,9 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 		return nil
 	}
 
+	srcWord := backendHumanName(opts.Source)
+	dstWord := backendHumanName(opts.Destination)
+
 	var err error
 	destinationState, sDiags := opts.Destination.StateMgr(opts.destinationWorkspace)
 	if sDiags.HasErrors() {
@@ -288,7 +301,7 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 			// for a new name and migrate the default state to the given named state.
 			destinationState, err = func() (statemgr.Full, error) {
 				log.Print("[TRACE] backendMigrateState: destination doesn't support a default workspace, so we must prompt for a new name")
-				name, err := m.promptNewWorkspaceName(opts.DestinationType)
+				name, err := m.promptNewWorkspaceName(opts.DestinationType, dstWord)
 				if err != nil {
 					return nil, err
 				}
@@ -317,7 +330,7 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 		} else {
 			// For any other error, return it immediately to avoid nil pointer dereference
 			return fmt.Errorf(strings.TrimSpace(
-				errMigrateSingleLoadDefault), opts.DestinationType, sDiags.Err())
+				errMigrateSingleLoadDefault), opts.DestinationType, dstWord, sDiags.Err())
 		}
 	}
 	if err != nil {
@@ -455,7 +468,8 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 	log.Print("[TRACE] backendMigrateState: migration confirmed, so migrating")
 	if err := statemgr.Migrate(destinationState, sourceState); err != nil {
 		return fmt.Errorf(strings.TrimSpace(errBackendStateCopy),
-			opts.SourceType, opts.DestinationType, err)
+			opts.SourceType, srcWord,
+			opts.DestinationType, dstWord, err)
 	}
 	// The backend is currently handled before providers are installed during init,
 	// so requiring schemas here could lead to a catch-22 where it requires some manual
@@ -463,7 +477,8 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 	// when migrating to HCP Terraform backend, the initial JSON varient of state won't be generated and stored.
 	if err := destinationState.PersistState(nil); err != nil {
 		return fmt.Errorf(strings.TrimSpace(errBackendStateCopy),
-			opts.SourceType, opts.DestinationType, err)
+			opts.SourceType, srcWord,
+			opts.DestinationType, dstWord, err)
 	}
 
 	// And we're done.
@@ -472,23 +487,28 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 
 func (m *Meta) backendMigrateEmptyConfirm(source, destination statemgr.Full, opts *backendMigrateOpts) (bool, error) {
 	var inputOpts *terraform.InputOpts
+	srcWord := backendHumanName(opts.Source)
+	dstWord := backendHumanName(opts.Destination)
+
 	if opts.DestinationType == "cloud" {
 		appName := "HCP Terraform"
 		if cloudBackend, ok := opts.Destination.(*cloud.Cloud); ok {
 			appName = cloudBackend.AppName()
 		}
 		inputOpts = &terraform.InputOpts{
-			Id:          "backend-migrate-copy-to-empty-cloud",
-			Query:       "Do you want to copy existing state to HCP Terraform?",
-			Description: fmt.Sprintf(strings.TrimSpace(inputBackendMigrateEmptyCloud), opts.SourceType, appName),
+			Id:    "backend-migrate-copy-to-empty-cloud",
+			Query: "Do you want to copy existing state to HCP Terraform?",
+			Description: fmt.Sprintf(strings.TrimSpace(inputBackendMigrateEmptyCloud),
+				opts.SourceType, srcWord, appName),
 		}
 	} else {
 		inputOpts = &terraform.InputOpts{
 			Id:    "backend-migrate-copy-to-empty",
-			Query: "Do you want to copy existing state to the new backend?",
+			Query: fmt.Sprintf("Do you want to copy existing state to the new %s?", dstWord),
 			Description: fmt.Sprintf(
 				strings.TrimSpace(inputBackendMigrateEmpty),
-				opts.SourceType, opts.DestinationType),
+				opts.SourceType, srcWord,
+				opts.DestinationType, dstWord),
 		}
 	}
 
@@ -524,6 +544,9 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 		return false, fmt.Errorf("Error saving temporary state: %s", err)
 	}
 
+	srcWord := backendHumanName(opts.Source)
+	dstWord := backendHumanName(opts.Destination)
+
 	// Ask for confirmation
 	var inputOpts *terraform.InputOpts
 	if opts.DestinationType == "cloud" {
@@ -536,15 +559,16 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 			Query: "Do you want to copy existing state to HCP Terraform?",
 			Description: fmt.Sprintf(
 				strings.TrimSpace(inputBackendMigrateNonEmptyCloud),
-				opts.SourceType, sourcePath, destinationPath, appName),
+				opts.SourceType, srcWord, sourcePath, destinationPath, appName),
 		}
 	} else {
 		inputOpts = &terraform.InputOpts{
 			Id:    "backend-migrate-to-backend",
-			Query: "Do you want to copy existing state to the new backend?",
+			Query: fmt.Sprintf("Do you want to copy existing state to the new %s?", dstWord),
 			Description: fmt.Sprintf(
 				strings.TrimSpace(inputBackendMigrateNonEmpty),
-				opts.SourceType, opts.DestinationType, sourcePath, destinationPath),
+				opts.SourceType, srcWord, sourcePath,
+				opts.DestinationType, dstWord, destinationPath),
 		}
 	}
 
@@ -580,7 +604,7 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 	if err != nil {
 		return err
 	}
-	//to be used below, not yet implamented
+	// to be used below, not yet implemented
 	// destinationWorkspaces, destinationSingleState
 	_, _, err = retrieveWorkspaces(opts.Destination, opts.SourceType)
 	if err != nil {
@@ -589,9 +613,11 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 
 	// from HCP Terraform to non-TFC backend
 	if sourceTFC && !destinationTFC {
+		dstWord := backendHumanName(opts.Destination)
 		// From HCP Terraform to another backend. This is not yet implemented, and
 		// we recommend people to use the HCP Terraform API.
-		return errors.New(strings.TrimSpace(errTFCMigrateNotYetImplemented))
+		return fmt.Errorf(
+			strings.TrimSpace(errTFCMigrateNotYetImplemented), dstWord)
 	}
 
 	// Everything below, by the above two conditionals, now assumes that the
@@ -690,6 +716,9 @@ func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspa
 	}
 	newCurrentWorkspace := ""
 
+	srcWord := backendHumanName(opts.Source)
+	dstWord := backendHumanName(opts.Destination)
+
 	// This map is used later when doing the migration per source/destination.
 	// If a source has 'default' and has state, then we ask what the new name should be.
 	// And further down when we actually run state migration for each
@@ -705,15 +734,15 @@ func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspa
 			sourceState, sDiags := opts.Source.StateMgr(backend.DefaultStateName)
 			if sDiags.HasErrors() {
 				return fmt.Errorf(strings.TrimSpace(
-					errMigrateSingleLoadDefault), opts.SourceType, sDiags.Err())
+					errMigrateSingleLoadDefault), opts.SourceType, srcWord, sDiags.Err())
 			}
 			// RefreshState is what actually pulls the state to be evaluated.
 			if err := sourceState.RefreshState(); err != nil {
 				return fmt.Errorf(strings.TrimSpace(
-					errMigrateSingleLoadDefault), opts.SourceType, err)
+					errMigrateSingleLoadDefault), opts.SourceType, srcWord, err)
 			}
 			if !sourceState.State().Empty() {
-				newName, err := m.promptNewWorkspaceName(opts.DestinationType)
+				newName, err := m.promptNewWorkspaceName(opts.DestinationType, dstWord)
 				if err != nil {
 					return err
 				}
@@ -750,7 +779,7 @@ func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspa
 			appName = "HCP Terraform"
 		}
 
-		pattern, err = m.promptMultiStateMigrationPattern(opts.SourceType, appName)
+		pattern, err = m.promptMultiStateMigrationPattern(opts.SourceType, srcWord, appName)
 		if err != nil {
 			return err
 		}
@@ -774,7 +803,9 @@ func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspa
 		log.Printf("[INFO] backendMigrateTFC: multi-to-multi migration, source workspace %q to destination workspace %q", opts.sourceWorkspace, opts.destinationWorkspace)
 		if err := m.backendMigrateState_s_s(opts); err != nil {
 			return fmt.Errorf(strings.TrimSpace(
-				errMigrateMulti), name, opts.SourceType, opts.DestinationType, err)
+				errMigrateMulti), name,
+				opts.SourceType, srcWord,
+				opts.DestinationType, dstWord, err)
 		}
 
 		if currentWorkspace == opts.sourceWorkspace {
@@ -899,13 +930,14 @@ func (m *Meta) promptMultiToSingleCloudMigration(opts *backendMigrateOpts) error
 		if cloudBackend, ok := opts.Destination.(*cloud.Cloud); ok {
 			appName = cloudBackend.AppName()
 		}
+		srcWord := backendHumanName(opts.Source)
 		// Ask the user if they want to migrate their existing remote state
 		migrate, err = m.confirm(&terraform.InputOpts{
 			Id:    "backend-migrate-multistate-to-single",
 			Query: "Do you want to copy only your current workspace?",
 			Description: fmt.Sprintf(
 				strings.TrimSpace(tfcInputBackendMigrateMultiToSingle),
-				opts.SourceType, opts.destinationWorkspace, appName),
+				opts.SourceType, srcWord, opts.destinationWorkspace, appName),
 		})
 		if err != nil {
 			return fmt.Errorf("Error asking for state migration action: %s", err)
@@ -919,9 +951,9 @@ func (m *Meta) promptMultiToSingleCloudMigration(opts *backendMigrateOpts) error
 	return nil
 }
 
-func (m *Meta) promptNewWorkspaceName(destinationType string) (string, error) {
-	message := fmt.Sprintf("[reset][bold][yellow]The %q backend configuration only allows "+
-		"named workspaces![reset]", destinationType)
+func (m *Meta) promptNewWorkspaceName(destinationType, dstWord string) (string, error) {
+	message := fmt.Sprintf("[reset][bold][yellow]The %q %s configuration only allows "+
+		"named workspaces![reset]", destinationType, dstWord)
 	if destinationType == "cloud" {
 		if !m.input {
 			log.Print("[TRACE] backendMigrateState: can't prompt for input, so aborting migration")
@@ -941,13 +973,14 @@ func (m *Meta) promptNewWorkspaceName(destinationType string) (string, error) {
 	return name, nil
 }
 
-func (m *Meta) promptMultiStateMigrationPattern(sourceType string, appName string) (string, error) {
+func (m *Meta) promptMultiStateMigrationPattern(sourceType, srcWord, appName string) (string, error) {
 	// This is not the first prompt a user would be presented with in the migration to TFC, so no
 	// guard on m.input is needed here.
 	renameWorkspaces, err := m.UIInput().Input(context.Background(), &terraform.InputOpts{
-		Id:          "backend-migrate-multistate-to-tfc",
-		Query:       fmt.Sprintf("[reset][bold][yellow]%s[reset]", "Would you like to rename your workspaces?"),
-		Description: fmt.Sprintf(strings.TrimSpace(tfcInputBackendMigrateMultiToMulti), sourceType, appName),
+		Id:    "backend-migrate-multistate-to-tfc",
+		Query: fmt.Sprintf("[reset][bold][yellow]%s[reset]", "Would you like to rename your workspaces?"),
+		Description: fmt.Sprintf(strings.TrimSpace(tfcInputBackendMigrateMultiToMulti),
+			sourceType, srcWord, appName),
 	})
 	if err != nil {
 		return "", fmt.Errorf("Error asking for state migration action: %s", err)
@@ -981,11 +1014,19 @@ func (m *Meta) promptMultiStateMigrationPattern(sourceType string, appName strin
 	return pattern, nil
 }
 
+func backendHumanName(b backend.Backend) string {
+	name := "backend"
+	if _, isPluggable := b.(*pluggable.Pluggable); isPluggable {
+		name = "state store"
+	}
+	return name
+}
+
 const errMigrateLoadStates = `
-Error inspecting states in the %q backend:
+Error inspecting states in the %q %s:
     %s
 
-Prior to changing backends, Terraform inspects the source and destination
+Prior to migration, Terraform inspects the source and destination
 states to determine what kind of migration steps need to be taken, if any.
 Terraform failed to load the states. The data in both the source and the
 destination remain unmodified. Please resolve the above error and try again.
@@ -993,19 +1034,19 @@ destination remain unmodified. Please resolve the above error and try again.
 
 const errMigrateSingleLoadDefault = `
 Error loading state:
-    %[2]s
+    %[3]s
 
-Terraform failed to load the default state from the %[1]q backend.
-State migration cannot occur unless the state can be loaded. Backend
-modification and state migration has been aborted. The state in both the
+Terraform failed to load the default state from the %[1]q %[2]s.
+State migration cannot occur unless the state can be loaded.
+State migration has been aborted. The state in both the
 source and the destination remain unmodified. Please resolve the
 above error and try again.
 `
 
 const errMigrateMulti = `
-Error migrating the workspace %q from the previous %q backend
-to the newly configured %q backend:
-    %s
+Error migrating the workspace %[1]q from the previous %[2]q %[3]s
+to the newly configured %[4]q %[5]s:
+    %[6]s
 
 Terraform copies workspaces in alphabetical order. Any workspaces
 alphabetically earlier than this one have been copied. Any workspaces
@@ -1017,16 +1058,16 @@ This will attempt to copy (with permission) all workspaces again.
 `
 
 const errBackendStateCopy = `
-Error copying state from the previous %q backend to the newly configured
-%q backend:
-    %s
+Error copying state from the previous %[1]q %[2]s to the newly configured
+%[3]q %[4]s:
+    %[5]s
 
-The state in the previous backend remains intact and unmodified. Please resolve
+The state in the previous %[2]s remains intact and unmodified. Please resolve
 the error above and try again.
 `
 
 const errTFCMigrateNotYetImplemented = `
-Migrating state from HCP Terraform or Terraform Enterprise to another backend is not 
+Migrating state from HCP Terraform or Terraform Enterprise to another %s is not 
 yet implemented.
 
 Please use the API to do this: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/state-versions
@@ -1056,7 +1097,7 @@ networking-staging-us-east).
 
 For more information on workspace naming, see https://developer.hashicorp.com/terraform/cloud-docs/workspaces/create
 
-When migrating existing workspaces from the backend %[1]q to %[2]s, 
+When migrating existing workspaces from the %[2]s %[1]q to %[3]s, 
 would you like to rename your workspaces? Enter 1 or 2.
 
 1. Yes, I'd like to rename all workspaces according to a pattern I will provide.
@@ -1065,10 +1106,10 @@ would you like to rename your workspaces? Enter 1 or 2.
 
 // Done
 const tfcInputBackendMigrateMultiToSingle = `
-The previous backend %[1]q has multiple workspaces, but %[3]s has
+The previous %[2]s %[1]q has multiple workspaces, but %[3]s has
 been configured to use a single workspace (%[2]q). By continuing, you will
 only migrate your current workspace. If you wish to migrate all workspaces
-from the previous backend, you may cancel this operation and use the 'tags'
+from the previous %[2]s, you may cancel this operation and use the 'tags'
 strategy in your workspace configuration block instead.
 
 Enter "yes" to proceed or "no" to cancel.
@@ -1104,59 +1145,59 @@ Enter "yes" to proceed or "no" to cancel.
 `
 
 const inputBackendMigrateEmpty = `
-Pre-existing state was found while migrating the previous %q backend to the
-newly configured %q backend. No existing state was found in the newly
-configured %[2]q backend. Do you want to copy this state to the new %[2]q
-backend? Enter "yes" to copy and "no" to start with an empty state.
+Pre-existing state was found while migrating the previous %[1]q %[2]s to the
+newly configured %[1]q %[4]s. No existing state was found in the newly
+configured %[3]q %[4]s. Do you want to copy this state to the new %[3]q
+%[4]s? Enter "yes" to copy and "no" to start with an empty state.
 `
 
 // Done
 const inputBackendMigrateEmptyCloud = `
-Pre-existing state was found while migrating the previous %[1]q backend to %[2]s.
-No existing state was found in %[2]s. Do you want to copy this state to %[2]s?
+Pre-existing state was found while migrating the previous %[1]q %[2]s to %[3]s.
+No existing state was found in %[3]s. Do you want to copy this state to %[3]s?
 Enter "yes" to copy and "no" to start with an empty state.
 `
 
 const inputBackendMigrateNonEmpty = `
-Pre-existing state was found while migrating the previous %q backend to the
-newly configured %q backend. An existing non-empty state already exists in
-the new backend. The two states have been saved to temporary files that will be
+Pre-existing state was found while migrating the previous %[1]q %[2]s to the
+newly configured %[4]q %[5]s. An existing non-empty state already exists in
+the new %[5]. The two states have been saved to temporary files that will be
 removed after responding to this query.
 
-Previous (type %[1]q): %[3]s
-New      (type %[2]q): %[4]s
+Previous (%[2]s %[1]q): %[3]s
+New      (%[5]s %[4]q): %[6]s
 
-Do you want to overwrite the state in the new backend with the previous state?
+Do you want to overwrite the state in the new %[5]s with the previous state?
 Enter "yes" to copy and "no" to start with the existing state in the newly
-configured %[2]q backend.
+configured %[4]q %[5]s.
 `
 
 // Done
 const inputBackendMigrateNonEmptyCloud = `
-Pre-existing state was found while migrating the previous %q backend to
-%[4]s. An existing non-empty state already exists in %[4]s.
+Pre-existing state was found while migrating the previous %[1]q %[2] to
+%[4]s. An existing non-empty state already exists in %[5]s.
 The two states have been saved to temporary files that will be removed after
 responding to this query.
 
-Previous (type %[1]q): %[2]s
-New      (%[4]s): %[3]s
+Previous (%[2]s %[1]q): %[3]s
+New      (%[5]s): %[4]s
 
-Do you want to overwrite the state in %[4]s with the previous state?
-Enter "yes" to copy and "no" to start with the existing state in %.
+Do you want to overwrite the state in %[5]s with the previous state?
+Enter "yes" to copy and "no" to start with the existing state in %[5]s.
 `
 
 const inputBackendMigrateMultiToSingle = `
-The existing %[1]q backend supports workspaces and you currently are
-using more than one. The newly configured %[2]q backend doesn't support
-workspaces. If you continue, Terraform will copy your current workspace %[3]q
-to the default workspace in the new backend. Your existing workspaces in the
-source backend won't be modified. If you want to switch workspaces, back them
+The existing %[1]q %[2]s supports workspaces and you currently are
+using more than one. The newly configured %[3]q %[4]s doesn't support
+workspaces. If you continue, Terraform will copy your current workspace %[5]q
+to the default workspace in the new %[4]s. Your existing workspaces in the
+source %[2]s won't be modified. If you want to switch workspaces, back them
 up, or cancel altogether, answer "no" and Terraform will abort.
 `
 
 const inputBackendMigrateMultiToMulti = `
-Both the existing %[1]q backend and the newly configured %[2]q backend
-support workspaces. When migrating between backends, Terraform will copy
+Both the existing %[1]q %[2]s and the newly configured %[3]q %[4]s
+support workspaces. During the migration, Terraform will copy
 all workspaces (with the same names). THIS WILL OVERWRITE any conflicting
 states in the destination.
 

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -1146,7 +1146,7 @@ Enter "yes" to proceed or "no" to cancel.
 
 const inputBackendMigrateEmpty = `
 Pre-existing state was found while migrating the previous %[1]q %[2]s to the
-newly configured %[1]q %[4]s. No existing state was found in the newly
+newly configured %[3]q %[4]s. No existing state was found in the newly
 configured %[3]q %[4]s. Do you want to copy this state to the new %[3]q
 %[4]s? Enter "yes" to copy and "no" to start with an empty state.
 `

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -4,8 +4,49 @@
 package command
 
 import (
+	"strings"
 	"testing"
+
+	backendLocal "github.com/hashicorp/terraform/internal/backend/local"
+	"github.com/hashicorp/terraform/internal/backend/pluggable"
 )
+
+func Test_backendMigrateState_S_S(t *testing.T) {
+	storeType := "test_store"
+	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+	source, err := pluggable.NewPluggable(p, storeType)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	destination := backendLocal.New() // local
+
+	opts := &backendMigrateOpts{
+		SourceType: storeType,
+		Source:     source,
+
+		DestinationType: "local",
+		Destination:     destination,
+	}
+
+	inputWriter := testInputMap(t, map[string]string{
+		"backend-migrate-multistate-to-multistate": "no", // We're only testing the prompt, no is sufficient
+	})
+
+	meta := Meta{
+		input: true,
+		Ui:    testUiWrapped(t),
+	}
+	err = meta.backendMigrateState_S_S(opts)
+	if err == nil {
+		t.Fatal("expected a 'Migration aborted by user' error but got none")
+	}
+
+	// Check the source and destination are interpolated in the expected places
+	expected := `the existing "test_store" state store and the newly configured "local" backend`
+	if !strings.Contains(inputWriter.String(), expected) {
+		t.Fatalf("expected the input prompt to include %q, but got':\n %s", expected, inputWriter.String())
+	}
+}
 
 func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 	// Setup the meta

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -42,7 +42,7 @@ func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 		t.Log("Test: ", name)
 		m := testMetaBackend(t, nil)
 		input := map[string]string{}
-		_ = testInputMap(t, input)
+		inputWriter := testInputMap(t, input)
 		if tc.renamePrompt != "" {
 			input["backend-migrate-multistate-to-tfc"] = tc.renamePrompt
 		}
@@ -50,13 +50,19 @@ func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 			input["backend-migrate-multistate-to-tfc-pattern"] = tc.patternPrompt
 		}
 
-		sourceType := "cloud"
+		sourceType := "s3"
 		_, err := m.promptMultiStateMigrationPattern(sourceType, "backend", "HCP Terraform")
 		if tc.expectedErr == "" && err != nil {
 			t.Fatalf("expected error to be nil, but was %s", err.Error())
 		}
 		if tc.expectedErr != "" && tc.expectedErr != err.Error() {
 			t.Fatalf("expected error to eq %s but got %s", tc.expectedErr, err.Error())
+		}
+
+		// Check prompt text uses arguments in expected way
+		expected := `migrating existing workspaces from the backend "s3" to HCP Terraform`
+		if !strings.Contains(inputWriter.String(), expected) {
+			t.Fatalf("expected the input prompt to include: %s\nbut got:\n %s", expected, inputWriter.String())
 		}
 	}
 }

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -92,6 +92,64 @@ func Test_backendMigrateState_S_s(t *testing.T) {
 	}
 }
 
+// A method that `backendMigrateState_s_s` uses to prompt users (no direct tests for `backendMigrateState_s_s`)
+func Test_backendMigrateEmptyConfirm(t *testing.T) {
+	workspaceName := "default"
+
+	storeType := "test_store"
+	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+	p.ConfigureProviderCalled = true
+	p.ConfigureStateStoreCalled = true
+	source, err := pluggable.NewPluggable(p, storeType)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	sourceStateMgr, diags := source.StateMgr(workspaceName)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	destination := backendLocal.New()
+	destinationStateMgr, diags := source.StateMgr(workspaceName)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	opts := &backendMigrateOpts{
+		SourceType: storeType,
+		Source:     source,
+
+		DestinationType: "local",
+		Destination:     destination,
+	}
+
+	inputWriter := testInputMap(t, map[string]string{
+		"backend-migrate-copy-to-empty": "no", // We're only testing the prompt, no is sufficient
+	})
+
+	meta := Meta{
+		input: true,
+		Ui:    testUiWrapped(t),
+	}
+	_, err = meta.backendMigrateEmptyConfirm(sourceStateMgr, destinationStateMgr, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// Check the source and destination are interpolated in the expected places
+	promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
+	expected := []string{
+		`migrating the previous "test_store" state store to the newly configured "local" backend.`,
+		`No existing state was found in the newly configured "local" backend`,
+		`copy this state to the new "local" backend?`,
+	}
+	for _, e := range expected {
+		if !strings.Contains(promptText, e) {
+			t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
+		}
+	}
+}
+
 func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 	// Setup the meta
 

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -150,6 +150,66 @@ func Test_backendMigrateEmptyConfirm(t *testing.T) {
 	}
 }
 
+// A method that `backendMigrateState_s_s` uses to prompt users (no direct tests for `backendMigrateState_s_s`)
+func Test_backendMigrateNonEmptyConfirm(t *testing.T) {
+	workspaceName := "default"
+
+	storeType := "test_store"
+	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+	p.ConfigureProviderCalled = true
+	p.ConfigureStateStoreCalled = true
+	source, err := pluggable.NewPluggable(p, storeType)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	sourceStateMgr, diags := source.StateMgr(workspaceName)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	destination := backendLocal.New()
+	destinationStateMgr, diags := source.StateMgr(workspaceName)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	opts := &backendMigrateOpts{
+		SourceType: storeType,
+		Source:     source,
+
+		DestinationType: "local",
+		Destination:     destination,
+	}
+
+	inputWriter := testInputMap(t, map[string]string{
+		"backend-migrate-to-backend": "no", // We're only testing the prompt, no is sufficient
+	})
+
+	meta := Meta{
+		input: true,
+		Ui:    testUiWrapped(t),
+	}
+	_, err = meta.backendMigrateNonEmptyConfirm(sourceStateMgr, destinationStateMgr, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// Check the source and destination are interpolated in the expected places
+	promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
+	expected := []string{
+		`migrating the previous "test_store" state store to the newly configured "local" backend.`,
+		`non-empty state already exists in the new backend.`,
+		`Previous (state store "test_store"):`,
+		`New (backend "local"):`,
+		`overwrite the state in the new backend with the previous state?`,
+	}
+	for _, e := range expected {
+		if !strings.Contains(promptText, e) {
+			t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
+		}
+	}
+}
+
 func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 	// Setup the meta
 

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// TODO - there are no tests for `backendMigrateTFC`
+
 func Test_backendMigrateState_S_S(t *testing.T) {
 	storeType := "test_store"
 	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
@@ -96,6 +98,7 @@ func Test_backendMigrateState_S_s(t *testing.T) {
 	}
 }
 
+// Scenarios that cause a prompt to be created via `backendMigrateEmptyConfirm` or `backendMigrateNonEmptyConfirm`
 func Test_backendMigrateState_s_s(t *testing.T) {
 	t.Run("no state in destination - prompt via backendMigrateEmptyConfirm", func(t *testing.T) {
 		workspaceName := "default"

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -51,7 +51,7 @@ func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 		}
 
 		sourceType := "cloud"
-		_, err := m.promptMultiStateMigrationPattern(sourceType, "HCP Terraform")
+		_, err := m.promptMultiStateMigrationPattern(sourceType, "backend", "HCP Terraform")
 		if tc.expectedErr == "" && err != nil {
 			t.Fatalf("expected error to be nil, but was %s", err.Error())
 		}

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -7,8 +7,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	backendLocal "github.com/hashicorp/terraform/internal/backend/local"
 	"github.com/hashicorp/terraform/internal/backend/pluggable"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func Test_backendMigrateState_S_S(t *testing.T) {
@@ -92,122 +96,143 @@ func Test_backendMigrateState_S_s(t *testing.T) {
 	}
 }
 
-// A method that `backendMigrateState_s_s` uses to prompt users (no direct tests for `backendMigrateState_s_s`)
-func Test_backendMigrateEmptyConfirm(t *testing.T) {
-	workspaceName := "default"
+func Test_backendMigrateState_s_s(t *testing.T) {
+	t.Run("no state in destination - prompt via backendMigrateEmptyConfirm", func(t *testing.T) {
+		workspaceName := "default"
 
-	storeType := "test_store"
-	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
-	p.ConfigureProviderCalled = true
-	p.ConfigureStateStoreCalled = true
-	source, err := pluggable.NewPluggable(p, storeType)
-	if err != nil {
-		t.Fatalf("unexpected err: %s", err)
-	}
-	sourceStateMgr, diags := source.StateMgr(workspaceName)
-	if diags.HasErrors() {
-		t.Fatal(diags.Err())
-	}
+		storeType := "test_store"
+		p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+		p.ConfigureProviderCalled = true
+		p.ConfigureStateStoreCalled = true
 
-	destination := backendLocal.New()
-	destinationStateMgr, diags := source.StateMgr(workspaceName)
-	if diags.HasErrors() {
-		t.Fatal(diags.Err())
-	}
+		// We need a state to migrate
+		p.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+			"test_store",
+			workspaceName,
+			[]byte(`{"version":4,"terraform_version":"1.16.0","serial":1,"lineage":"8595356e-c764-dea1-8dae-156b936ec6e2","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
+		)
+		source, err := pluggable.NewPluggable(p, storeType)
+		if err != nil {
+			t.Fatalf("unexpected err: %s", err)
+		}
+		destination := backendLocal.New()
 
-	opts := &backendMigrateOpts{
-		SourceType: storeType,
-		Source:     source,
+		opts := &backendMigrateOpts{
+			SourceType: storeType,
+			Source:     source,
 
-		DestinationType: "local",
-		Destination:     destination,
-	}
+			DestinationType: "local",
+			Destination:     destination,
 
-	inputWriter := testInputMap(t, map[string]string{
-		"backend-migrate-copy-to-empty": "no", // We're only testing the prompt, no is sufficient
+			sourceWorkspace: workspaceName,
+		}
+
+		inputWriter := testInputMap(t, map[string]string{
+			"backend-migrate-copy-to-empty": "no", // We're only testing the prompt, no is sufficient
+		})
+
+		meta := Meta{
+			input: true,
+			Ui:    testUiWrapped(t),
+		}
+		err = meta.backendMigrateState_s_s(opts)
+		if err != nil {
+			t.Fatalf("Didn't expect an error but got: %s", err)
+		}
+
+		// Check the source and destination are interpolated in the expected places
+		promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
+		expected := []string{
+			`migrating the previous "test_store" state store to the newly configured "local" backend.`,
+			`No existing state was found in the newly configured "local" backend`,
+			`copy this state to the new "local" backend?`,
+		}
+		for _, e := range expected {
+			if !strings.Contains(promptText, e) {
+				t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
+			}
+		}
 	})
 
-	meta := Meta{
-		input: true,
-		Ui:    testUiWrapped(t),
-	}
-	_, err = meta.backendMigrateEmptyConfirm(sourceStateMgr, destinationStateMgr, opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+	t.Run("state in destination - prompt via backendMigrateNonEmptyConfirm", func(t *testing.T) {
+		td := t.TempDir()
+		t.Chdir(td)
 
-	// Check the source and destination are interpolated in the expected places
-	promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
-	expected := []string{
-		`migrating the previous "test_store" state store to the newly configured "local" backend.`,
-		`No existing state was found in the newly configured "local" backend`,
-		`copy this state to the new "local" backend?`,
-	}
-	for _, e := range expected {
-		if !strings.Contains(promptText, e) {
-			t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
+		workspaceName := "default"
+
+		// Source - has a state for migration
+		storeType := "test_store"
+		p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+		p.ConfigureProviderCalled = true
+		p.ConfigureStateStoreCalled = true
+		p.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+			"test_store",
+			workspaceName,
+			[]byte(`{"version":4,"terraform_version":"1.16.0","serial":1,"lineage":"8595356e-c764-dea1-8dae-156b936ec6e2","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
+		)
+		source, err := pluggable.NewPluggable(p, storeType)
+		if err != nil {
+			t.Fatalf("unexpected err: %s", err)
 		}
-	}
-}
 
-// A method that `backendMigrateState_s_s` uses to prompt users (no direct tests for `backendMigrateState_s_s`)
-func Test_backendMigrateNonEmptyConfirm(t *testing.T) {
-	workspaceName := "default"
+		// Destination - has a state present to cause the prompt under test
+		state := states.NewState()
+		state.SetOutputValue(
+			addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
+			cty.StringVal("bar value"), false,
+		)
+		state.SetOutputValue(
+			addrs.OutputValue{Name: "secret"}.Absolute(addrs.RootModuleInstance),
+			cty.StringVal("secret value"), true,
+		)
+		destination := backendLocal.New()
+		dStateMgr, diags := destination.StateMgr(workspaceName)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		err = dStateMgr.WriteState(state)
+		if err != nil {
+			t.Fatalf("unexpected err: %s", err)
+		}
 
-	storeType := "test_store"
-	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
-	p.ConfigureProviderCalled = true
-	p.ConfigureStateStoreCalled = true
-	source, err := pluggable.NewPluggable(p, storeType)
-	if err != nil {
-		t.Fatalf("unexpected err: %s", err)
-	}
-	sourceStateMgr, diags := source.StateMgr(workspaceName)
-	if diags.HasErrors() {
-		t.Fatal(diags.Err())
-	}
+		opts := &backendMigrateOpts{
+			SourceType: storeType,
+			Source:     source,
 
-	destination := backendLocal.New()
-	destinationStateMgr, diags := source.StateMgr(workspaceName)
-	if diags.HasErrors() {
-		t.Fatal(diags.Err())
-	}
+			DestinationType: "local",
+			Destination:     destination,
 
-	opts := &backendMigrateOpts{
-		SourceType: storeType,
-		Source:     source,
+			sourceWorkspace: workspaceName,
+		}
 
-		DestinationType: "local",
-		Destination:     destination,
-	}
+		inputWriter := testInputMap(t, map[string]string{
+			"backend-migrate-to-backend": "no", // We're only testing the prompt, no is sufficient
+		})
 
-	inputWriter := testInputMap(t, map[string]string{
-		"backend-migrate-to-backend": "no", // We're only testing the prompt, no is sufficient
+		meta := Meta{
+			input: true,
+			Ui:    testUiWrapped(t),
+		}
+		err = meta.backendMigrateState_s_s(opts)
+		if err != nil {
+			t.Fatalf("Didn't expect an error but got: %s", err)
+		}
+
+		// Check the source and destination are interpolated in the expected places
+		promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
+		expected := []string{
+			`migrating the previous "test_store" state store to the newly configured "local" backend.`,
+			`non-empty state already exists in the new backend.`,
+			`Previous (state store "test_store"):`,
+			`New (backend "local"):`,
+			`overwrite the state in the new backend with the previous state?`,
+		}
+		for _, e := range expected {
+			if !strings.Contains(promptText, e) {
+				t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
+			}
+		}
 	})
-
-	meta := Meta{
-		input: true,
-		Ui:    testUiWrapped(t),
-	}
-	_, err = meta.backendMigrateNonEmptyConfirm(sourceStateMgr, destinationStateMgr, opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	// Check the source and destination are interpolated in the expected places
-	promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
-	expected := []string{
-		`migrating the previous "test_store" state store to the newly configured "local" backend.`,
-		`non-empty state already exists in the new backend.`,
-		`Previous (state store "test_store"):`,
-		`New (backend "local"):`,
-		`overwrite the state in the new backend with the previous state?`,
-	}
-	for _, e := range expected {
-		if !strings.Contains(promptText, e) {
-			t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
-		}
-	}
 }
 
 func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -48,6 +48,50 @@ func Test_backendMigrateState_S_S(t *testing.T) {
 	}
 }
 
+func Test_backendMigrateState_S_s(t *testing.T) {
+	storeType := "test_store"
+	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+	p.ConfigureProviderCalled = true
+	p.ConfigureStateStoreCalled = true
+	source, err := pluggable.NewPluggable(p, storeType)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	destination := backendLocal.TestNewLocalSingle() // local with no workspace support
+
+	opts := &backendMigrateOpts{
+		SourceType: storeType,
+		Source:     source,
+
+		DestinationType: "local",
+		Destination:     destination,
+	}
+
+	inputWriter := testInputMap(t, map[string]string{
+		"backend-migrate-multistate-to-single": "no", // We're only testing the prompt, no is sufficient
+	})
+
+	meta := Meta{
+		input: true,
+		Ui:    testUiWrapped(t),
+	}
+	err = meta.backendMigrateState_S_s(opts)
+	if err == nil {
+		t.Fatal("expected a 'Migration aborted by user' error but got none")
+	}
+
+	// Check the source and destination are interpolated in the expected places
+	expected := []string{
+		`Destination backend "local" doesn't support workspaces`,
+		`The existing "test_store" state store supports workspaces`,
+	}
+	for _, e := range expected {
+		if !strings.Contains(inputWriter.String(), e) {
+			t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, inputWriter.String())
+		}
+	}
+}
+
 func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 	// Setup the meta
 


### PR DESCRIPTION
I went back and forth on some more refactoring choices:

1. Move messages from the bottom of the file to in-line
2. Use `text/template`
3. Have `backend.Backend` "self-identify" - e.g. through a new method `FriendlyName` that returns either `backend` or `state store`

We could still do any/all but I felt it would be mostly over-optimisation esp. considering we intend to phase out backends in favour of PSS at some point.

The PR is expected to have zero end-user impact on users who do not use PSS.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
