### PR TITLE
PSS: Implement Human and JSON view methods for state migration 'start', 'complete', 'errored', and 'finalized' events

### DIFF
--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -380,7 +380,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 
 	view.Diagnostics(diags) // Log any warnings
 
-	view.Log(views.StateMigrationCompletedMessage, source, destination)
+	view.Log(views.StateMigrationFinalizedMessage, source, destination)
 
 	return 0
 }

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -335,7 +335,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("State migration failed: %w", err))
 		view.Diagnostics(diags)
-		view.Log(views.StateMigrationFailureMessage, source, destination)
+		view.LogStateMigrationErrored(views.DuringMigration, source, destination)
 		return 1
 	}
 
@@ -360,7 +360,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		diags = diags.Append(depLockFileDiags)
 		if depLockFileDiags.HasErrors() {
 			view.Diagnostics(diags)
-			view.Log(views.StateMigrationPostStepsInterruptedMessage, source, destination)
+			view.LogStateMigrationErrored(views.DuringLockfile, source, destination)
 			return 1
 		}
 		if output {
@@ -374,7 +374,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	diags = diags.Append(bsfDiags)
 	if bsfDiags.HasErrors() {
 		view.Diagnostics(diags)
-		view.Log(views.StateMigrationPostStepsInterruptedMessage, source, destination)
+		view.LogStateMigrationErrored(views.DuringBackendStateFile, source, destination)
 		return 1
 	}
 

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -380,7 +380,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 
 	view.Diagnostics(diags) // Log any warnings
 
-	view.Log(views.StateMigrationFinalizedMessage, source, destination)
+	view.LogStateMigrationFinalized(source, destination)
 
 	return 0
 }

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -328,7 +328,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	view.Log(views.StateMigrationStartMessage, source, destination)
+	view.LogStateMigrationStart(source, destination)
 
 	// Perform the migration from source to destination
 	err := c.Meta.backendMigrateState(migrateOpts)

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -75,5 +75,6 @@ const (
 	// State Migration messages (`state migrate` command)
 	StateMigrationStart                             MessageType = "migration_start"
 	StateMigrationComplete                          MessageType = "migration_complete"
+	StateMigrationErrored                           MessageType = "migration_errored"
 	StateMigrationFinalized                         MessageType = "migration_finalized"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -74,4 +74,5 @@ const (
 
 	// State Migration messages (`state migrate` command)
 	StateMigrationStart                             MessageType = "migration_start"
+	StateMigrationComplete                          MessageType = "migration_complete"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -75,4 +75,5 @@ const (
 	// State Migration messages (`state migrate` command)
 	StateMigrationStart                             MessageType = "migration_start"
 	StateMigrationComplete                          MessageType = "migration_complete"
+	StateMigrationFinalized                         MessageType = "migration_finalized"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -77,4 +77,8 @@ const (
 	StateMigrationComplete                          MessageType = "migration_complete"
 	StateMigrationErrored                           MessageType = "migration_errored"
 	StateMigrationFinalized                         MessageType = "migration_finalized"
+	StateMigrationSourceInitializationStart         MessageType = "migration_source_initialization_start"
+	StateMigrationSourceInitializationComplete      MessageType = "migration_source_initialization_complete"
+	StateMigrationDestinationInitializationStart    MessageType = "migration_destination_initialization_start"
+	StateMigrationDestinationInitializationComplete MessageType = "migration_destination_initialization_complete"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -71,4 +71,7 @@ const (
 	StateStoreProviderInteractiveApproval  MessageType = "state_store_provider_interactive_approval"
 	StateStoreProviderInteractiveRejection MessageType = "state_store_provider_interactive_rejection"
 	StateStoreProviderAutomaticApproval    MessageType = "state_store_provider_automatic_approval"
+
+	// State Migration messages (`state migrate` command)
+	StateMigrationStart                             MessageType = "migration_start"
 )

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -56,4 +56,7 @@ type ProviderInstallationLogger interface {
 const (
 	logInitializingStateStoreProviderStartMessageHuman = "[reset][bold]Initializing provider %s%s for state store %q..."
 	logInitializingStateStoreProviderStartMessageJSON  = "Initializing provider %s%s for state store %q..."
+
+	logFindingMatchingVersionMessageHuman = "- Finding %s versions matching %q..."
+	logFindingMatchingVersionMessageJSON  = "Finding matching versions for provider: %s, version_constraint: %q"
 )

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -30,7 +30,7 @@ const (
 
 	// Notify the user that an error has occurred, but there have been changes to where state is stored.
 	// Hopefully the errors accompanying this message are actionable by users, but if not we expect a bug report.
-	StateMigrationPostStepsInterruptedMessage = `[reset][bold]Finished migrating state from %s to %s, but an error occurred before Terraform was finished.[reset]
+	logStateMigrationErroredAfterMigrationMessageHuman = `[reset][bold]Finished migrating state from %s to %s, but an error occurred before Terraform was finished.[reset]
 
 Your state has been copied to the new destination, but Terraform was unable to perform final operations to enable future commands to use your migrated state. Either Terraform was unable to record the new provider used for the destination state store to your dependency lock file, or the backend state file was unable to be updated. Please check the errors message(s) above for more information.
 
@@ -38,10 +38,11 @@ The successful migration means you will have two copies of your state, both in t
 
 If you can address the errors you can retry this command safely. Otherwise, please report the issue to the Terraform team with the error messages and your configuration.
 `
+	logStateMigrationErroredAfterMigrationMessageJSON = `Finished migrating state from %s to %s, but an error occurred before Terraform was finished.`
 
 	// Notify the user that the migration failed. This may be due to a misconfiguration, e.g. insufficient permissions to interact with a service.
 	// We expect these errors to either be actionable by users, or to originate from a state store provider (but reports shouldn't come to us unless due to a backend).
-	StateMigrationFailureMessage = `[reset][bold]Failed to migrate state from %s to %s.[reset]
+	logStateMigrationErroredDuringMigrationMessageHuman = `[reset][bold]Failed to migrate state from %s to %s.[reset]
 
 Something went wrong while migrating the state. Please check the errors message(s) above for more information.
 
@@ -49,6 +50,16 @@ The "terraform state migrate" command does not modify the source state, so you c
 
 Make sure you're supplying all the necessary attribute values for both the source and destination state stores. Remember, some values may need to be supplied via environment variables for either of the source or destination locations. If you continue to experience issues please report the issue to either the Terraform team when using a backend, or to the relevant provider development team when using a pluggable state store.
 `
+
+	logStateMigrationErroredDuringMigrationMessageJSON = `Failed to migrate state from %s to %s.`
+)
+
+type stateMigrationFailureMode string
+
+const (
+	DuringMigration        = "error_during_migration"
+	DuringLockfile         = "error_updating_provider_lockfile"
+	DuringBackendStateFile = "error_updating_workdir_state"
 )
 
 type StateMigrate interface {
@@ -57,6 +68,7 @@ type StateMigrate interface {
 
 	LogStateMigrationStart(source, destination string)
 	LogStateMigrationComplete()
+	LogStateMigrationErrored(failMode stateMigrationFailureMode, source, destination string)
 	LogStateMigrationFinalized(source, destination string)
 
 	ProviderInstallationLogger
@@ -104,6 +116,24 @@ func (s *StateMigrateHuman) LogStateMigrationFinalized(source string, destinatio
 
 func (s *StateMigrateHuman) LogStateMigrationComplete() {
 	// no-op
+}
+
+func (s *StateMigrateHuman) LogStateMigrationErrored(failMode stateMigrationFailureMode, source, destination string) {
+	// The JSON object describes slightly different failures that led to an error.
+	// So different messages are be logged depending which happened.
+	var msg string
+	switch failMode {
+	case DuringMigration:
+		// migration itself failed
+		msg = fmt.Sprintf(logStateMigrationErroredDuringMigrationMessageHuman, source, destination)
+	case DuringLockfile, DuringBackendStateFile:
+		// migration succeeded by updates in the working directory failed
+		msg = fmt.Sprintf(logStateMigrationErroredAfterMigrationMessageHuman, source, destination)
+	default:
+		panic("(*StateMigrateHuman)LogStateMigrationErrored: called incorrectly")
+	}
+
+	s.log(msg)
 }
 
 func (s *StateMigrateHuman) Log(message string, params ...any) {
@@ -304,6 +334,28 @@ func (s *StateMigrateJSON) LogStateMigrationComplete() {
 	s.view.log.Info(
 		logStateMigrationCompletedMessageJSON,
 		"type", json.StateMigrationComplete,
+	)
+}
+
+func (s *StateMigrateJSON) LogStateMigrationErrored(failMode stateMigrationFailureMode, source, destination string) {
+	// The JSON object describes slightly different failures that led to an error.
+	// So different messages are be logged depending which happened.
+	var msg string
+	switch failMode {
+	case DuringMigration:
+		// migration itself failed
+		msg = fmt.Sprintf(logStateMigrationErroredDuringMigrationMessageJSON, source, destination)
+	case DuringLockfile, DuringBackendStateFile:
+		// migration succeeded by updates in the working directory failed
+		msg = fmt.Sprintf(logStateMigrationErroredAfterMigrationMessageJSON, source, destination)
+	default:
+		panic("(*StateMigrateJSON)LogStateMigrationErrored: called incorrectly")
+	}
+
+	s.view.log.Info(
+		msg,
+		"failure_mode", failMode,
+		"type", json.StateMigrationErrored,
 	)
 }
 

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -10,14 +10,16 @@ import (
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/views/json"
 	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// Message text used in human output.
+// Message text used in human output, or as human-readable @message field in JSON output
 const (
 	// Notify the user that any preparation steps are over and the migration is starting.
-	StateMigrationStartMessage = "[reset][bold]Migrating state from %s to %s...[reset]"
+	logStateMigrationStartMessageHuman = "[reset][bold]Migrating state from %s to %s...[reset]"
+	logStateMigrationStartMessageJSON  = "Migrating state from %s to %s..."
 
 	// Notify the user that everything has completed successfully.
 	StateMigrationCompletedMessage = "[reset][bold]Finished migrating state from %s to %s.[reset]"
@@ -48,6 +50,8 @@ Make sure you're supplying all the necessary attribute values for both the sourc
 type StateMigrate interface {
 	Log(message string, params ...any)
 	Diagnostics(diags tfdiags.Diagnostics)
+
+	LogStateMigrationStart(source, destination string)
 
 	ProviderInstallationLogger
 	DependencyLockingLogger
@@ -80,6 +84,11 @@ type StateMigrateHuman struct {
 
 func (s *StateMigrateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 	s.view.Diagnostics(diags)
+}
+
+func (s *StateMigrateHuman) LogStateMigrationStart(source string, destination string) {
+	msg := fmt.Sprintf(logStateMigrationStartMessageHuman, source, destination)
+	s.log(msg)
 }
 
 func (s *StateMigrateHuman) Log(message string, params ...any) {
@@ -267,3 +276,11 @@ func (s *StateMigrateJSON) LogAutomaticApproval() {
 	)
 }
 
+func (s *StateMigrateJSON) LogStateMigrationStart(source, destination string) {
+	msg := fmt.Sprintf(logStateMigrationStartMessageJSON, source, destination)
+
+	s.view.log.Info(
+		msg,
+		"type", json.StateMigrationStart,
+	)
+}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -70,6 +70,10 @@ type StateMigrate interface {
 	LogStateMigrationComplete()
 	LogStateMigrationErrored(failMode stateMigrationFailureMode, source, destination string)
 	LogStateMigrationFinalized(source, destination string)
+	// LogStateMigrationSourceInitializationStart()
+	// LogStateMigrationSourceInitializationComplete()
+	// LogStateMigrationDestinationInitializationStart()
+	// LogStateMigrationDestinationInitializationComplete()
 
 	ProviderInstallationLogger
 	DependencyLockingLogger
@@ -93,6 +97,7 @@ func NewStateMigrate(viewType arguments.ViewType, view *View) StateMigrate {
 var (
 	_ StateMigrate               = (*StateMigrateHuman)(nil)
 	_ ProviderInstallationLogger = (*StateMigrateHuman)(nil)
+	_ DependencyLockingLogger    = (*StateMigrateHuman)(nil)
 	_ Spacer                     = (*StateMigrateHuman)(nil)
 )
 
@@ -297,6 +302,32 @@ func (s *StateMigrateJSON) Spacer() {
 	// no-op for JSON output, since we don't want to log empty messages in JSON
 }
 
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) Output(code InitMessageCode, params ...any) {
+	message, ok := MessageRegistry[code]
+	if !ok {
+		panic("missing message for InstallingProviderMessage init message code")
+	}
+	s.view.log.Info(
+		strings.TrimSpace(fmt.Sprintf(message.JSONValue, params...)),
+		"type", "log",
+	)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogInitializingStateStoreProviderStart(pAddr tfaddr.Provider, cons getproviders.VersionConstraints, storeType string) {
+	consSuffix := ""
+	if len(cons) > 0 {
+		consSuffix = fmt.Sprintf(" (%s)", getproviders.VersionConstraintsString(cons))
+	}
+	params := []any{pAddr.ForDisplay(), consSuffix, storeType}
+	msg := fmt.Sprintf(logInitializingStateStoreProviderStartMessageJSON, params...)
+	s.view.log.Info(
+		msg,
+		"type", json.InitializingStateStoreProviderStart,
+	)
+}
+
 // Implements StateStoreProviderTrustLogger interface.
 func (s *StateMigrateJSON) LogInteractiveApproval() {
 	s.view.log.Info(
@@ -319,6 +350,75 @@ func (s *StateMigrateJSON) LogAutomaticApproval() {
 		logInteractiveAutomaticApprovalMessageJSON,
 		"type", json.StateStoreProviderAutomaticApproval,
 	)
+}
+
+// Implements ProviderInstallationLogger interface.
+// func (s *StateMigrateJSON) LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints) {
+// 	params := []any{providerAddr.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints)}
+// 	msg := fmt.Sprintf(logFindingMatchingVersionMessageHuman, params...)
+// 	s.Output(FindingMatchingVersionMessage, params...)
+
+// 	s.view.log.Info(
+// 		msg,
+// 		"type", json.Provider,
+// 	)
+// }
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogFindingLatestVersion(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+	s.Output(FindingLatestVersionMessage, params...)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogProviderVersionAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+	s.Output(ProviderAlreadyInstalledMessage, params...)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogUsingProviderVersionFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+	s.Output(UsingProviderFromCacheDirInfo, params...)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
+	params := []any{providerAddr.ForDisplay()}
+	s.Output(BuiltInProviderAvailableMessage, params...)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogInstallingProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{providerAddr.ForDisplay(), version}
+	s.Output(InstallingProviderMessage, params...)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogReusingPreviousProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
+	params := []any{version, providerAddr.ForDisplay()}
+	s.Output(ReusingPreviousVersionInfo, params...)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+	params := []any{providerAddr.ForDisplay(), version, auth, ""}
+	s.Output(InstalledProviderVersionInfo, params...)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+	params := []any{providerAddr.ForDisplay(), version, auth, fmt.Sprintf(", key ID %s", keyID)}
+	s.Output(InstalledProviderVersionInfo, params...)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogPartnerAndCommunityProviders() {
+	s.Output(PartnerAndCommunityProvidersMessage)
+}
+
+func (s *StateMigrateJSON) Log(msg string, params ...any) {
+	panic("don't use this method")
 }
 
 func (s *StateMigrateJSON) LogStateMigrationStart(source, destination string) {

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -21,8 +21,11 @@ const (
 	logStateMigrationStartMessageHuman = "[reset][bold]Migrating state from %s to %s...[reset]"
 	logStateMigrationStartMessageJSON  = "Migrating state from %s to %s..."
 
-	// Notify the user that everything has completed successfully.
-	StateMigrationCompletedMessage = "[reset][bold]Finished migrating state from %s to %s.[reset]"
+	// JSON output only; mark when migration process ends within the wider command
+	logStateMigrationCompletedMessageJSON = "Migration complete"
+
+	// Notify the user that everything has completed successfully, including updating the backend state file.
+	StateMigrationFinalizedMessage = "[reset][bold]Finished migrating state from %s to %s.[reset]"
 
 	// Notify the user that an error has occurred, but there have been changes to where state is stored.
 	// Hopefully the errors accompanying this message are actionable by users, but if not we expect a bug report.
@@ -52,6 +55,7 @@ type StateMigrate interface {
 	Diagnostics(diags tfdiags.Diagnostics)
 
 	LogStateMigrationStart(source, destination string)
+	LogStateMigrationComplete()
 
 	ProviderInstallationLogger
 	DependencyLockingLogger
@@ -89,6 +93,10 @@ func (s *StateMigrateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 func (s *StateMigrateHuman) LogStateMigrationStart(source string, destination string) {
 	msg := fmt.Sprintf(logStateMigrationStartMessageHuman, source, destination)
 	s.log(msg)
+}
+
+func (s *StateMigrateHuman) LogStateMigrationComplete() {
+	// no-op
 }
 
 func (s *StateMigrateHuman) Log(message string, params ...any) {
@@ -282,5 +290,12 @@ func (s *StateMigrateJSON) LogStateMigrationStart(source, destination string) {
 	s.view.log.Info(
 		msg,
 		"type", json.StateMigrationStart,
+	)
+}
+
+func (s *StateMigrateJSON) LogStateMigrationComplete() {
+	s.view.log.Info(
+		logStateMigrationCompletedMessageJSON,
+		"type", json.StateMigrationComplete,
 	)
 }

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -25,7 +25,8 @@ const (
 	logStateMigrationCompletedMessageJSON = "Migration complete"
 
 	// Notify the user that everything has completed successfully, including updating the backend state file.
-	StateMigrationFinalizedMessage = "[reset][bold]Finished migrating state from %s to %s.[reset]"
+	logStateMigrationFinalizedMessageHuman = "[reset][bold]Finished migrating state from %s to %s.[reset]"
+	logStateMigrationFinalizedMessageJSON  = "Finished migrating state from %s to %s."
 
 	// Notify the user that an error has occurred, but there have been changes to where state is stored.
 	// Hopefully the errors accompanying this message are actionable by users, but if not we expect a bug report.
@@ -56,6 +57,7 @@ type StateMigrate interface {
 
 	LogStateMigrationStart(source, destination string)
 	LogStateMigrationComplete()
+	LogStateMigrationFinalized(source, destination string)
 
 	ProviderInstallationLogger
 	DependencyLockingLogger
@@ -92,6 +94,11 @@ func (s *StateMigrateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 
 func (s *StateMigrateHuman) LogStateMigrationStart(source string, destination string) {
 	msg := fmt.Sprintf(logStateMigrationStartMessageHuman, source, destination)
+	s.log(msg)
+}
+
+func (s *StateMigrateHuman) LogStateMigrationFinalized(source string, destination string) {
+	msg := fmt.Sprintf(logStateMigrationFinalizedMessageHuman, source, destination)
 	s.log(msg)
 }
 
@@ -297,5 +304,12 @@ func (s *StateMigrateJSON) LogStateMigrationComplete() {
 	s.view.log.Info(
 		logStateMigrationCompletedMessageJSON,
 		"type", json.StateMigrationComplete,
+	)
+}
+
+func (s *StateMigrateJSON) LogStateMigrationFinalized() {
+	s.view.log.Info(
+		logStateMigrationFinalizedMessageJSON,
+		"type", json.StateMigrationFinalized,
 	)
 }

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -207,3 +207,24 @@ func TestNewStateMigrate_LogStateMigrationStart_json(t *testing.T) {
 	}
 }
 
+func TestNewStateMigrate_LogStateMigrationComplete_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogStateMigrationComplete()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Migration complete"`,
+		`"@module":"terraform.ui"`,
+		`"type":"migration_complete"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -117,6 +117,72 @@ func TestNewStateMigrate_Spacer_json(t *testing.T) {
 	}
 }
 
+func TestNewStateMigrate_LogStateMigrationErrored_human(t *testing.T) {
+	t.Run("migration error", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := NewStateMigrate(arguments.ViewHuman, view)
+
+		source := `backend "local"`
+		destination := `state store "test_store"`
+
+		smView.LogStateMigrationErrored(DuringMigration, source, destination)
+
+		// Assert output
+		output := done(t)
+		expectedOutputSnippets := []string{
+			`Failed to migrate state from backend "local" to state store "test_store"`,
+		}
+		for _, snippet := range expectedOutputSnippets {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
+	t.Run("provider lockfile error", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := NewStateMigrate(arguments.ViewHuman, view)
+
+		source := `backend "local"`
+		destination := `state store "test_store"`
+
+		smView.LogStateMigrationErrored(DuringLockfile, source, destination)
+
+		// Assert output
+		output := done(t)
+		expectedOutputSnippets := []string{
+			`Finished migrating state from backend "local" to state store "test_store", but an error occurred before Terraform was finished.`,
+		}
+		for _, snippet := range expectedOutputSnippets {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
+	t.Run("backend state file error", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := NewStateMigrate(arguments.ViewHuman, view)
+
+		source := `backend "local"`
+		destination := `state store "test_store"`
+
+		smView.LogStateMigrationErrored(DuringBackendStateFile, source, destination)
+
+		// Assert output
+		output := done(t)
+		expectedOutputSnippets := []string{
+			`Finished migrating state from backend "local" to state store "test_store", but an error occurred before Terraform was finished.`,
+		}
+		for _, snippet := range expectedOutputSnippets {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
+}
+
 func TestNewStateMigrate_LogInteractiveApproval_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
@@ -227,4 +293,84 @@ func TestNewStateMigrate_LogStateMigrationComplete_json(t *testing.T) {
 			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
 		}
 	}
+}
+
+func TestNewStateMigrate_LogStateMigrationErrored_json(t *testing.T) {
+	t.Run("migration error", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := StateMigrateJSON{view: NewJSONView(view)}
+
+		source := `backend "local"`
+		destination := `state store "test_store"`
+
+		smView.LogStateMigrationErrored(DuringMigration, source, destination)
+
+		// Assert output
+		output := done(t)
+		expectedOutputFields := []string{
+			`"@level":"info"`,
+			`Failed to migrate state from`, // @message
+			`"@module":"terraform.ui"`,
+			`"failure_mode":"error_during_migration"`, // custom field
+			`"type":"migration_errored"`,
+		}
+		for _, snippet := range expectedOutputFields {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
+	t.Run("provider lockfile error", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := StateMigrateJSON{view: NewJSONView(view)}
+
+		source := `backend "local"`
+		destination := `state store "test_store"`
+
+		smView.LogStateMigrationErrored(DuringLockfile, source, destination)
+
+		// Assert output
+		output := done(t)
+		expectedOutputFields := []string{
+			`"@level":"info"`,
+			`Finished migrating state`,                        // @message
+			`an error occurred before Terraform was finished`, // @message
+			`"@module":"terraform.ui"`,
+			`"failure_mode":"error_updating_provider_lockfile"`, // custom field
+			`"type":"migration_errored"`,
+		}
+		for _, snippet := range expectedOutputFields {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
+	t.Run("backend state file error", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := StateMigrateJSON{view: NewJSONView(view)}
+
+		source := `backend "local"`
+		destination := `state store "test_store"`
+
+		smView.LogStateMigrationErrored(DuringBackendStateFile, source, destination)
+
+		// Assert output
+		output := done(t)
+		expectedOutputFields := []string{
+			`"@level":"info"`,
+			`Finished migrating state`,                        // @message
+			`an error occurred before Terraform was finished`, // @message
+			`"@module":"terraform.ui"`,
+			`"failure_mode":"error_updating_workdir_state"`, // custom field
+			`"type":"migration_errored"`,
+		}
+		for _, snippet := range expectedOutputFields {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
 }

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -182,3 +182,28 @@ func TestNewStateMigrate_LogAutomaticApproval_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogStateMigrationStart_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	source := `backend "local"`
+	destination := `state store "test_store"`
+	smView.LogStateMigrationStart(source, destination)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Migrating state from backend \"local\" to state store \"test_store\"..."`,
+		`"@module":"terraform.ui"`,
+		`"type":"migration_start"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+


### PR DESCRIPTION
WIP

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
