### PR TITLE
fix: Ensure diagnostics not discarded when renewing an ephemeral resource

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260807-121758.yaml
+++ b/.changes/v1.17/BUG FIXES-20260807-121758.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: "ephemeral: Terraform will now use and display diagnostics raised when _renewing_ an ephemeral resource. This may cause warnings to appear that previously were lost. We expect that any error diagnostics that were previously lost would have caused confusing downstream errors."
+time: 2026-08-07T12:17:58.779212+01:00
+custom:
+  Issue: "38989"

--- a/.changes/v1.17/BUG FIXES-20260807-121758.yaml
+++ b/.changes/v1.17/BUG FIXES-20260807-121758.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: "ephemeral: Terraform will now use and display diagnostics raised when _renewing_ an ephemeral resource. This may cause warnings to appear that previously were lost. We expect that any error diagnostics that were previously lost would have caused confusing downstream errors."
+body: "ephemeral: Terraform will now use and display diagnostics raised when _renewing_ an ephemeral resource. This may cause warnings to appear that previously were lost. We expect that any error diagnostics that were previously lost would have caused confusing downstream errors, so we do not anticipate this change to be breaking."
 time: 2026-08-07T12:17:58.779212+01:00
 custom:
   Issue: "38989"

--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -246,7 +246,7 @@ func (r *resourceInstanceInternal) handleRenewal(ctx context.Context, wg *sync.W
 			// It's time to renew
 			r.renewMu.Lock()
 			anotherRenew, diags := r.impl.Renew(ctx, *nextRenew)
-			r.renewDiags.Append(diags)
+			r.renewDiags = r.renewDiags.Append(diags)
 			if diags.HasErrors() {
 				// If renewal fails then we'll stop trying to renew.
 				r.renewCancel = noopCancel

--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -102,7 +102,10 @@ func (r *Resources) InstanceValue(addr addrs.AbsResourceInstance) (val cty.Value
 	}
 	// If renewal has failed then we can't assume that the object is still
 	// live, but we can still return the original value regardless.
-	return inst.value, !inst.renewDiags.HasErrors()
+	inst.renewMu.Lock()
+	live = !inst.renewDiags.HasErrors()
+	inst.renewMu.Unlock()
+	return inst.value, live
 }
 
 // CloseInstances shuts down any live ephemeral resource instances that are


### PR DESCRIPTION
This change stops diagnostics being lost during the process of renewing an ephemeral resource instance.

This enables calling code to:
1) Identify expired ephemeral resource instances (see [this part of (d *evaluationStateData) getEphemeralResource](https://github.com/hashicorp/terraform/blob/89881f35bd73e6be8ce686c16decd95b134ab9a9/internal/terraform/evaluate.go#L1124) - `isLive` depends on lack of errors)
2) Show any warnings from the renewal process after the ephemeral resource instance is closed (see [this line in (r *resourceInstanceInternal) close ](https://github.com/hashicorp/terraform/blob/89881f35bd73e6be8ce686c16decd95b134ab9a9/internal/resources/ephemeral/ephemeral_resources.go#L225)that passes renew diags to calling code.)

As this could potentially change the behaviour of an ephemeral resource, I'll add a change file reporting this as a bug fix.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
