### PR TITLE
Address unused diagnostics in v4 state file parsing logic

### DIFF
--- a/internal/states/statefile/read.go
+++ b/internal/states/statefile/read.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	version "github.com/hashicorp/go-version"
@@ -32,9 +31,11 @@ type ErrUnusableState struct {
 func errUnusable(err error) *ErrUnusableState {
 	return &ErrUnusableState{inner: err}
 }
+
 func (e *ErrUnusableState) Error() string {
 	return e.inner.Error()
 }
+
 func (e *ErrUnusableState) Unwrap() error {
 	return e.inner
 }
@@ -60,7 +61,7 @@ func Read(r io.Reader) (*File, error) {
 	// We actually just buffer the whole thing in memory, because states are
 	// generally not huge and we need to do be able to sniff for a version
 	// number before full parsing.
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/states/statefile/roundtrip_test.go
+++ b/internal/states/statefile/roundtrip_test.go
@@ -5,7 +5,6 @@ package statefile
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -17,7 +16,7 @@ import (
 
 func TestRoundtrip(t *testing.T) {
 	const dir = "testdata/roundtrip"
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +36,7 @@ func TestRoundtrip(t *testing.T) {
 		outName := name + outSuffix
 
 		t.Run(name, func(t *testing.T) {
-			oSrcWant, err := ioutil.ReadFile(filepath.Join(dir, outName))
+			oSrcWant, err := os.ReadFile(filepath.Join(dir, outName))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/states/statefile/testdata/bad-state-files/invalid-provider-for-resource.tfstate
+++ b/internal/states/statefile/testdata/bad-state-files/invalid-provider-for-resource.tfstate
@@ -1,0 +1,33 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.0",
+  "serial": 0,
+  "lineage": "f2968801-fa14-41ab-a044-224f3a4adf04",
+  "outputs": {
+    "numbers": {
+      "value": "0,1",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "bar",
+      "provider": "this is an invalid value for this field",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes_flat": {
+            "id": "5388490630832483079",
+            "triggers.%": "1",
+            "triggers.whaaat": "0,1"
+          },
+          "depends_on": [
+            "null_resource.foo"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -87,7 +87,6 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 		}
 
 		providerAddr, addrDiags := addrs.ParseAbsProviderConfigStr(rsV4.ProviderConfig)
-		diags.Append(addrDiags)
 		if addrDiags.HasErrors() {
 			// If ParseAbsProviderConfigStr returns an error, the state may have
 			// been written before Provider FQNs were introduced and the
@@ -97,6 +96,9 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 			var legacyAddrDiags tfdiags.Diagnostics
 			providerAddr, legacyAddrDiags = addrs.ParseLegacyAbsProviderConfigStr(rsV4.ProviderConfig)
 			if legacyAddrDiags.HasErrors() {
+				// Perhaps it wasn't a legacy string format after all; return
+				// the original error to the caller
+				diags = diags.Append(addrDiags)
 				continue
 			}
 		}

--- a/internal/states/statefile/version4_test.go
+++ b/internal/states/statefile/version4_test.go
@@ -263,7 +263,8 @@ func TestVersion4_marshalPaths(t *testing.T) {
 }
 
 // Regression test - make sure that errors parsing the provider address of a resource
-// are returned to calling code and result in user-facing diagnostics.
+// are returned to calling code and result in user-facing diagnostics. This only happens
+// if 'regular' and legacy parsing attempts both fail.
 func TestVersion4_readStateV4(t *testing.T) {
 	// internal/states/statefile/testdata/bad-state-files/
 	path := "testdata/bad-state-files/invalid-provider-for-resource.tfstate"

--- a/internal/states/statefile/version4_test.go
+++ b/internal/states/statefile/version4_test.go
@@ -4,6 +4,7 @@
 package statefile
 
 import (
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -258,5 +259,22 @@ func TestVersion4_marshalPaths(t *testing.T) {
 				t.Fatalf("wrong JSON output\n got: %s\nwant: %s\n", got, want)
 			}
 		})
+	}
+}
+
+// Regression test - make sure that errors parsing the provider address of a resource
+// are returned to calling code and result in user-facing diagnostics.
+func TestVersion4_readStateV4(t *testing.T) {
+	// internal/states/statefile/testdata/bad-state-files/
+	path := "testdata/bad-state-files/invalid-provider-for-resource.tfstate"
+	input, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, diags := readStateV4(input)
+
+	if !diags.HasErrors() {
+		t.Fatal("expected an error due to bad provider address data, but got none")
 	}
 }

--- a/internal/states/statefile/version4_test.go
+++ b/internal/states/statefile/version4_test.go
@@ -266,7 +266,6 @@ func TestVersion4_marshalPaths(t *testing.T) {
 // are returned to calling code and result in user-facing diagnostics. This only happens
 // if 'regular' and legacy parsing attempts both fail.
 func TestVersion4_readStateV4(t *testing.T) {
-	// internal/states/statefile/testdata/bad-state-files/
 	path := "testdata/bad-state-files/invalid-provider-for-resource.tfstate"
 	input, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
This fixes any alerts about unused return values from `(Diagnostics).Append` that can happen in a PR if it merges main into its branch ([example](https://github.com/hashicorp/terraform/actions/runs/31171291630/job/92843452351?pr=38869)). When that happens any existing instances of the problem on main are detectable by the check on the PR.

In this part of code we're parsing a v4 state file, specifically the address for the provider used to provision a resource.

There is some tolerance of bad values in this code by falling back to attempting to parse the 'bad' value as a legacy provider string. Due to this I figured it was only appropriate to append the original error to the `diags` collection if that second parsing attempt also fails.

Realistically, I don't expect that this change will result in users experiencing new errors as there would be downstream errors if the state file couldn't accurately report which provider was used for a given resource.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
