### PR TITLE
refactor: Add `LogConfigurationCopyingStart` method to `init` command's view implementations

### DIFF
--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -76,7 +76,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 			return 1
 		}
 
-		view.Output(views.CopyingConfigurationMessage, src)
+		view.LogConfigurationCopyingStart(src)
 
 		hooks := uiModuleInstallHooks{
 			Ui:             c.Ui,

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -22,6 +22,9 @@ type Init interface {
 	PolicyDiagnostics(diags policy.Diagnostics)
 	Output(messageCode InitMessageCode, params ...any)
 
+	// LogConfigurationCopyingStart describes the start of copying a module to create the root module in an empty directory.
+	LogConfigurationCopyingStart(moduleSource string)
+
 	ModuleInstallationLogger
 	ProviderInstallationLogger
 	DependencyLockingLogger
@@ -76,6 +79,10 @@ func (v *InitHuman) PolicyResult(addr string, resp policy.EvaluationResponse) {
 
 func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
 	v.print(v.prepareMessage(messageCode, params...))
+}
+
+func (v *InitHuman) LogConfigurationCopyingStart(moduleSource string) {
+	v.print(v.prepareMessage(CopyingConfigurationMessage, moduleSource))
 }
 
 func (v *InitHuman) LogInitializingStateStoreProviderPlugin(pAddr tfaddr.Provider, cons getproviders.VersionConstraints, storeType string) {
@@ -249,6 +256,14 @@ func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
 		"type", "init_output",
 		"message_code", string(messageCode),
 	)
+}
+
+func (v *InitJSON) LogConfigurationCopyingStart(moduleSource string) {
+	params := []any{moduleSource}
+
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.Output(CopyingConfigurationMessage, params...)
 }
 
 // logInitMessage is an internalised version of an old method `LogInitMessage`.

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -1051,6 +1051,30 @@ func TestNewInit_LogModuleInitialization_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogConfigurationCopyingStart_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	source := "./modules/my-bestest-module"
+	initView.LogConfigurationCopyingStart(source)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Copying configuration from \"./modules/my-bestest-module\"..."`,
+		`"@module":"terraform.ui"`,
+		`"message_code":"copying_configuration_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)


### PR DESCRIPTION
This replaces an instance of how the `Output` command is used. In future, this change could enable the JSON output for this event to be more specialised as it's logged via an even-specific method.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.