### PR TITLE
refactor: Add methods to init command's view implementations for logging about progress of initialising the working directory

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -146,7 +146,7 @@ func (c *InitCommand) initCloud(ctx context.Context, root *configs.Module, extra
 	_ = ctx // prevent staticcheck from complaining to avoid a maintenance hazard of having the wrong ctx in scope here
 	defer span.End()
 
-	view.Output(views.InitializingTerraformCloudMessage)
+	view.LogCloudInitializationStart()
 
 	if len(extraConfig.AllItems()) != 0 {
 		diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -110,7 +110,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		return 1
 	}
 	if empty {
-		view.Output(views.OutputInitEmptyMessage)
+		view.LogInitializationComplete(true)
 		return 0
 	}
 
@@ -449,7 +449,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	if cloud {
 		view.LogCloudInitializationComplete()
 	} else {
-		view.LogInitializationComplete()
+		view.LogInitializationComplete(false)
 	}
 
 	if !c.RunningInAutomation {

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -456,11 +456,11 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		// If we're not running in an automation wrapper, give the user
 		// some more detailed next steps that are appropriate for interactive
 		// shell usage.
-		output := views.OutputInitSuccessCLIMessage
 		if cloud {
-			output = views.OutputInitSuccessCLICloudMessage
+			view.LogCloudInitializationCompleteCallToAction()
+		} else {
+			view.LogInitializationCompleteCallToAction()
 		}
-		view.Output(output)
 	}
 	return 0
 }

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -446,18 +446,17 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	// still the final thing shown.
 	view.Diagnostics(diags)
 	_, cloud := back.(*cloud.Cloud)
-	output := views.OutputInitSuccessMessage
 	if cloud {
-		output = views.OutputInitSuccessCloudMessage
+		view.LogCloudInitializationComplete()
+	} else {
+		view.LogInitializationComplete()
 	}
-
-	view.Output(output)
 
 	if !c.RunningInAutomation {
 		// If we're not running in an automation wrapper, give the user
 		// some more detailed next steps that are appropriate for interactive
 		// shell usage.
-		output = views.OutputInitSuccessCLIMessage
+		output := views.OutputInitSuccessCLIMessage
 		if cloud {
 			output = views.OutputInitSuccessCLICloudMessage
 		}

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -32,7 +32,9 @@ type Init interface {
 	LogCloudInitializationCompleteCallToAction()
 
 	// LogInitializationComplete describes the successful end of initializing the workspace.
-	// Output is different depending on whether the configuration is empty or contains resources.
+	//
+	// Output is different depending on whether the configuration is empty or contains resources. Calling code should report if
+	// the config is empty via the boolean.
 	LogInitializationComplete(emptyDirectory bool)
 	// LogInitializationCompleteCallToAction  prompts users about what to do next after initialization.
 	// This is only used if the CLI is being used outside of automation; a human will see the CTA.

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -31,8 +31,9 @@ type Init interface {
 	// This is only used if the cloud backend is used, and the CLI is being used outside of automation; a human will see the CTA.
 	LogCloudInitializationCompleteCallToAction()
 
-	// LogInitializationComplete describes the successful end of initializing the workspace
-	LogInitializationComplete()
+	// LogInitializationComplete describes the successful end of initializing the workspace.
+	// Output is different depending on whether the configuration is empty or contains resources.
+	LogInitializationComplete(emptyDirectory bool)
 	// LogInitializationCompleteCallToAction  prompts users about what to do next after initialization.
 	// This is only used if the CLI is being used outside of automation; a human will see the CTA.
 	LogInitializationCompleteCallToAction()
@@ -113,9 +114,15 @@ func (v *InitHuman) LogInitializationCompleteCallToAction() {
 	v.print(v.prepareMessage(OutputInitSuccessCLIMessage, params...))
 }
 
-func (v *InitHuman) LogInitializationComplete() {
+func (v *InitHuman) LogInitializationComplete(emptyDirectory bool) {
 	params := []any{}
-	v.print(v.prepareMessage(OutputInitSuccessMessage, params...))
+	var code InitMessageCode
+	if emptyDirectory {
+		code = OutputInitEmptyMessage
+	} else {
+		code = OutputInitSuccessMessage
+	}
+	v.print(v.prepareMessage(code, params...))
 }
 
 func (v *InitHuman) LogInitializingStateStoreProviderPlugin(pAddr tfaddr.Provider, cons getproviders.VersionConstraints, storeType string) {
@@ -323,12 +330,18 @@ func (v *InitJSON) LogInitializationCompleteCallToAction() {
 	v.Output(OutputInitSuccessCLIMessage, params...)
 }
 
-func (v *InitJSON) LogInitializationComplete() {
+func (v *InitJSON) LogInitializationComplete(emptyDirectory bool) {
 	params := []any{}
+	var code InitMessageCode
+	if emptyDirectory {
+		code = OutputInitEmptyMessage
+	} else {
+		code = OutputInitSuccessMessage
+	}
 
 	// This was previously logged via Output, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
-	v.Output(OutputInitSuccessMessage, params...)
+	v.Output(code, params...)
 }
 
 // logInitMessage is an internalised version of an old method `LogInitMessage`.

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -27,9 +27,15 @@ type Init interface {
 	// LogCloudInitializationComplete describes the successful end of initializing the workspace
 	// while using the cloud backend
 	LogCloudInitializationComplete()
+	// LogCloudInitializationCompleteCallToAction prompts users about what to do next after initialization.
+	// This is only used if the cloud backend is used, and the CLI is being used outside of automation; a human will see the CTA.
+	LogCloudInitializationCompleteCallToAction()
 
 	// LogInitializationComplete describes the successful end of initializing the workspace
 	LogInitializationComplete()
+	// LogInitializationCompleteCallToAction  prompts users about what to do next after initialization.
+	// This is only used if the CLI is being used outside of automation; a human will see the CTA.
+	LogInitializationCompleteCallToAction()
 
 	ModuleInstallationLogger
 	ProviderInstallationLogger
@@ -95,6 +101,16 @@ func (v *InitHuman) LogCloudInitializationStart() {
 func (v *InitHuman) LogCloudInitializationComplete() {
 	params := []any{}
 	v.print(v.prepareMessage(OutputInitSuccessCloudMessage, params...))
+}
+
+func (v *InitHuman) LogCloudInitializationCompleteCallToAction() {
+	params := []any{}
+	v.print(v.prepareMessage(OutputInitSuccessCLICloudMessage, params...))
+}
+
+func (v *InitHuman) LogInitializationCompleteCallToAction() {
+	params := []any{}
+	v.print(v.prepareMessage(OutputInitSuccessCLIMessage, params...))
 }
 
 func (v *InitHuman) LogInitializationComplete() {
@@ -289,6 +305,22 @@ func (v *InitJSON) LogCloudInitializationComplete() {
 	// This was previously logged via Output, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	v.Output(OutputInitSuccessCloudMessage, params...)
+}
+
+func (v *InitJSON) LogCloudInitializationCompleteCallToAction() {
+	params := []any{}
+
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.Output(OutputInitSuccessCLICloudMessage, params...)
+}
+
+func (v *InitJSON) LogInitializationCompleteCallToAction() {
+	params := []any{}
+
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.Output(OutputInitSuccessCLIMessage, params...)
 }
 
 func (v *InitJSON) LogInitializationComplete() {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -24,6 +24,12 @@ type Init interface {
 
 	// LogCloudInitializationStart describes the start of initializing the cloud backend
 	LogCloudInitializationStart()
+	// LogCloudInitializationComplete describes the successful end of initializing the workspace
+	// while using the cloud backend
+	LogCloudInitializationComplete()
+
+	// LogInitializationComplete describes the successful end of initializing the workspace
+	LogInitializationComplete()
 
 	ModuleInstallationLogger
 	ProviderInstallationLogger
@@ -84,6 +90,16 @@ func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
 func (v *InitHuman) LogCloudInitializationStart() {
 	params := []any{}
 	v.print(v.prepareMessage(InitializingTerraformCloudMessage, params...))
+}
+
+func (v *InitHuman) LogCloudInitializationComplete() {
+	params := []any{}
+	v.print(v.prepareMessage(OutputInitSuccessCloudMessage, params...))
+}
+
+func (v *InitHuman) LogInitializationComplete() {
+	params := []any{}
+	v.print(v.prepareMessage(OutputInitSuccessMessage, params...))
 }
 
 func (v *InitHuman) LogInitializingStateStoreProviderPlugin(pAddr tfaddr.Provider, cons getproviders.VersionConstraints, storeType string) {
@@ -265,6 +281,22 @@ func (v *InitJSON) LogCloudInitializationStart() {
 	// This was previously logged via Output, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	v.Output(InitializingTerraformCloudMessage, params...)
+}
+
+func (v *InitJSON) LogCloudInitializationComplete() {
+	params := []any{}
+
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.Output(OutputInitSuccessCloudMessage, params...)
+}
+
+func (v *InitJSON) LogInitializationComplete() {
+	params := []any{}
+
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.Output(OutputInitSuccessMessage, params...)
 }
 
 // logInitMessage is an internalised version of an old method `LogInitMessage`.

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -22,6 +22,9 @@ type Init interface {
 	PolicyDiagnostics(diags policy.Diagnostics)
 	Output(messageCode InitMessageCode, params ...any)
 
+	// LogCloudInitializationStart describes the start of initializing the cloud backend
+	LogCloudInitializationStart()
+
 	ModuleInstallationLogger
 	ProviderInstallationLogger
 	DependencyLockingLogger
@@ -76,6 +79,11 @@ func (v *InitHuman) PolicyResult(addr string, resp policy.EvaluationResponse) {
 
 func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
 	v.print(v.prepareMessage(messageCode, params...))
+}
+
+func (v *InitHuman) LogCloudInitializationStart() {
+	params := []any{}
+	v.print(v.prepareMessage(InitializingTerraformCloudMessage, params...))
 }
 
 func (v *InitHuman) LogInitializingStateStoreProviderPlugin(pAddr tfaddr.Provider, cons getproviders.VersionConstraints, storeType string) {
@@ -249,6 +257,14 @@ func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
 		"type", "init_output",
 		"message_code", string(messageCode),
 	)
+}
+
+func (v *InitJSON) LogCloudInitializationStart() {
+	params := []any{}
+
+	// This was previously logged via Output, so we need to match implementation of that method
+	// to ensure the same JSON log is produced.
+	v.Output(InitializingTerraformCloudMessage, params...)
 }
 
 // logInitMessage is an internalised version of an old method `LogInitMessage`.

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -1075,6 +1075,54 @@ func TestNewInit_LogCloudInitializationStart_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogCloudInitializationComplete_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogCloudInitializationComplete()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"HCP Terraform has been successfully initialized!"`,
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"message_code":"output_init_success_cloud_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewInit_LogInitializationComplete_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogInitializationComplete()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Terraform has been successfully initialized!"`,
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"message_code":"output_init_success_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -1123,6 +1123,54 @@ func TestNewInit_LogInitializationComplete_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogCloudInitializationCompleteCallToAction_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogCloudInitializationCompleteCallToAction()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"You may now begin working with HCP Terraform. Try running \"terraform plan\"`, // ... incomplete but sufficient for test
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"message_code":"output_init_success_cli_cloud_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewInit_LogInitializationCompleteCallToAction_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogInitializationCompleteCallToAction()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"You may now begin working with Terraform. Try running \"terraform plan\" `, // ... incomplete but sufficient for test
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"message_code":"output_init_success_cli_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -1100,27 +1100,54 @@ func TestNewInit_LogCloudInitializationComplete_json(t *testing.T) {
 }
 
 func TestNewInit_LogInitializationComplete_json(t *testing.T) {
-	streams, done := terminal.StreamsForTesting(t)
-	view := NewView(streams)
-	initView := NewInit(arguments.ViewJSON, view)
+	t.Run("empty config", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		initView := NewInit(arguments.ViewJSON, view)
 
-	initView.LogInitializationComplete()
+		empty := true
+		initView.LogInitializationComplete(empty)
 
-	// Assert output
-	output := done(t)
-	expectedOutputFields := []string{
-		`"@level":"info"`,
-		`"@message":"Terraform has been successfully initialized!"`,
-		`"@module":"terraform.ui"`,
-		//@timestamp is dynamic
-		`"message_code":"output_init_success_message"`,
-		`"type":"init_output"`,
-	}
-	for _, snippet := range expectedOutputFields {
-		if !strings.Contains(output.Stdout(), snippet) {
-			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		// Assert output
+		output := done(t)
+		expectedOutputFields := []string{
+			`"@level":"info"`,
+			`"@message":"Terraform initialized in an empty directory!`, // ... incomplete but sufficient for test
+			`"@module":"terraform.ui"`,
+			//@timestamp is dynamic
+			`"message_code":"output_init_empty_message"`,
+			`"type":"init_output"`,
 		}
-	}
+		for _, snippet := range expectedOutputFields {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
+	t.Run("non-empty config", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		initView := NewInit(arguments.ViewJSON, view)
+
+		empty := false
+		initView.LogInitializationComplete(empty)
+
+		// Assert output
+		output := done(t)
+		expectedOutputFields := []string{
+			`"@level":"info"`,
+			`"@message":"Terraform has been successfully initialized!"`,
+			`"@module":"terraform.ui"`,
+			//@timestamp is dynamic
+			`"message_code":"output_init_success_message"`,
+			`"type":"init_output"`,
+		}
+		for _, snippet := range expectedOutputFields {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
 }
 
 func TestNewInit_LogCloudInitializationCompleteCallToAction_json(t *testing.T) {

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -1051,6 +1051,30 @@ func TestNewInit_LogModuleInitialization_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogCloudInitializationStart_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogCloudInitializationStart()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Initializing HCP Terraform..."`,
+		`"@module":"terraform.ui"`,
+		//@timestamp is dynamic
+		`"message_code":"initializing_terraform_cloud_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)


### PR DESCRIPTION
This PR adds methods to the `views` package's `Init` interface for logging messages related to the progress of initialising the working directory:

1) Initialization is starting (only used for cloud backend)
* Text `Initializing HCP Terraform...`
* JSON message code: `initializing_terraform_cloud_message`

2) Initialization completes
* Text `Terraform has been successfully initialized!` OR `Terraform initialized in an empty directory!`
* JSON message code: `output_init_success_message` OR `output_init_empty_message`

3) Calls to action shown to those using the CLI directly after successful init
* Text `You may now begin working with Terraform...`
* JSON message code: `output_init_success_cli_message`

4) Calls to action shown to those using the CLI to managed HCP Terraform directly after successful init
* Text `You may now begin working with HCP Terraform...`
* JSON message code: `output_init_success_cli_cloud_message`

## Design decisions

### In future, fewer JSON `type`s could be used and nuances described via other fields.

I combined logging `Terraform has been successfully initialized!` and `Terraform initialized in an empty directory!` to the same method as I imagine that a future JSON object representing initialisation of a working directory could be `type` =  a more generic `init_complete` and then distinguish between whether the config was empty or not using fields in the JSON (and different human-readable summaries of the object).

This could be extended to allow cloud and non-cloud versions of a message to be made from a single method, but I figured that was over-optimisation for this stage.

### Using language that matches how other structured logging/SRO is implemented

In plan/apply's JSON logging the message types have conventions of _start, _progress, _complete, _errored as shared suffixes for JSON object types.

The init command produces structured logging/SRO but doesn't follow these conventions. The method names in this PR attempt to do this, and hopefully in future we can make changes to the JSON objects themselves (breaking change tho 😭).



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
