### PR TITLE
import: Fix expansion panic with matching child module + root module import targets

### DIFF
--- a/internal/terraform/context_plan_import_test.go
+++ b/internal/terraform/context_plan_import_test.go
@@ -2513,3 +2513,49 @@ resource "test_object" "a" {}
 		t.Fatal("Wrong, but impressive - how did you even defer the wrong resource?")
 	}
 }
+
+// This is a regression test for an expansion panic during plan where the
+// child import block registers an expansion in the root module, which would
+// then cause an "expansion already registered for <resource address>" panic.
+func TestContextPlan_import_in_module_matches_root_to_addr(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "child" {
+  source = "./child"
+}
+import {
+  to = test_object.samename
+  id = "test-a"
+}
+		`,
+		"child/main.tf": `
+import {
+  to = test_object.samename
+  id = "test-b"
+}
+		`,
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(simpleMockProvider()),
+		},
+	})
+
+	validateDiags := ctx.Validate(m, nil)
+
+	wantErr := "module.child.test_object.samename not found. Only resources within the root module are eligible for config generation."
+	if !validateDiags.HasErrors() {
+		t.Errorf("unexpected success from validate\nwant: message containing %q", wantErr)
+	} else if got, want := validateDiags.Err().Error(), wantErr; !strings.Contains(got, want) {
+		t.Errorf("wrong error from validate:\ngot:  %s\nwant: message containing %q", got, want)
+	}
+
+	// The expected error is only raised from validate, but the panic this regression test
+	// covers happens during expansion which is occurs in the plan.
+	//
+	// Since this isn't valid configuration we only care that plan doesn't panic.
+	ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode: plans.NormalMode,
+	})
+}

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -241,13 +241,13 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 	// generating configuration. Add them to the graph for validation.
 	for _, i := range importTargets {
 
-		log.Printf("[DEBUG] ConfigTransformer: adding config generation node for %s", i.Config.ToResource)
+		log.Printf("[DEBUG] ConfigTransformer: adding config generation node for %s", i.AbsToConfigResource)
 
 		// TODO: if config generation is ever supported for for_each
 		// resources, this will add multiple nodes for the same
 		// resource
 		abstract := &NodeAbstractResource{
-			Addr:               i.Config.ToResource,
+			Addr:               i.AbsToConfigResource,
 			importTargets:      []*ImportTarget{i},
 			generateConfigPath: t.generateConfigPathForImportTargets,
 		}


### PR DESCRIPTION
No open bug for this as child module imports aren't released yet! I just ran into a panic when messing around with child modules. I've included what I believe to be the narrow fix. The child module import target adds a resource node in the root module (which eventually causes a panic when they both attempt to expand).

I accidentally created an invalid configuration attempting to test the error message when running `terraform plan -generate-config-out=generated.tf`:
```tf
# main.tf
module "child" {
  source = "./child"
}
import {
  to = test_object.samename
  id = "test-a"
}

# child/main.tf
import {
  to = test_object.samename
  id = "test-b"
}
```

This is invalid configuration because we can't generate configuration in child modules, but rather than a validation error I got a panic (the one below is from the test I included in this PR):
```bash
!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

Terraform crashed! This is always indicative of a bug within Terraform.
Please report the crash with Terraform[[1](https://github.com/hashicorp/terraform/issues)] so that we can fix this.

When reporting bugs, please include your terraform version, the stack trace
shown below, and any additional information which may help replicate the issue.

[1]: https://github.com/hashicorp/terraform/issues

!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

panic: expansion already registered for test_object.samename
goroutine 94 [running]:
runtime/debug.Stack()
	/Users/austin.valle/go/pkg/mod/golang.org/[toolchain@v0.0.1-go1.26.4.darwin-arm64](mailto:toolchain@v0.0.1-go1.26.4.darwin-arm64)/src/runtime/debug/stack.go:26 +0x64
github.com/hashicorp/terraform/internal/logging.PanicHandler()
	/Users/austin.valle/code/terraform/internal/logging/panic.go:84 +0x164
panic({0x1079ccbe0?, 0x41b46b67e270?})
	/Users/austin.valle/go/pkg/mod/golang.org/[toolchain@v0.0.1-go1.26.4.darwin-arm64](mailto:toolchain@v0.0.1-go1.26.4.darwin-arm64)/src/runtime/panic.go:860 +0x12c
github.com/hashicorp/terraform/internal/terraform.(*Graph).walk.func1.1()
	/Users/austin.valle/code/terraform/internal/terraform/graph.go:55 +0x304
panic({0x1079ccbe0?, 0x41b46b67e270?})
	/Users/austin.valle/go/pkg/mod/golang.org/[toolchain@v0.0.1-go1.26.4.darwin-arm64](mailto:toolchain@v0.0.1-go1.26.4.darwin-arm64)/src/runtime/panic.go:860 +0x12c
github.com/hashicorp/terraform/internal/instances.(*Expander).setResourceExpansion(0x41b46b836800, {0x0, 0x0, 0x0}, {{}, 0x4d, {0x41b46b6afd80, 0xb}, {0x41b46b6afd78, 0x8}}, ...)
	/Users/austin.valle/code/terraform/internal/instances/expander.go:556 +0x1a8
github.com/hashicorp/terraform/internal/instances.(*Expander).SetResourceSingle(...)
	/Users/austin.valle/code/terraform/internal/instances/expander.go:96
github.com/hashicorp/terraform/internal/terraform.(*NodeAbstractResource).recordResourceData(0x41b46b8f41c0, {0x107fade18, 0x41b46b63c500}, {{}, {0x0, 0x0, 0x0}, {{}, 0x4d, {0x41b46b6afd80, ...}, ...}})
	/Users/austin.valle/code/terraform/internal/terraform/node_resource_abstract.go:532 +0x1e4
github.com/hashicorp/terraform/internal/terraform.(*nodeExpandPlannableResource).expandResourceInstances(0x41b46b648600, {0x107fade18, 0x41b46b310a00}, {{}, {0x0, 0x0, 0x0}, {{}, 0x4d, {0x41b46b6afd80, ...}, ...}}, ...)
	/Users/austin.valle/code/terraform/internal/terraform/node_resource_plan.go:460 +0xb4
github.com/hashicorp/terraform/internal/terraform.(*nodeExpandPlannableResource).dynamicExpand(0x41b46b648600, {0x107fade18, 0x41b46b310a00}, {0x1081bbe00, 0x1, 0x1}, {0x41b46b8bf6b8?})
	/Users/austin.valle/code/terraform/internal/terraform/node_resource_plan.go:414 +0x814
github.com/hashicorp/terraform/internal/terraform.(*nodeExpandPlannableResource).DynamicExpand(0x41b46b648600, {0x107fade18, 0x41b46b310a00})
	/Users/austin.valle/code/terraform/internal/terraform/node_resource_plan.go:139 +0x42c
github.com/hashicorp/terraform/internal/terraform.(*Graph).walk.func1({0x107f53500, 0x41b46b648600})
	/Users/austin.valle/code/terraform/internal/terraform/graph.go:149 +0x708
github.com/hashicorp/terraform/internal/dag.(*Walker).walkVertex(0x41b46b647d60, {0x107f53500, 0x41b46b648600}, 0x41b46b89bc50)
	/Users/austin.valle/code/terraform/internal/dag/walk.go:277 +0x1a4
created by github.com/hashicorp/terraform/internal/dag.(*Walker).Walk in goroutine 49
	/Users/austin.valle/code/terraform/internal/dag/walk.go:207 +0x5b0
FAIL	github.com/hashicorp/terraform/internal/terraform	0.994s
FAIL
```

## Target Release

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing. (it is user facing, but we don't need a changelog imo)
