### PR TITLE
Move policy from experiments into main builds

### DIFF
--- a/.changes/v1.17/NEW FEATURES-20260810-122653.yaml
+++ b/.changes/v1.17/NEW FEATURES-20260810-122653.yaml
@@ -1,5 +1,5 @@
 kind: NEW FEATURES
-body: 'policy: Terraform Policy is now generally available. The `-policies` flag for `plan`, `apply`, and `init` no longer requires the `-allow-experimental-features` flag.'
+body: 'policy: Terraform Policy is now generally available. The `-policies` flag for `plan`, `apply`, and `init` no longer requires the `-allow-experimental-features` flag. See https://developer.hashicorp.com/terraform/policy for more information.'
 time: 2026-08-10T12:26:53.000000+00:00
 custom:
     Issue: "38970"

--- a/.changes/v1.17/NEW FEATURES-20260810-122653.yaml
+++ b/.changes/v1.17/NEW FEATURES-20260810-122653.yaml
@@ -1,0 +1,5 @@
+kind: NEW FEATURES
+body: 'policy: Terraform Policy is now generally available. The `-policies` flag for `plan`, `apply`, and `init` no longer requires the `-allow-experimental-features` flag.'
+time: 2026-08-10T12:26:53.000000+00:00
+custom:
+    Issue: "38970"

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -162,7 +162,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 }
 
 func (c *ApplyCommand) Validate(args *arguments.Apply) (diags tfdiags.Diagnostics) {
-	return diags.Append(validatePolicyPaths(args.PolicyPaths, c.AllowExperimentalFeatures))
+	return diags.Append(validatePolicyPaths(args.PolicyPaths))
 }
 
 func (c *ApplyCommand) LoadPlanFile(path string) (*planfile.WrappedPlanFile, tfdiags.Diagnostics) {

--- a/internal/command/apply_policy_test.go
+++ b/internal/command/apply_policy_test.go
@@ -39,9 +39,8 @@ func TestApply_WithPolicyDiagnosticsJSON(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	c := &ApplyCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 	resp := policy.EvaluationFromProtoResponse(
@@ -176,9 +175,8 @@ func TestApply_PolicyResultsJSON_WithSavedPlan(t *testing.T) {
 	planOverrides.PolicyClient = policy.NewTestMockClient(t)
 	planCmd := &PlanCommand{
 		Meta: Meta{
-			testingOverrides:          planOverrides,
-			View:                      planView,
-			AllowExperimentalFeatures: true,
+			testingOverrides: planOverrides,
+			View:             planView,
 		},
 	}
 	if code := planCmd.Run([]string{"-policies", td, "-no-color", "-out=planfile"}); code != 0 {
@@ -193,9 +191,8 @@ func TestApply_PolicyResultsJSON_WithSavedPlan(t *testing.T) {
 	applyOverrides.PolicyClient = applyPolicyClient
 	applyCmd := &ApplyCommand{
 		Meta: Meta{
-			testingOverrides:          applyOverrides,
-			View:                      applyView,
-			AllowExperimentalFeatures: true,
+			testingOverrides: applyOverrides,
+			View:             applyView,
 		},
 	}
 
@@ -314,9 +311,8 @@ func TestApply_WithPolicyClientStopAfterApply(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	c := &ApplyCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 
@@ -357,9 +353,8 @@ func TestApply_WithPlanPolicyDiagnosticsJSON(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	c := &ApplyCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -141,26 +141,6 @@ func testFixturePath(name string) string {
 	return filepath.Join(fixtureDir, name)
 }
 
-func testPolicyFixtureDir(t *testing.T) string {
-	t.Helper()
-
-	td := t.TempDir()
-	testCopyDir(t, testFixturePath("plan"), td)
-	t.Chdir(td)
-
-	policyCode := `		resource_policy "resource_type" "policy_name" {
-		  enforce_attrs {
-		    key = attr.value == "foo"
-		  }
-		}
-	`
-	if err := os.WriteFile(filepath.Join(td, "policy.hcl"), []byte(policyCode), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	return td
-}
-
 func metaOverridesForProvider(p providers.Interface) *testingOverrides {
 	return &testingOverrides{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -254,102 +234,6 @@ func testPlan(t *testing.T) *plans.Plan {
 
 func testPlanFile(t *testing.T, configSnap *configload.Snapshot, state *states.State, plan *plans.Plan) string {
 	return testPlanFileMatchState(t, configSnap, state, plan, statemgr.SnapshotMeta{})
-}
-
-func TestPlan_PoliciesRequireExperimentalFeatures(t *testing.T) {
-	td := testPolicyFixtureDir(t)
-
-	p := planFixtureProvider()
-	view, done := testView(t)
-	c := &PlanCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			View:             view,
-		},
-	}
-
-	code := c.Run([]string{"-policies", td, "-no-color"})
-	output := done(t)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d\n\n%s", code, output.All())
-	}
-	if got := output.Stderr(); !strings.Contains(got, "The -policies flag is only valid in experimental builds of Terraform.") {
-		t.Fatalf("expected policy experiment gating diagnostic, got: %s", got)
-	}
-	if strings.Contains(output.All(), "Failed to connect to policy engine") {
-		t.Fatalf("policy engine should not be initialized when experiments are disabled: %s", output.All())
-	}
-}
-
-func TestApply_PoliciesRequireExperimentalFeatures(t *testing.T) {
-	td := testPolicyFixtureDir(t)
-
-	p := planFixtureProvider()
-	view, done := testView(t)
-	c := &ApplyCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			View:             view,
-		},
-	}
-
-	code := c.Run([]string{"-policies", td, "-no-color", "-auto-approve"})
-	output := done(t)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d\n\n%s", code, output.All())
-	}
-	if got := output.Stderr(); !strings.Contains(got, "The -policies flag is only valid in experimental builds of Terraform.") {
-		t.Fatalf("expected policy experiment gating diagnostic, got: %s", got)
-	}
-	if strings.Contains(output.All(), "Failed to connect to policy engine") {
-		t.Fatalf("policy engine should not be initialized when experiments are disabled: %s", output.All())
-	}
-}
-
-func TestInit_PoliciesRequireExperimentalFeatures(t *testing.T) {
-	td := testPolicyFixtureDir(t)
-
-	view, done := testView(t)
-	c := &InitCommand{
-		Meta: Meta{
-			Ui:   new(cli.MockUi),
-			View: view,
-		},
-	}
-
-	code := c.Run([]string{"-policies", td, "-no-color"})
-	output := done(t)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d\n\n%s", code, output.All())
-	}
-	if got := output.Stderr(); !strings.Contains(got, "The -policies flag is only valid in experimental builds of Terraform.") {
-		t.Fatalf("expected policy experiment gating diagnostic, got: %s", got)
-	}
-}
-
-func TestQuery_PoliciesRequireExperimentalFeatures(t *testing.T) {
-	td := testPolicyFixtureDir(t)
-
-	p := queryFixtureProvider()
-	view, done := testView(t)
-	c := &QueryCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			View:             view,
-		},
-	}
-
-	code := c.Run([]string{"-policies", td, "-no-color"})
-	output := done(t)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d\n\n%s", code, output.All())
-	}
-	if got := output.Stderr(); !strings.Contains(got, "The -policies flag is only valid in experimental builds of Terraform.") {
-		t.Fatalf("expected policy experiment gating diagnostic, got: %s", got)
-	}
-	if strings.Contains(output.All(), "Failed to connect to policy engine") {
-		t.Fatalf("policy engine should not be initialized when experiments are disabled: %s", output.All())
-	}
 }
 
 func testPlanFileMatchState(t *testing.T, configSnap *configload.Snapshot, state *states.State, plan *plans.Plan, stateMeta statemgr.SnapshotMeta) string {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -299,7 +299,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ini
 }
 
 func (c *InitCommand) Validate(args *arguments.Init) (diags tfdiags.Diagnostics) {
-	diags = diags.Append(validatePolicyPaths(args.PolicyPaths, c.AllowExperimentalFeatures))
+	diags = diags.Append(validatePolicyPaths(args.PolicyPaths))
 	return diags
 }
 

--- a/internal/command/meta_policy.go
+++ b/internal/command/meta_policy.go
@@ -29,10 +29,6 @@ func (c *Meta) PolicyClient(ctx context.Context, policyPaths []string, ent *poli
 			client.Stop()
 		}
 	}
-	if !c.AllowExperimentalFeatures {
-		log.Printf("[DEBUG] Policies are not supported without experiments enabled, skipping policy client setup")
-		return client, nil, closer
-	}
 	if len(policyPaths) == 0 {
 		log.Printf("[DEBUG] No policy paths configured, skipping policy client setup")
 		return client, nil, closer

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -134,7 +134,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 }
 
 func (c *PlanCommand) Validate(args *arguments.Plan) (diags tfdiags.Diagnostics) {
-	return diags.Append(validatePolicyPaths(args.PolicyPaths, c.AllowExperimentalFeatures))
+	return diags.Append(validatePolicyPaths(args.PolicyPaths))
 }
 
 func (c *PlanCommand) PrepareBackend(args *arguments.State, viewType arguments.ViewType) (backendrun.OperationsBackend, tfdiags.Diagnostics) {

--- a/internal/command/plan_policy_test.go
+++ b/internal/command/plan_policy_test.go
@@ -40,9 +40,8 @@ func TestPlan_WithPolicy(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	c := &PlanCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 	resp := policy.EvaluationFromProtoResponse(
@@ -158,9 +157,8 @@ func TestPlan_WithPolicyDiagnosticsJSON(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	c := &PlanCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 	resp := policy.EvaluationFromProtoResponse(
@@ -355,9 +353,8 @@ func TestPlan_WithPolicyUnknown(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	c := &PlanCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 
@@ -482,10 +479,9 @@ func TestPlan_WithPolicySuccessInfo(t *testing.T) {
 	policyClient := policy.NewTestMockClient(t)
 	overrides.PolicyClient = policyClient
 	meta := Meta{
-		testingOverrides:          overrides,
-		View:                      view,
-		ProviderSource:            providerSource,
-		AllowExperimentalFeatures: true,
+		testingOverrides: overrides,
+		View:             view,
+		ProviderSource:   providerSource,
 	}
 
 	init := &InitCommand{
@@ -674,9 +670,8 @@ func TestPlan_WithPolicySuccessInfoJSON(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	c := &PlanCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 
@@ -859,9 +854,8 @@ func TestPlan_Policy_Destroy(t *testing.T) {
 
 	c := &PlanCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 
@@ -948,9 +942,8 @@ func TestPlan_WithPolicyClientStopAfterPlan(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	c := &PlanCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 
@@ -991,9 +984,8 @@ func TestPlan_WithPolicySetupFailure(t *testing.T) {
 	// diagnostics from attempting to connect to the policy engine.
 	c := &PlanCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 
@@ -1073,9 +1065,8 @@ func TestPlan_WithPolicySetupFailureJSON(t *testing.T) {
 	// diagnostics from attempting to connect to the policy engine.
 	c := &PlanCommand{
 		Meta: Meta{
-			testingOverrides:          overrides,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+			testingOverrides: overrides,
+			View:             view,
 		},
 	}
 

--- a/internal/command/policy.go
+++ b/internal/command/policy.go
@@ -10,15 +10,7 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-func validatePolicyPaths(policyPaths []string, experimental bool) (diags tfdiags.Diagnostics) {
-	if !experimental && len(policyPaths) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			"The -policies flag is only valid in experimental builds of Terraform.",
-		))
-	}
-
+func validatePolicyPaths(policyPaths []string) (diags tfdiags.Diagnostics) {
 	for _, path := range policyPaths {
 		if _, err := os.Stat(path); err != nil {
 			if os.IsNotExist(err) {

--- a/internal/command/policy_test.go
+++ b/internal/command/policy_test.go
@@ -44,18 +44,6 @@ func TestValidatePolicyPaths(t *testing.T) {
 				),
 			},
 		},
-		{
-			name:             "existing path, experiments disallowed",
-			path:             existingPath,
-			allowExperiments: false,
-			want: tfdiags.Diagnostics{
-				tfdiags.Sourceless(
-					tfdiags.Error,
-					"Failed to parse command-line flags",
-					"The -policies flag is only valid in experimental builds of Terraform.",
-				),
-			},
-		},
 	}
 
 	for _, tc := range tests {

--- a/internal/command/query.go
+++ b/internal/command/query.go
@@ -177,8 +177,7 @@ func (c *QueryCommand) configureQueryPolicyClient(be backendrun.OperationsBacken
 }
 
 func (c *QueryCommand) Validate(args *arguments.Query) (diags tfdiags.Diagnostics) {
-	// validatePolicyPaths call ejects early if -policies flag was passed for non-experimental builds
-	return diags.Append(validatePolicyPaths(args.PolicyPaths, c.AllowExperimentalFeatures))
+	return diags.Append(validatePolicyPaths(args.PolicyPaths))
 }
 
 func (c *QueryCommand) PrepareBackend(args *arguments.State, viewType arguments.ViewType) (backendrun.OperationsBackend, tfdiags.Diagnostics) {

--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -347,18 +347,6 @@ func TestQueryCommand_Validate(t *testing.T) {
 				),
 			},
 		},
-		{
-			name:             "experiments disallowed",
-			policyPaths:      []string{td},
-			allowExperiments: false,
-			wantDiags: tfdiags.Diagnostics{
-				tfdiags.Sourceless(
-					tfdiags.Error,
-					"Failed to parse command-line flags",
-					"The -policies flag is only valid in experimental builds of Terraform.",
-				),
-			},
-		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This moves the policy feature into main builds. See https://developer.hashicorp.com/terraform/policy for more information.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
