### PR TITLE
feat: Add methods to the `state migrate` view interface for logging multiple progress events during the migration command, including JSON-specific methods.

### DIFF
--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -328,7 +328,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	view.Log(views.StateMigrationStartMessage, source, destination)
+	view.LogStateMigrationStart(source, destination)
 
 	// Perform the migration from source to destination
 	err := c.Meta.backendMigrateState(migrateOpts)
@@ -338,6 +338,8 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		view.Log(views.StateMigrationFailureMessage, source, destination)
 		return 1
 	}
+
+	view.LogStateMigrationComplete()
 
 	// After a successful migration to a state store, we must make sure the dependency lock file contains the
 	// details of the destination state store provider.
@@ -380,7 +382,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 
 	view.Diagnostics(diags) // Log any warnings
 
-	view.Log(views.StateMigrationCompletedMessage, source, destination)
+	view.LogStateMigrationFinalized(source, destination)
 
 	return 0
 }

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -99,6 +99,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	c.Meta.forceInitCopy = args.ForceCopy // backendMigrateOpts.force is overwritten with this value, so we also need to set it.
 
 	// Load the source backend
+	view.LogMigrationSourceInitializationStart()
 	var source string
 	var sourceLock *depsfile.Locks // This should only contain a single lock, if non nil. Used to avoid re-download if destination provider is the same.
 	if smi.Backend != nil {
@@ -160,8 +161,10 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			migrateOpts.Source = srcB
 		}
 	}
+	view.LogMigrationSourceInitializationComplete()
 
 	// Load the destination backend
+	view.LogMigrationDestinationInitializationStart()
 	rootMod := cfg.Module
 	var destination string
 	var destinationLock *depsfile.Locks                               // This should only contain a single lock, if non nil. Used to update the dependency lock file on disk.
@@ -327,6 +330,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		view.Diagnostics(diags)
 		return 1
 	}
+	view.LogMigrationDestinationInitializationComplete()
 
 	view.LogStateMigrationStart(source, destination)
 

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -53,6 +53,11 @@ type StateMigrate interface {
 	LogStateMigrationComplete()
 	LogStateMigrationFinalized(source, destination string)
 
+	LogMigrationSourceInitializationStart()
+	LogMigrationSourceInitializationComplete()
+	LogMigrationDestinationInitializationStart()
+	LogMigrationDestinationInitializationComplete()
+
 	ProviderInstallationLogger
 	DependencyLockingLogger
 
@@ -88,6 +93,22 @@ func (s *StateMigrateHuman) LogStateMigrationStart(source string, destination st
 }
 
 func (s *StateMigrateHuman) LogStateMigrationComplete() {
+	// no-op in human view
+}
+
+func (s *StateMigrateHuman) LogMigrationSourceInitializationStart() {
+	// no-op in human view
+}
+
+func (s *StateMigrateHuman) LogMigrationSourceInitializationComplete() {
+	// no-op in human view
+}
+
+func (s *StateMigrateHuman) LogMigrationDestinationInitializationStart() {
+	// no-op in human view
+}
+
+func (s *StateMigrateHuman) LogMigrationDestinationInitializationComplete() {
 	// no-op in human view
 }
 

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -19,8 +19,8 @@ const (
 	// Notify the user that any preparation steps are over and the migration is starting.
 	StateMigrationStartMessage = "[reset][bold]Migrating state from %s to %s...[reset]"
 
-	// Notify the user that everything has completed successfully.
-	StateMigrationCompletedMessage = "[reset][bold]Finished migrating state from %s to %s.[reset]"
+	// Notify the user that everything has finished successfully; migration and lockfile+backend state file updates.
+	StateMigrationFinalizedMessage = "[reset][bold]Finished migrating state from %s to %s.[reset]"
 
 	// Notify the user that an error has occurred, but there have been changes to where state is stored.
 	// Hopefully the errors accompanying this message are actionable by users, but if not we expect a bug report.
@@ -49,6 +49,10 @@ type StateMigrate interface {
 	Log(message string, params ...any)
 	Diagnostics(diags tfdiags.Diagnostics)
 
+	LogStateMigrationStart(source, destination string)
+	LogStateMigrationComplete()
+	LogStateMigrationFinalized(source, destination string)
+
 	ProviderInstallationLogger
 	DependencyLockingLogger
 
@@ -76,6 +80,20 @@ type StateMigrateHuman struct {
 
 func (s *StateMigrateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 	s.view.Diagnostics(diags)
+}
+
+func (s *StateMigrateHuman) LogStateMigrationStart(source string, destination string) {
+	msg := fmt.Sprintf(StateMigrationStartMessage, source, destination)
+	s.log(msg)
+}
+
+func (s *StateMigrateHuman) LogStateMigrationComplete() {
+	// no-op in human view
+}
+
+func (s *StateMigrateHuman) LogStateMigrationFinalized(source string, destination string) {
+	msg := fmt.Sprintf(StateMigrationFinalizedMessage, source, destination)
+	s.log(msg)
 }
 
 func (s *StateMigrateHuman) Log(message string, params ...any) {


### PR DESCRIPTION
More work to flesh out the `state migrate` command's view interface with event-specific methods.

In a future PR I'll implement the JSON view for this command, but I think it makes sense to establish the interface with the current human view to start.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
