### PR TITLE
refactor: Add method to the `state migrate` view interface for logging when different types of error occurs

### DIFF
--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -339,7 +339,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("State migration failed: %w", err))
 		view.Diagnostics(diags)
-		view.Log(views.StateMigrationFailureMessage, source, destination)
+		view.LogStateMigrationErrored(views.DuringMigration, source, destination)
 		return 1
 	}
 
@@ -352,6 +352,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		diags = diags.Append(originalLockDiags)
 		if originalLockDiags.HasErrors() {
 			view.Diagnostics(diags)
+			view.LogStateMigrationErrored(views.DuringLockfile, source, destination)
 			return 1
 		}
 
@@ -366,7 +367,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		diags = diags.Append(depLockFileDiags)
 		if depLockFileDiags.HasErrors() {
 			view.Diagnostics(diags)
-			view.Log(views.StateMigrationPostStepsInterruptedMessage, source, destination)
+			view.LogStateMigrationErrored(views.DuringLockfile, source, destination)
 			return 1
 		}
 		if output {
@@ -380,7 +381,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	diags = diags.Append(bsfDiags)
 	if bsfDiags.HasErrors() {
 		view.Diagnostics(diags)
-		view.Log(views.StateMigrationPostStepsInterruptedMessage, source, destination)
+		view.LogStateMigrationErrored(views.DuringBackendStateFile, source, destination)
 		return 1
 	}
 

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -51,9 +51,9 @@ type stateMigrationFailureMode string
 // In the JSON view these values are used as the value of a field indicating when the error occurred.
 // Therefore these strings are user-facing in JSON output and should not be changed!
 const (
-	DuringMigration        = "error_during_migration"
-	DuringLockfile         = "error_updating_provider_lockfile"
-	DuringBackendStateFile = "error_updating_workdir_state"
+	DuringMigration        stateMigrationFailureMode = "error_during_migration"
+	DuringLockfile         stateMigrationFailureMode = "error_updating_provider_lockfile"
+	DuringBackendStateFile stateMigrationFailureMode = "error_updating_workdir_state"
 )
 
 type StateMigrate interface {

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -45,12 +45,24 @@ Make sure you're supplying all the necessary attribute values for both the sourc
 `
 )
 
+type stateMigrationFailureMode string
+
+// In the human view these values are only used to control which human-readable message is printed to stdout.
+// In the JSON view these values are used as the value of a field indicating when the error occurred.
+// Therefore these strings are user-facing in JSON output and should not be changed!
+const (
+	DuringMigration        = "error_during_migration"
+	DuringLockfile         = "error_updating_provider_lockfile"
+	DuringBackendStateFile = "error_updating_workdir_state"
+)
+
 type StateMigrate interface {
 	Log(message string, params ...any)
 	Diagnostics(diags tfdiags.Diagnostics)
 
 	LogStateMigrationStart(source, destination string)
 	LogStateMigrationComplete()
+	LogStateMigrationErrored(failMode stateMigrationFailureMode, source, destination string)
 	LogStateMigrationFinalized(source, destination string)
 
 	LogMigrationSourceInitializationStart()
@@ -96,6 +108,24 @@ func (s *StateMigrateHuman) LogStateMigrationStart(source string, destination st
 
 func (s *StateMigrateHuman) LogStateMigrationComplete() {
 	// no-op in human view
+}
+
+func (s *StateMigrateHuman) LogStateMigrationErrored(failMode stateMigrationFailureMode, source, destination string) {
+	// The JSON object describes slightly different failures that led to an error.
+	// So different messages are be logged depending which happened.
+	var msg string
+	switch failMode {
+	case DuringMigration:
+		// migration itself failed
+		msg = fmt.Sprintf(StateMigrationFailureMessage, source, destination)
+	case DuringLockfile, DuringBackendStateFile:
+		// migration succeeded by updates in the working directory failed
+		msg = fmt.Sprintf(StateMigrationPostStepsInterruptedMessage, source, destination)
+	default:
+		panic(fmt.Sprintf("(*StateMigrateHuman)LogStateMigrationErrored: called incorrectly with unknown failure mode : %q", failMode))
+	}
+
+	s.log(msg)
 }
 
 func (s *StateMigrateHuman) LogMigrationSourceInitializationStart() {


### PR DESCRIPTION
There's a single method for logging details about error occur during or after the migration takes place.

In the human view this method will log different human-facing message describing how to address the issue. Deciding on which message to show depends on the enum passed into the method from the calling code, which describes the context that the error occurred in.

In the (not-yet-implemented) JSON view the generic `migration_errored` JSON object will have a field describing the specific type of error that's occurred. The enum value wil be used to set the value of that field, but that's for a future PR.



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
