### PR TITLE
Bring validation from legacy config to new graph-based config builder

### DIFF
--- a/internal/command/testdata/invalid-child-modules/with-backend/.terraform/modules/modules.json
+++ b/internal/command/testdata/invalid-child-modules/with-backend/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"child","Source":"./child","Dir":"child"}]}

--- a/internal/command/testdata/invalid-child-modules/with-backend/child/main.tf
+++ b/internal/command/testdata/invalid-child-modules/with-backend/child/main.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "./test.tfstate"
+  }
+}

--- a/internal/command/testdata/invalid-child-modules/with-backend/main.tf
+++ b/internal/command/testdata/invalid-child-modules/with-backend/main.tf
@@ -1,0 +1,5 @@
+module "child" {
+  source = "./child"
+}
+
+resource "test_instance" "a" {}

--- a/internal/command/testdata/invalid-child-modules/with-cloud-block/.terraform/modules/modules.json
+++ b/internal/command/testdata/invalid-child-modules/with-cloud-block/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"child","Source":"./child","Dir":"child"}]}

--- a/internal/command/testdata/invalid-child-modules/with-cloud-block/child/main.tf
+++ b/internal/command/testdata/invalid-child-modules/with-cloud-block/child/main.tf
@@ -1,0 +1,5 @@
+terraform {
+  cloud {
+    hostname = "example.com"
+  }
+}

--- a/internal/command/testdata/invalid-child-modules/with-cloud-block/main.tf
+++ b/internal/command/testdata/invalid-child-modules/with-cloud-block/main.tf
@@ -1,0 +1,5 @@
+module "child" {
+  source = "./child"
+}
+
+resource "test_instance" "a" {}

--- a/internal/command/testdata/valid-child-modules/with-import/.terraform/modules/modules.json
+++ b/internal/command/testdata/valid-child-modules/with-import/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"child","Source":"./child","Dir":"child"}]}

--- a/internal/command/testdata/valid-child-modules/with-import/child/main.tf
+++ b/internal/command/testdata/valid-child-modules/with-import/child/main.tf
@@ -1,0 +1,6 @@
+resource "test_instance" "b" {}
+
+import {
+  to = test_instance.b
+  id = "test-b"
+}

--- a/internal/command/testdata/valid-child-modules/with-import/main.tf
+++ b/internal/command/testdata/valid-child-modules/with-import/main.tf
@@ -1,0 +1,10 @@
+module "child" {
+  source = "./child"
+}
+
+resource "test_instance" "a" {}
+
+import {
+  to = test_instance.a
+  id = "test-a"
+}

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -20,11 +20,27 @@ import (
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/terminal"
 )
 
 func setupTest(t *testing.T, fixturepath string, args ...string) (*terminal.TestOutput, int) {
 	view, done := testView(t)
+	c := &ValidateCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(validateTestProvider()),
+			View:             view,
+		},
+	}
+
+	args = append(args, "-no-color")
+	args = append(args, testFixturePath(fixturepath))
+
+	code := c.Run(args)
+	return done(t), code
+}
+
+func validateTestProvider() *testing_provider.MockProvider {
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
@@ -49,18 +65,8 @@ func setupTest(t *testing.T, fixturepath string, args ...string) (*terminal.Test
 			},
 		},
 	}
-	c := &ValidateCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(p),
-			View:             view,
-		},
-	}
 
-	args = append(args, "-no-color")
-	args = append(args, testFixturePath(fixturepath))
-
-	code := c.Run(args)
-	return done(t), code
+	return p
 }
 
 func TestValidateCommand(t *testing.T) {
@@ -335,34 +341,10 @@ func TestValidate_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		p := testProvider()
-		p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-			ResourceTypes: map[string]providers.Schema{
-				"test_instance": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"ami": {Type: cty.String, Optional: true},
-						},
-						BlockTypes: map[string]*configschema.NestedBlock{
-							"network_interface": {
-								Nesting: configschema.NestingList,
-								Block: configschema.Block{
-									Attributes: map[string]*configschema.Attribute{
-										"device_index": {Type: cty.String, Optional: true},
-										"description":  {Type: cty.String, Optional: true},
-										"name":         {Type: cty.String, Optional: true},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
 		view, done := testView(t)
 		c := &ValidateCommand{
 			Meta: Meta{
-				testingOverrides: metaOverridesForProvider(p),
+				testingOverrides: metaOverridesForProvider(validateTestProvider()),
 				View:             view,
 				WorkingDir:       wd,
 			},
@@ -391,34 +373,10 @@ func TestValidate_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		p := testProvider()
-		p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-			ResourceTypes: map[string]providers.Schema{
-				"test_instance": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"ami": {Type: cty.String, Optional: true},
-						},
-						BlockTypes: map[string]*configschema.NestedBlock{
-							"network_interface": {
-								Nesting: configschema.NestingList,
-								Block: configschema.Block{
-									Attributes: map[string]*configschema.Attribute{
-										"device_index": {Type: cty.String, Optional: true},
-										"description":  {Type: cty.String, Optional: true},
-										"name":         {Type: cty.String, Optional: true},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
 		view, done := testView(t)
 		c := &ValidateCommand{
 			Meta: Meta{
-				testingOverrides: metaOverridesForProvider(p),
+				testingOverrides: metaOverridesForProvider(validateTestProvider()),
 				View:             view,
 				WorkingDir:       wd,
 			},
@@ -852,4 +810,83 @@ func TestValidate_resourceBlock(t *testing.T) {
 			)
 		}
 	})
+}
+
+func TestValidate_child_module_backend_warning(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("invalid-child-modules/with-backend"), td)
+	t.Chdir(td)
+
+	view, done := testView(t)
+	c := &ValidateCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(validateTestProvider()),
+			View:             view,
+		},
+	}
+
+	args := []string{"-no-color"}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("expected successful exit code, got: %d\n\n%s", code, output.Stdout())
+	}
+
+	expectedWarning := "Warning: Backend configuration ignored"
+	if !strings.Contains(output.Stdout(), expectedWarning) {
+		t.Fatalf("unexpected stdout content: wanted %q, got: %s",
+			expectedWarning,
+			output.Stdout(),
+		)
+	}
+}
+
+func TestValidate_child_module_cloud_block_warning(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("invalid-child-modules/with-cloud-block"), td)
+	t.Chdir(td)
+
+	view, done := testView(t)
+	c := &ValidateCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(validateTestProvider()),
+			View:             view,
+		},
+	}
+
+	args := []string{"-no-color"}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("expected successful exit code, got: %d\n\n%s", code, output.Stdout())
+	}
+
+	expectedWarning := "Warning: Cloud configuration ignored"
+	if !strings.Contains(output.Stdout(), expectedWarning) {
+		t.Fatalf("unexpected stdout content: wanted %q, got: %s",
+			expectedWarning,
+			output.Stdout(),
+		)
+	}
+}
+
+func TestValidate_child_module_import(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("valid-child-modules/with-import"), td)
+	t.Chdir(td)
+
+	view, done := testView(t)
+	c := &ValidateCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(validateTestProvider()),
+			View:             view,
+		},
+	}
+
+	args := []string{"-no-color"}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("unexpected non-successful exit code %d\n\n%s", code, output.Stderr())
+	}
 }

--- a/internal/terraform/node_module_install.go
+++ b/internal/terraform/node_module_install.go
@@ -5,6 +5,8 @@ package terraform
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -108,14 +110,14 @@ func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdia
 		CallRange:         n.ModuleCall.DeclRange,
 	}
 
-	cfg, v, modDiags := n.Walker.LoadModule(req)
+	modCfg, v, modDiags := n.Walker.LoadModule(req)
 	diags = diags.Append(modDiags)
 	if diags.HasErrors() {
 		return diags
 	}
 
 	config := &configs.Config{
-		Module:            cfg,
+		Module:            modCfg,
 		Parent:            n.Parent,
 		Path:              n.Addr.Module(),
 		Root:              n.Parent.Root,
@@ -127,6 +129,8 @@ func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdia
 		Version:           v,
 		VersionConstraint: version,
 	}
+
+	diags = diags.Append(n.validateModuleConfig(modCfg, config.Path))
 
 	// Insert the installed module into the children of the current module
 	currentModuleKey := n.Addr[len(n.Addr)-1].Name
@@ -141,7 +145,40 @@ func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdia
 	n.Config = config
 	n.Version = v
 
-	return nil
+	return diags
+}
+
+func (n *nodeInstallModule) validateModuleConfig(mod *configs.Module, modPath addrs.Module) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	if mod.Backend != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Backend configuration ignored",
+			Detail:   "Any selected backend applies to the entire configuration, so Terraform expects backend configurations only in the root module.\n\nThis is a warning rather than an error because it's sometimes convenient to temporarily call a root module as a child module for testing purposes, but this backend configuration block will have no effect.",
+			Subject:  mod.Backend.DeclRange.Ptr(),
+		})
+	}
+
+	if mod.CloudConfig != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Cloud configuration ignored",
+			Detail:   "A cloud configuration block applies to the entire configuration, so Terraform expects 'cloud' blocks to only be in the root module.\n\nThis is a warning rather than an error because it's sometimes convenient to temporarily call a root module as a child module for testing purposes, but this cloud configuration block will have no effect.",
+			Subject:  mod.CloudConfig.DeclRange.Ptr(),
+		})
+	}
+
+	if len(mod.ListResources) > 0 {
+		first := slices.Collect(maps.Values(mod.ListResources))[0]
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid list configuration",
+			Detail:   fmt.Sprintf("A list block was detected in %q. List blocks are only allowed in the root module.", modPath),
+			Subject:  first.DeclRange.Ptr(),
+		})
+	}
+
+	return diags
 }
 
 func (n *nodeInstallModule) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {


### PR DESCRIPTION
This PR brings the fix made in #38994 (originally targeting `v1.15`) into `main` with two differences:
1. There is no changelog, since we will release this fix eventually with `v1.15`
2. The child module validation for `import` blocks was removed and the test was adjusted to assert the configuration is valid, due to the upcoming `v1.16` release of #38352 

This will be backported to `v1.16` as-is 👍🏻 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing. (already has a changelog)
