### PR TITLE
test: Test prompts shown to users when migrating state

### DIFF
--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -1161,7 +1161,7 @@ Enter "yes" to copy and "no" to start with an empty state.
 const inputBackendMigrateNonEmpty = `
 Pre-existing state was found while migrating the previous %[1]q %[2]s to the
 newly configured %[4]q %[5]s. An existing non-empty state already exists in
-the new %[5]. The two states have been saved to temporary files that will be
+the new %[5]s. The two states have been saved to temporary files that will be
 removed after responding to this query.
 
 Previous (%[2]s %[1]q): %[3]s

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -1146,7 +1146,7 @@ Enter "yes" to proceed or "no" to cancel.
 
 const inputBackendMigrateEmpty = `
 Pre-existing state was found while migrating the previous %[1]q %[2]s to the
-newly configured %[1]q %[4]s. No existing state was found in the newly
+newly configured %[3]q %[4]s. No existing state was found in the newly
 configured %[3]q %[4]s. Do you want to copy this state to the new %[3]q
 %[4]s? Enter "yes" to copy and "no" to start with an empty state.
 `

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -4,8 +4,49 @@
 package command
 
 import (
+	"strings"
 	"testing"
+
+	backendLocal "github.com/hashicorp/terraform/internal/backend/local"
+	"github.com/hashicorp/terraform/internal/backend/pluggable"
 )
+
+func Test_backendMigrateState_S_S(t *testing.T) {
+	storeType := "test_store"
+	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+	source, err := pluggable.NewPluggable(p, storeType)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	destination := backendLocal.New() // local
+
+	opts := &backendMigrateOpts{
+		SourceType: storeType,
+		Source:     source,
+
+		DestinationType: "local",
+		Destination:     destination,
+	}
+
+	inputWriter := testInputMap(t, map[string]string{
+		"backend-migrate-multistate-to-multistate": "no", // We're only testing the prompt, no is sufficient
+	})
+
+	meta := Meta{
+		input: true,
+		Ui:    testUiWrapped(t),
+	}
+	err = meta.backendMigrateState_S_S(opts)
+	if err == nil {
+		t.Fatal("expected a 'Migration aborted by user' error but got none")
+	}
+
+	// Check the source and destination are interpolated in the expected places
+	expected := `the existing "test_store" state store and the newly configured "local" backend`
+	if !strings.Contains(inputWriter.String(), expected) {
+		t.Fatalf("expected the input prompt to include %q, but got':\n %s", expected, inputWriter.String())
+	}
+}
 
 func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 	// Setup the meta

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -42,7 +42,7 @@ func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 		t.Log("Test: ", name)
 		m := testMetaBackend(t, nil)
 		input := map[string]string{}
-		_ = testInputMap(t, input)
+		inputWriter := testInputMap(t, input)
 		if tc.renamePrompt != "" {
 			input["backend-migrate-multistate-to-tfc"] = tc.renamePrompt
 		}
@@ -50,13 +50,19 @@ func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 			input["backend-migrate-multistate-to-tfc-pattern"] = tc.patternPrompt
 		}
 
-		sourceType := "cloud"
+		sourceType := "s3"
 		_, err := m.promptMultiStateMigrationPattern(sourceType, "backend", "HCP Terraform")
 		if tc.expectedErr == "" && err != nil {
 			t.Fatalf("expected error to be nil, but was %s", err.Error())
 		}
 		if tc.expectedErr != "" && tc.expectedErr != err.Error() {
 			t.Fatalf("expected error to eq %s but got %s", tc.expectedErr, err.Error())
+		}
+
+		// Check prompt text uses arguments in expected way
+		expected := `migrating existing workspaces from the backend "s3" to HCP Terraform`
+		if !strings.Contains(inputWriter.String(), expected) {
+			t.Fatalf("expected the input prompt to include: %s\nbut got:\n %s", expected, inputWriter.String())
 		}
 	}
 }

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -92,6 +92,64 @@ func Test_backendMigrateState_S_s(t *testing.T) {
 	}
 }
 
+// A method that `backendMigrateState_s_s` uses to prompt users (no direct tests for `backendMigrateState_s_s`)
+func Test_backendMigrateEmptyConfirm(t *testing.T) {
+	workspaceName := "default"
+
+	storeType := "test_store"
+	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+	p.ConfigureProviderCalled = true
+	p.ConfigureStateStoreCalled = true
+	source, err := pluggable.NewPluggable(p, storeType)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	sourceStateMgr, diags := source.StateMgr(workspaceName)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	destination := backendLocal.New()
+	destinationStateMgr, diags := source.StateMgr(workspaceName)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	opts := &backendMigrateOpts{
+		SourceType: storeType,
+		Source:     source,
+
+		DestinationType: "local",
+		Destination:     destination,
+	}
+
+	inputWriter := testInputMap(t, map[string]string{
+		"backend-migrate-copy-to-empty": "no", // We're only testing the prompt, no is sufficient
+	})
+
+	meta := Meta{
+		input: true,
+		Ui:    testUiWrapped(t),
+	}
+	_, err = meta.backendMigrateEmptyConfirm(sourceStateMgr, destinationStateMgr, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// Check the source and destination are interpolated in the expected places
+	promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
+	expected := []string{
+		`migrating the previous "test_store" state store to the newly configured "local" backend.`,
+		`No existing state was found in the newly configured "local" backend`,
+		`copy this state to the new "local" backend?`,
+	}
+	for _, e := range expected {
+		if !strings.Contains(promptText, e) {
+			t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
+		}
+	}
+}
+
 func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 	// Setup the meta
 

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -150,6 +150,66 @@ func Test_backendMigrateEmptyConfirm(t *testing.T) {
 	}
 }
 
+// A method that `backendMigrateState_s_s` uses to prompt users (no direct tests for `backendMigrateState_s_s`)
+func Test_backendMigrateNonEmptyConfirm(t *testing.T) {
+	workspaceName := "default"
+
+	storeType := "test_store"
+	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+	p.ConfigureProviderCalled = true
+	p.ConfigureStateStoreCalled = true
+	source, err := pluggable.NewPluggable(p, storeType)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	sourceStateMgr, diags := source.StateMgr(workspaceName)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	destination := backendLocal.New()
+	destinationStateMgr, diags := source.StateMgr(workspaceName)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	opts := &backendMigrateOpts{
+		SourceType: storeType,
+		Source:     source,
+
+		DestinationType: "local",
+		Destination:     destination,
+	}
+
+	inputWriter := testInputMap(t, map[string]string{
+		"backend-migrate-to-backend": "no", // We're only testing the prompt, no is sufficient
+	})
+
+	meta := Meta{
+		input: true,
+		Ui:    testUiWrapped(t),
+	}
+	_, err = meta.backendMigrateNonEmptyConfirm(sourceStateMgr, destinationStateMgr, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// Check the source and destination are interpolated in the expected places
+	promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
+	expected := []string{
+		`migrating the previous "test_store" state store to the newly configured "local" backend.`,
+		`non-empty state already exists in the new backend.`,
+		`Previous (state store "test_store"):`,
+		`New (backend "local"):`,
+		`overwrite the state in the new backend with the previous state?`,
+	}
+	for _, e := range expected {
+		if !strings.Contains(promptText, e) {
+			t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
+		}
+	}
+}
+
 func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 	// Setup the meta
 

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// TODO - there are no tests for `backendMigrateTFC`
+
 func Test_backendMigrateState_S_S(t *testing.T) {
 	storeType := "test_store"
 	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
@@ -96,6 +98,7 @@ func Test_backendMigrateState_S_s(t *testing.T) {
 	}
 }
 
+// Scenarios that cause a prompt to be created via `backendMigrateEmptyConfirm` or `backendMigrateNonEmptyConfirm`
 func Test_backendMigrateState_s_s(t *testing.T) {
 	t.Run("no state in destination - prompt via backendMigrateEmptyConfirm", func(t *testing.T) {
 		workspaceName := "default"

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -7,8 +7,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	backendLocal "github.com/hashicorp/terraform/internal/backend/local"
 	"github.com/hashicorp/terraform/internal/backend/pluggable"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func Test_backendMigrateState_S_S(t *testing.T) {
@@ -92,122 +96,143 @@ func Test_backendMigrateState_S_s(t *testing.T) {
 	}
 }
 
-// A method that `backendMigrateState_s_s` uses to prompt users (no direct tests for `backendMigrateState_s_s`)
-func Test_backendMigrateEmptyConfirm(t *testing.T) {
-	workspaceName := "default"
+func Test_backendMigrateState_s_s(t *testing.T) {
+	t.Run("no state in destination - prompt via backendMigrateEmptyConfirm", func(t *testing.T) {
+		workspaceName := "default"
 
-	storeType := "test_store"
-	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
-	p.ConfigureProviderCalled = true
-	p.ConfigureStateStoreCalled = true
-	source, err := pluggable.NewPluggable(p, storeType)
-	if err != nil {
-		t.Fatalf("unexpected err: %s", err)
-	}
-	sourceStateMgr, diags := source.StateMgr(workspaceName)
-	if diags.HasErrors() {
-		t.Fatal(diags.Err())
-	}
+		storeType := "test_store"
+		p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+		p.ConfigureProviderCalled = true
+		p.ConfigureStateStoreCalled = true
 
-	destination := backendLocal.New()
-	destinationStateMgr, diags := source.StateMgr(workspaceName)
-	if diags.HasErrors() {
-		t.Fatal(diags.Err())
-	}
+		// We need a state to migrate
+		p.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+			"test_store",
+			workspaceName,
+			[]byte(`{"version":4,"terraform_version":"1.16.0","serial":1,"lineage":"8595356e-c764-dea1-8dae-156b936ec6e2","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
+		)
+		source, err := pluggable.NewPluggable(p, storeType)
+		if err != nil {
+			t.Fatalf("unexpected err: %s", err)
+		}
+		destination := backendLocal.New()
 
-	opts := &backendMigrateOpts{
-		SourceType: storeType,
-		Source:     source,
+		opts := &backendMigrateOpts{
+			SourceType: storeType,
+			Source:     source,
 
-		DestinationType: "local",
-		Destination:     destination,
-	}
+			DestinationType: "local",
+			Destination:     destination,
 
-	inputWriter := testInputMap(t, map[string]string{
-		"backend-migrate-copy-to-empty": "no", // We're only testing the prompt, no is sufficient
+			sourceWorkspace: workspaceName,
+		}
+
+		inputWriter := testInputMap(t, map[string]string{
+			"backend-migrate-copy-to-empty": "no", // We're only testing the prompt, no is sufficient
+		})
+
+		meta := Meta{
+			input: true,
+			Ui:    testUiWrapped(t),
+		}
+		err = meta.backendMigrateState_s_s(opts)
+		if err != nil {
+			t.Fatalf("Didn't expect an error but got: %s", err)
+		}
+
+		// Check the source and destination are interpolated in the expected places
+		promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
+		expected := []string{
+			`migrating the previous "test_store" state store to the newly configured "local" backend.`,
+			`No existing state was found in the newly configured "local" backend`,
+			`copy this state to the new "local" backend?`,
+		}
+		for _, e := range expected {
+			if !strings.Contains(promptText, e) {
+				t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
+			}
+		}
 	})
 
-	meta := Meta{
-		input: true,
-		Ui:    testUiWrapped(t),
-	}
-	_, err = meta.backendMigrateEmptyConfirm(sourceStateMgr, destinationStateMgr, opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+	t.Run("state in destination - prompt via backendMigrateNonEmptyConfirm", func(t *testing.T) {
+		td := t.TempDir()
+		t.Chdir(td)
 
-	// Check the source and destination are interpolated in the expected places
-	promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
-	expected := []string{
-		`migrating the previous "test_store" state store to the newly configured "local" backend.`,
-		`No existing state was found in the newly configured "local" backend`,
-		`copy this state to the new "local" backend?`,
-	}
-	for _, e := range expected {
-		if !strings.Contains(promptText, e) {
-			t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
+		workspaceName := "default"
+
+		// Source - has a state for migration
+		storeType := "test_store"
+		p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+		p.ConfigureProviderCalled = true
+		p.ConfigureStateStoreCalled = true
+		p.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+			"test_store",
+			workspaceName,
+			[]byte(`{"version":4,"terraform_version":"1.16.0","serial":1,"lineage":"8595356e-c764-dea1-8dae-156b936ec6e2","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
+		)
+		source, err := pluggable.NewPluggable(p, storeType)
+		if err != nil {
+			t.Fatalf("unexpected err: %s", err)
 		}
-	}
-}
 
-// A method that `backendMigrateState_s_s` uses to prompt users (no direct tests for `backendMigrateState_s_s`)
-func Test_backendMigrateNonEmptyConfirm(t *testing.T) {
-	workspaceName := "default"
+		// Destination - has a state present to cause the prompt under test
+		state := states.NewState()
+		state.SetOutputValue(
+			addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
+			cty.StringVal("bar value"), false,
+		)
+		state.SetOutputValue(
+			addrs.OutputValue{Name: "secret"}.Absolute(addrs.RootModuleInstance),
+			cty.StringVal("secret value"), true,
+		)
+		destination := backendLocal.New()
+		dStateMgr, diags := destination.StateMgr(workspaceName)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		err = dStateMgr.WriteState(state)
+		if err != nil {
+			t.Fatalf("unexpected err: %s", err)
+		}
 
-	storeType := "test_store"
-	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
-	p.ConfigureProviderCalled = true
-	p.ConfigureStateStoreCalled = true
-	source, err := pluggable.NewPluggable(p, storeType)
-	if err != nil {
-		t.Fatalf("unexpected err: %s", err)
-	}
-	sourceStateMgr, diags := source.StateMgr(workspaceName)
-	if diags.HasErrors() {
-		t.Fatal(diags.Err())
-	}
+		opts := &backendMigrateOpts{
+			SourceType: storeType,
+			Source:     source,
 
-	destination := backendLocal.New()
-	destinationStateMgr, diags := source.StateMgr(workspaceName)
-	if diags.HasErrors() {
-		t.Fatal(diags.Err())
-	}
+			DestinationType: "local",
+			Destination:     destination,
 
-	opts := &backendMigrateOpts{
-		SourceType: storeType,
-		Source:     source,
+			sourceWorkspace: workspaceName,
+		}
 
-		DestinationType: "local",
-		Destination:     destination,
-	}
+		inputWriter := testInputMap(t, map[string]string{
+			"backend-migrate-to-backend": "no", // We're only testing the prompt, no is sufficient
+		})
 
-	inputWriter := testInputMap(t, map[string]string{
-		"backend-migrate-to-backend": "no", // We're only testing the prompt, no is sufficient
+		meta := Meta{
+			input: true,
+			Ui:    testUiWrapped(t),
+		}
+		err = meta.backendMigrateState_s_s(opts)
+		if err != nil {
+			t.Fatalf("Didn't expect an error but got: %s", err)
+		}
+
+		// Check the source and destination are interpolated in the expected places
+		promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
+		expected := []string{
+			`migrating the previous "test_store" state store to the newly configured "local" backend.`,
+			`non-empty state already exists in the new backend.`,
+			`Previous (state store "test_store"):`,
+			`New (backend "local"):`,
+			`overwrite the state in the new backend with the previous state?`,
+		}
+		for _, e := range expected {
+			if !strings.Contains(promptText, e) {
+				t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
+			}
+		}
 	})
-
-	meta := Meta{
-		input: true,
-		Ui:    testUiWrapped(t),
-	}
-	_, err = meta.backendMigrateNonEmptyConfirm(sourceStateMgr, destinationStateMgr, opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	// Check the source and destination are interpolated in the expected places
-	promptText := cleanString(inputWriter.String()) // assertions need to space newlines, this makes it easier
-	expected := []string{
-		`migrating the previous "test_store" state store to the newly configured "local" backend.`,
-		`non-empty state already exists in the new backend.`,
-		`Previous (state store "test_store"):`,
-		`New (backend "local"):`,
-		`overwrite the state in the new backend with the previous state?`,
-	}
-	for _, e := range expected {
-		if !strings.Contains(promptText, e) {
-			t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, promptText)
-		}
-	}
 }
 
 func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {

--- a/internal/command/meta_backend_migrate_test.go
+++ b/internal/command/meta_backend_migrate_test.go
@@ -48,6 +48,50 @@ func Test_backendMigrateState_S_S(t *testing.T) {
 	}
 }
 
+func Test_backendMigrateState_S_s(t *testing.T) {
+	storeType := "test_store"
+	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema(storeType))
+	p.ConfigureProviderCalled = true
+	p.ConfigureStateStoreCalled = true
+	source, err := pluggable.NewPluggable(p, storeType)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	destination := backendLocal.TestNewLocalSingle() // local with no workspace support
+
+	opts := &backendMigrateOpts{
+		SourceType: storeType,
+		Source:     source,
+
+		DestinationType: "local",
+		Destination:     destination,
+	}
+
+	inputWriter := testInputMap(t, map[string]string{
+		"backend-migrate-multistate-to-single": "no", // We're only testing the prompt, no is sufficient
+	})
+
+	meta := Meta{
+		input: true,
+		Ui:    testUiWrapped(t),
+	}
+	err = meta.backendMigrateState_S_s(opts)
+	if err == nil {
+		t.Fatal("expected a 'Migration aborted by user' error but got none")
+	}
+
+	// Check the source and destination are interpolated in the expected places
+	expected := []string{
+		`Destination backend "local" doesn't support workspaces`,
+		`The existing "test_store" state store supports workspaces`,
+	}
+	for _, e := range expected {
+		if !strings.Contains(inputWriter.String(), e) {
+			t.Fatalf("expected the input prompt to include %q, but got':\n %s", e, inputWriter.String())
+		}
+	}
+}
+
 func TestBackendMigrate_promptMultiStatePattern(t *testing.T) {
 	// Setup the meta
 


### PR DESCRIPTION
This PR adds tests for the different prompts that can be created via `backendMigrateState`. Instead of asserting the full prompt text it makes assertions about parts of the text that parameters are inserted into.

The `backendMigrateState` method has a switch statement that controls migration behaviour:

https://github.com/hashicorp/terraform/blob/2e1710bfc5fa8bb45735b9ebcc9b258e00e9c155/internal/command/meta_backend_migrate.go#L105-L107

These are the methods (on Meta) that can be used in those cases:
1. `backendMigrateTFC`
1. `backendMigrateState_s_s`
1. `backendMigrateState_S_s`
1. `backendMigrateState_S_s`

This PR adds tests for all except the first method. By supplying a source state store and a destination backend via  `opts` we can make assertions to confirm that the right names and `"backend"`/`"state store"` strings end up in the expected places.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
