### PR TITLE
feat: Add start of JSON view for the `state migrate` command (implements `Spacer`,`StateStoreProviderTrustLogger`)

### DIFF
--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -339,7 +339,7 @@ func (v *InitJSON) LogInteractiveRejection() {
 func (v *InitJSON) LogAutomaticApproval() {
 	v.view.log.Info(
 		logInteractiveAutomaticApprovalMessageJSON,
-		"type", json.ProviderAutomationApproval,
+		"type", json.ProviderAutomaticApproval,
 	)
 }
 

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -70,5 +70,5 @@ const (
 	// Provider trust-related message (currently used only in PSS context)
 	ProviderInteractiveApproval  MessageType = "provider_interactive_approval"
 	ProviderInteractiveRejection MessageType = "provider_interactive_rejection"
-	ProviderAutomationApproval   MessageType = "provider_automatic_approval"
+	ProviderAutomaticApproval    MessageType = "provider_automatic_approval"
 )

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -10,6 +10,7 @@ import (
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/views/json"
 	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -76,9 +77,10 @@ func NewStateMigrate(viewType arguments.ViewType, view *View) StateMigrate {
 }
 
 var (
-	_ StateMigrate               = (*StateMigrateHuman)(nil)
-	_ ProviderInstallationLogger = (*StateMigrateHuman)(nil)
-	_ Spacer                     = (*StateMigrateHuman)(nil)
+	_ StateMigrate                  = (*StateMigrateHuman)(nil)
+	_ ProviderInstallationLogger    = (*StateMigrateHuman)(nil)
+	_ StateStoreProviderTrustLogger = (*StateMigrateHuman)(nil)
+	_ Spacer                        = (*StateMigrateHuman)(nil)
 )
 
 type StateMigrateHuman struct {
@@ -269,9 +271,36 @@ type StateMigrateJSON struct {
 	view *JSONView
 }
 
-var _ Spacer = (*StateMigrateJSON)(nil)
+var (
+	_ StateStoreProviderTrustLogger = (*StateMigrateJSON)(nil)
+	_ Spacer                        = (*StateMigrateJSON)(nil)
+)
 
 // Implements Spacer
 func (s *StateMigrateJSON) Spacer() {
 	// no-op for JSON output, since we don't want to log empty messages in JSON
+}
+
+// Implements StateStoreProviderTrustLogger interface.
+func (s *StateMigrateJSON) LogInteractiveApproval() {
+	s.view.log.Info(
+		logInteractiveApprovalMessageJSON,
+		"type", json.ProviderInteractiveApproval,
+	)
+}
+
+// Implements StateStoreProviderTrustLogger interface.
+func (s *StateMigrateJSON) LogInteractiveRejection() {
+	s.view.log.Info(
+		logInteractiveRejectionMessageJSON,
+		"type", json.ProviderInteractiveRejection,
+	)
+}
+
+// Implements StateStoreProviderTrustLogger interface.
+func (s *StateMigrateJSON) LogAutomaticApproval() {
+	s.view.log.Info(
+		logInteractiveAutomaticApprovalMessageJSON,
+		"type", json.ProviderAutomaticApproval,
+	)
 }

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -264,3 +264,14 @@ func (s *StateMigrateHuman) prepareMessage(code InitMessageCode, params ...any) 
 
 	return s.view.colorize.Color(strings.TrimSpace(fmt.Sprintf(message.HumanValue, params...)))
 }
+
+type StateMigrateJSON struct {
+	view *JSONView
+}
+
+var _ Spacer = (*StateMigrateJSON)(nil)
+
+// Implements Spacer
+func (s *StateMigrateJSON) Spacer() {
+	// no-op for JSON output, since we don't want to log empty messages in JSON
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -116,3 +116,69 @@ func TestNewStateMigrate_Spacer_json(t *testing.T) {
 		t.Fatalf("expected no additional output after version message, got: %s", output.Stdout())
 	}
 }
+
+func TestNewStateMigrate_LogInteractiveApproval_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogInteractiveApproval()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`approved by the user`, // @message
+		`"@module":"terraform.ui"`,
+		`"type":"provider_interactive_approval"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewStateMigrate_LogInteractiveRejection_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogInteractiveRejection()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`rejected by the user`, // @message
+		`"@module":"terraform.ui"`,
+		`"type":"provider_interactive_rejection"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewStateMigrate_LogAutomaticApproval_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogAutomaticApproval()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`approved automatically`, // @message
+		`"@module":"terraform.ui"`,
+		`"type":"provider_automatic_approval"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -4,6 +4,7 @@
 package views
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -96,4 +97,22 @@ func TestNewStateMigrate_LogProviderVersionSuccessWithKeyID(t *testing.T) {
 			t.Fatalf("expected %q, got %q", expectedOutput, output.Stdout())
 		}
 	})
+}
+
+func TestNewStateMigrate_Spacer_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.Spacer()
+
+	// Assert output
+	output := done(t)
+
+	// We cannot simply assert no output as the JSON view logs the version message on initialization
+	// Splitting on \n when there's only the version log will get an array of the log and an empty string.
+	// If there are more logs there'll be >2 elements.
+	if x := strings.Split(output.Stdout(), "\n"); len(x) != 2 {
+		t.Fatalf("expected no additional output after version message, got: %s", output.Stdout())
+	}
 }


### PR DESCRIPTION
This PR adds the beginning of the JSON view for the `state migrate` command, but it's not a complete implementation yet.

I've introduced the new struct type and implemented some of the required interfaces:
* `Spacer`
* `StateStoreProviderTrustLogger`

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
