### PR TITLE
feat: Implement `DependencyLockingLogger` interface on `StateMigrateJSON`

### DIFF
--- a/internal/command/meta_dependencies.go
+++ b/internal/command/meta_dependencies.go
@@ -143,7 +143,7 @@ func (m *Meta) annotateDependencyLocksWithOverrides(ret *depsfile.Locks) *depsfi
 // saveDependencyLockFile can overwrite the contents of the dependency lock file.
 // If the locks match the previous locks, then the file is not updated and no output is produced.
 // If a "readonly" -lockfile flag is supplied then changing the file is blocked.
-func (m *Meta) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, incompleteProviders []string, flagLockfile string, view views.DependencyLockingLogger) (output bool, diags tfdiags.Diagnostics) {
+func (m *Meta) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, incompleteProviders []string, flagLockfile string, view views.ProviderLockingLogger) (output bool, diags tfdiags.Diagnostics) {
 	// If the provider dependencies have changed since the last run then we'll
 	// say a little about that in case the reader wasn't expecting a change.
 	// (When we later integrate module dependencies into the lock file we'll
@@ -194,10 +194,10 @@ func (m *Meta) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, i
 			// say a little about what the dependency lock file is, for new
 			// users or those who are upgrading from a previous Terraform
 			// version that didn't have dependency lock files.
-			view.LogDependencyLockfileCreated()
+			view.LogProviderLockfileCreated()
 			output = true
 		} else {
-			view.LogDependencyLockfileUpdated()
+			view.LogProviderLockfileUpdated()
 			output = true
 		}
 		lockFileDiags := m.replaceLockedDependencies(newLocks)

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -381,7 +381,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	diags = diags.Append(bsfDiags)
 	if bsfDiags.HasErrors() {
 		view.Diagnostics(diags)
-		view.LogStateMigrationErrored(views.DuringBackendStateFile, source, destination)
+		view.LogStateMigrationErrored(views.DuringWorkDirStateUpdate, source, destination)
 		return 1
 	}
 

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -481,7 +481,7 @@ func (c *StateMigrateCommand) getDestinationStateStoreProviderRequirements(provi
 }
 
 // saveDependencyLockFile overwrites the contents of the dependency lock file.
-func (c *StateMigrateCommand) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, view views.DependencyLockingLogger) (output bool, diags tfdiags.Diagnostics) {
+func (c *StateMigrateCommand) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, view views.ProviderLockingLogger) (output bool, diags tfdiags.Diagnostics) {
 	// The state migrate command does not support the -lockfile=readonly flag
 	// This flag is specific to the init command, and can only take "" or "readonly" as values.
 	// As state migrate doesn't take this flag, we can safely set it to "" here.

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -28,7 +28,7 @@ type Init interface {
 
 	ModuleInstallationLogger
 	ProviderInstallationLogger
-	DependencyLockingLogger
+	ProviderLockingLogger
 
 	StateStoreProviderTrustLogger
 
@@ -163,14 +163,14 @@ func (v *InitHuman) LogPartnerAndCommunityProviders() {
 	v.print(v.prepareMessage(PartnerAndCommunityProvidersMessage))
 }
 
-// Implements DependencyLockingLogger
-func (v *InitHuman) LogDependencyLockfileCreated() {
+// Implements ProviderLockingLogger
+func (v *InitHuman) LogProviderLockfileCreated() {
 	params := []any{}
 	v.print(v.prepareMessage(LockInfo, params...))
 }
 
-// Implements DependencyLockingLogger
-func (v *InitHuman) LogDependencyLockfileUpdated() {
+// Implements ProviderLockingLogger
+func (v *InitHuman) LogProviderLockfileUpdated() {
 	params := []any{}
 	v.print(v.prepareMessage(DependenciesLockChangesInfo, params...))
 }
@@ -422,16 +422,16 @@ func (v *InitJSON) LogPartnerAndCommunityProviders() {
 	v.logInitMessage(PartnerAndCommunityProvidersMessage)
 }
 
-// Implements DependencyLockingLogger
-func (v *InitJSON) LogDependencyLockfileCreated() {
+// Implements ProviderLockingLogger
+func (v *InitJSON) LogProviderLockfileCreated() {
 	// This was previously logged via Output, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	params := []any{}
 	v.Output(LockInfo, params...)
 }
 
-// Implements DependencyLockingLogger
-func (v *InitJSON) LogDependencyLockfileUpdated() {
+// Implements ProviderLockingLogger
+func (v *InitJSON) LogProviderLockfileUpdated() {
 	// This was previously logged via Output, so we need to match implementation of that method
 	// to ensure the same JSON log is produced.
 	params := []any{}

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -911,7 +911,7 @@ func TestNewInit_LogDependencyLockfileCreated_json(t *testing.T) {
 	view := NewView(streams)
 	initView := NewInit(arguments.ViewJSON, view)
 
-	initView.LogDependencyLockfileCreated()
+	initView.LogProviderLockfileCreated()
 
 	// Assert output
 	output := done(t)
@@ -935,7 +935,7 @@ func TestNewInit_LogDependencyLockfileUpdated_json(t *testing.T) {
 	view := NewView(streams)
 	initView := NewInit(arguments.ViewJSON, view)
 
-	initView.LogDependencyLockfileUpdated()
+	initView.LogProviderLockfileUpdated()
 
 	// Assert output
 	output := done(t)

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -68,6 +68,11 @@ const (
 	// Provider installation messages
 	InstallStateStoreProviderStart MessageType = "state_store_provider_installation_start"
 
+	// Dependency lock file messages
+	// Uses provider-oriented language in case we add a module lock file in future.
+	ProviderLockfileCreated MessageType = "provider_lockfile_created"
+	ProviderLockfileUpdated MessageType = "provider_lockfile_updated"
+
 	// Provider trust-related message (currently used only in PSS context)
 	ProviderInteractiveApproval  MessageType = "provider_interactive_approval"
 	ProviderInteractiveRejection MessageType = "provider_interactive_rejection"

--- a/internal/command/views/provider_locking_logger.go
+++ b/internal/command/views/provider_locking_logger.go
@@ -3,9 +3,9 @@
 
 package views
 
-type DependencyLockingLogger interface {
-	LogDependencyLockfileCreated()
-	LogDependencyLockfileUpdated()
+type ProviderLockingLogger interface {
+	LogProviderLockfileCreated()
+	LogProviderLockfileUpdated()
 }
 
 const previousLockInfoHuman = `

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -72,7 +72,7 @@ type StateMigrate interface {
 	LogMigrationDestinationInitializationComplete()
 
 	ProviderInstallationLogger
-	DependencyLockingLogger
+	ProviderLockingLogger
 
 	StateStoreProviderTrustLogger
 
@@ -272,12 +272,12 @@ func (s *StateMigrateHuman) LogPartnerAndCommunityProviders() {
 }
 
 // Implements DependencyLockLogger interface.
-func (s *StateMigrateHuman) LogDependencyLockfileCreated() {
+func (s *StateMigrateHuman) LogProviderLockfileCreated() {
 	s.log(previousLockInfoHuman)
 }
 
 // Implements DependencyLockLogger interface.
-func (s *StateMigrateHuman) LogDependencyLockfileUpdated() {
+func (s *StateMigrateHuman) LogProviderLockfileUpdated() {
 	s.log(dependenciesLockChangesInfo)
 }
 
@@ -302,7 +302,7 @@ type StateMigrateJSON struct {
 }
 
 var (
-	_ DependencyLockingLogger       = (*StateMigrateJSON)(nil)
+	_ ProviderLockingLogger         = (*StateMigrateJSON)(nil)
 	_ StateStoreProviderTrustLogger = (*StateMigrateJSON)(nil)
 	_ Spacer                        = (*StateMigrateJSON)(nil)
 )
@@ -336,8 +336,8 @@ func (s *StateMigrateJSON) LogAutomaticApproval() {
 	)
 }
 
-// Implements DependencyLockingLogger interface.
-func (s *StateMigrateJSON) LogDependencyLockfileCreated() {
+// Implements ProviderLockingLogger interface.
+func (s *StateMigrateJSON) LogProviderLockfileCreated() {
 	msg := strings.TrimSpace(previousLockInfoJSON)
 	s.view.log.Info(
 		msg,
@@ -345,8 +345,8 @@ func (s *StateMigrateJSON) LogDependencyLockfileCreated() {
 	)
 }
 
-// Implements DependencyLockingLogger interface.
-func (s *StateMigrateJSON) LogDependencyLockfileUpdated() {
+// Implements ProviderLockingLogger interface.
+func (s *StateMigrateJSON) LogProviderLockfileUpdated() {
 	msg := strings.TrimSpace(dependenciesLockChangesInfo)
 	s.view.log.Info(
 		msg,

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -52,9 +52,9 @@ type stateMigrationFailureMode string
 // In the JSON view these values are used as the value of a field indicating when the error occurred.
 // Therefore these strings are user-facing in JSON output and should not be changed!
 const (
-	DuringMigration        stateMigrationFailureMode = "error_during_migration"
-	DuringLockfile         stateMigrationFailureMode = "error_updating_provider_lockfile"
-	DuringBackendStateFile stateMigrationFailureMode = "error_updating_workdir_state"
+	DuringMigration          stateMigrationFailureMode = "error_during_migration"
+	DuringLockfile           stateMigrationFailureMode = "error_updating_provider_lockfile"
+	DuringWorkDirStateUpdate stateMigrationFailureMode = "error_updating_workdir_state"
 )
 
 type StateMigrate interface {
@@ -120,7 +120,7 @@ func (s *StateMigrateHuman) LogStateMigrationErrored(failMode stateMigrationFail
 	case DuringMigration:
 		// migration itself failed
 		msg = fmt.Sprintf(StateMigrationFailureMessage, source, destination)
-	case DuringLockfile, DuringBackendStateFile:
+	case DuringLockfile, DuringWorkDirStateUpdate:
 		// migration succeeded by updates in the working directory failed
 		msg = fmt.Sprintf(StateMigrationPostStepsInterruptedMessage, source, destination)
 	default:

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -302,6 +302,7 @@ type StateMigrateJSON struct {
 }
 
 var (
+	_ DependencyLockingLogger       = (*StateMigrateJSON)(nil)
 	_ StateStoreProviderTrustLogger = (*StateMigrateJSON)(nil)
 	_ Spacer                        = (*StateMigrateJSON)(nil)
 )
@@ -332,5 +333,23 @@ func (s *StateMigrateJSON) LogAutomaticApproval() {
 	s.view.log.Info(
 		logInteractiveAutomaticApprovalMessageJSON,
 		"type", json.ProviderAutomaticApproval,
+	)
+}
+
+// Implements DependencyLockingLogger interface.
+func (s *StateMigrateJSON) LogDependencyLockfileCreated() {
+	msg := strings.TrimSpace(previousLockInfoJSON)
+	s.view.log.Info(
+		msg,
+		"type", json.ProviderLockfileCreated,
+	)
+}
+
+// Implements DependencyLockingLogger interface.
+func (s *StateMigrateJSON) LogDependencyLockfileUpdated() {
+	msg := strings.TrimSpace(dependenciesLockChangesInfo)
+	s.view.log.Info(
+		msg,
+		"type", json.ProviderLockfileUpdated,
 	)
 }

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -128,7 +128,7 @@ func TestNewStateMigrate_LogInteractiveApproval_json(t *testing.T) {
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`approved by the user`, // @message
+		`approved by the user`, // @message - incomplete but sufficient
 		`"@module":"terraform.ui"`,
 		`"type":"provider_interactive_approval"`,
 	}
@@ -150,7 +150,7 @@ func TestNewStateMigrate_LogInteractiveRejection_json(t *testing.T) {
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`rejected by the user`, // @message
+		`rejected by the user`, // @message - incomplete but sufficient
 		`"@module":"terraform.ui"`,
 		`"type":"provider_interactive_rejection"`,
 	}
@@ -172,9 +172,31 @@ func TestNewStateMigrate_LogAutomaticApproval_json(t *testing.T) {
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`approved automatically`, // @message
+		`approved automatically`, // @message - incomplete but sufficient
 		`"@module":"terraform.ui"`,
 		`"type":"provider_automatic_approval"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewStateMigrate_LogDependencyLockfileCreated_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogDependencyLockfileCreated()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`Terraform has created a lock file .terraform.lock.hcl`, // @message - incomplete but sufficient
+		`"@module":"terraform.ui"`,
+		`"type":"provider_lockfile_created"`,
 	}
 	for _, snippet := range expectedOutputFields {
 		if !strings.Contains(output.Stdout(), snippet) {

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -188,7 +188,7 @@ func TestNewStateMigrate_LogDependencyLockfileCreated_json(t *testing.T) {
 	view := NewView(streams)
 	smView := StateMigrateJSON{view: NewJSONView(view)}
 
-	smView.LogDependencyLockfileCreated()
+	smView.LogProviderLockfileCreated()
 
 	// Assert output
 	output := done(t)


### PR DESCRIPTION
Stacks on https://github.com/hashicorp/terraform/pull/39002

Renames the `DependencyLockingLogger` interface to `ProviderLockingLogger` 

Implements `ProviderLockingLogger` on `StateMigrateJSON`.

The JSON view for `state migrate` isn't complete after this PR still. Once it _is_ complete I'll make it possible to activate via the `-json` flag.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
