### PR TITLE
import: Fix `id` and `identity` evaluation for child modules

### DIFF
--- a/internal/terraform/context_apply_import_test.go
+++ b/internal/terraform/context_apply_import_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -72,30 +73,8 @@ func TestContextApply_import_in_module(t *testing.T) {
 		t.Fatal("resource not imported")
 	}
 
-	rs := state.ResourceInstance(mustResourceInstanceAddr("module.child.test_object.bar[\"first\"]"))
-	if rs == nil {
-		t.Fatal("imported resource not found in module")
-	}
-	var attrs map[string]interface{}
-	err := json.Unmarshal(rs.Current.AttrsJSON, &attrs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got, want := attrs["id"], "testa"; got != want {
-		t.Fatalf("wrong id for \"first\" got:  %#v  want: %#v\n", got, want)
-	}
-
-	rs = state.ResourceInstance(mustResourceInstanceAddr("module.child.test_object.bar[\"second\"]"))
-	if rs == nil {
-		t.Fatal("imported resource not found in module")
-	}
-	err = json.Unmarshal(rs.Current.AttrsJSON, &attrs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got, want := attrs["id"], "testb"; got != want {
-		t.Fatalf("wrong id for \"second\" got:  %#v  want: %#v\n", got, want)
-	}
+	assertImportedId(t, state, "module.child.test_object.bar[\"first\"]", "testa")
+	assertImportedId(t, state, "module.child.test_object.bar[\"second\"]", "testb")
 }
 
 func TestContextApply_import_in_nested_module(t *testing.T) { // more nested than the test above. nesteder.
@@ -249,20 +228,8 @@ func TestContextApply_import_duplication(t *testing.T) {
 	state, diags := ctx.Apply(plan, m, nil)
 	tfdiags.AssertNoErrors(t, diags)
 
-	rs := state.ResourceInstance(mustResourceInstanceAddr("module.child.test_object.foo"))
-	if rs == nil {
-		t.Fatal("imported resource not found in module")
-	}
-	var attrs map[string]interface{}
-	err := json.Unmarshal(rs.Current.AttrsJSON, &attrs)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// the parent module import takes precedence (confirming the comment in refactoring/import_statement.go)
-	if got, want := attrs["id"], "rootimport"; got != want {
-		t.Fatalf("wrong id! got:  %#v  want: %#v\n", got, want)
-	}
+	assertImportedId(t, state, "module.child.test_object.foo", "rootimport")
 }
 
 func TestContextApply_import_in_state_not_config(t *testing.T) {
@@ -319,5 +286,163 @@ func TestContextApply_import_in_state_not_config(t *testing.T) {
 	_, diags = ctx.Plan(m, state, nil)
 	if !strings.Contains(diags.Err().Error(), "Configuration for import target does not exist") {
 		t.Fatalf("wrong error! got %s\n", diags.Err())
+	}
+}
+
+func TestContextApply_import_in_module_expressions(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "child" {
+  source = "./child"
+}
+resource "test_object" "root_foo" {}
+resource "test_object" "root_bar" {}
+
+locals {
+  root_foo_id = "foo-123"
+  root_bar_id = "bar-123"
+}
+import {
+  to = test_object.root_foo
+  id = local.root_foo_id
+}
+import {
+  to = test_object.root_bar
+  identity = {
+    id = local.root_bar_id
+  }
+}
+		`,
+		"child/main.tf": `
+resource "test_object" "child_foo" {}
+resource "test_object" "child_bar" {}
+
+locals {
+  child_foo_id = "foo-456"
+  child_bar_id = "bar-456"
+}
+import {
+  to = test_object.child_foo
+  id = local.child_foo_id
+}
+import {
+  to = test_object.child_bar
+  identity = {
+    id = local.child_bar_id
+  }
+}
+
+		`,
+	})
+
+	p := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{Body: &configschema.Block{}},
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": providers.Schema{
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"id":          {Type: cty.String, Computed: true},
+							"test_string": {Type: cty.String, Optional: true},
+						},
+					},
+					Identity: &configschema.Object{
+						Nesting: configschema.NestingSingle,
+						Attributes: map[string]*configschema.Attribute{
+							"id": {Type: cty.String, Required: true},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p.ImportResourceStateFn = func(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+		if !req.Identity.IsNull() {
+			return providers.ImportResourceStateResponse{
+				ImportedResources: []providers.ImportedResource{
+					{
+						TypeName: "test_object",
+						Identity: cty.ObjectVal(map[string]cty.Value{
+							"id": req.Identity.GetAttr("id"),
+						}),
+						State: cty.ObjectVal(map[string]cty.Value{
+							"test_string": cty.StringVal("importable"),
+							"id":          req.Identity.GetAttr("id"),
+						}),
+					},
+				},
+			}
+		}
+		return providers.ImportResourceStateResponse{
+			ImportedResources: []providers.ImportedResource{
+				{
+					TypeName: "test_object",
+					State: cty.ObjectVal(map[string]cty.Value{
+						"test_string": cty.StringVal("importable"),
+						"id":          cty.StringVal(req.ID),
+					}),
+					Identity: cty.ObjectVal(map[string]cty.Value{
+						"id": cty.StringVal(req.ID),
+					}),
+				},
+			},
+		}
+	}
+	p.ReadResourceFn = func(r providers.ReadResourceRequest) providers.ReadResourceResponse {
+		id := r.PriorState.GetAttr("id")
+		return providers.ReadResourceResponse{
+			NewState: cty.ObjectVal(map[string]cty.Value{
+				"test_string": cty.StringVal("importable"),
+				"id":          id,
+			}),
+			Identity: cty.ObjectVal(map[string]cty.Value{
+				"id": id,
+			}),
+		}
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, nil)
+	tfdiags.AssertNoErrors(t, diags)
+
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode: plans.NormalMode,
+	})
+	tfdiags.AssertNoErrors(t, diags)
+
+	state, diags := ctx.Apply(plan, m, nil)
+	tfdiags.AssertNoErrors(t, diags)
+
+	if !p.ImportResourceStateCalled {
+		t.Fatal("resources not imported")
+	}
+
+	assertImportedId(t, state, "test_object.root_foo", "foo-123")
+	assertImportedId(t, state, "test_object.root_bar", "bar-123")
+	assertImportedId(t, state, "module.child.test_object.child_foo", "foo-456")
+	assertImportedId(t, state, "module.child.test_object.child_bar", "bar-456")
+}
+
+func assertImportedId(t *testing.T, state *states.State, resourceAddr, expectedID string) {
+	t.Helper()
+
+	rs := state.ResourceInstance(mustResourceInstanceAddr(resourceAddr))
+	if rs == nil {
+		t.Errorf("imported resource %q not found in module", resourceAddr)
+		return
+	}
+	var attrs map[string]interface{}
+	err := json.Unmarshal(rs.Current.AttrsJSON, &attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := attrs["id"]; got != expectedID {
+		t.Errorf("wrong id for %q got:  %#v  want: %#v\n", resourceAddr, got, expectedID)
 	}
 }

--- a/internal/terraform/context_apply_import_test.go
+++ b/internal/terraform/context_apply_import_test.go
@@ -289,7 +289,7 @@ func TestContextApply_import_in_state_not_config(t *testing.T) {
 	}
 }
 
-func TestContextApply_import_in_module_expressions(t *testing.T) {
+func TestContextApply_import_expressions(t *testing.T) {
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "child" {
@@ -427,6 +427,271 @@ import {
 	assertImportedId(t, state, "test_object.root_bar", "bar-123")
 	assertImportedId(t, state, "module.child.test_object.child_foo", "foo-456")
 	assertImportedId(t, state, "module.child.test_object.child_bar", "bar-456")
+}
+
+func TestContextApply_import_into_module_expressions(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "child" {
+  source = "./child"
+}
+
+locals {
+  root_foo_id = "foo-123"
+  root_bar_id = "bar-123"
+}
+import {
+  to = module.child.test_object.child_foo
+  id = local.root_foo_id
+}
+import {
+  to = module.child.test_object.child_bar
+  identity = {
+    id = local.root_bar_id
+  }
+}
+		`,
+		"child/main.tf": `
+resource "test_object" "child_foo" {}
+resource "test_object" "child_bar" {}
+
+locals {
+  child_foo_id = "foo-456"
+  child_bar_id = "bar-456"
+}
+module "grandchild" {
+  source = "./grandchild"
+}
+import {
+  to = module.grandchild.test_object.grandchild_foo
+  id = local.child_foo_id
+}
+import {
+  to = module.grandchild.test_object.grandchild_bar
+  identity = {
+    id = local.child_bar_id
+  }
+}
+		`,
+		"child/grandchild/main.tf": `
+resource "test_object" "grandchild_foo" {}
+resource "test_object" "grandchild_bar" {}
+		`,
+	})
+
+	p := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{Body: &configschema.Block{}},
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": providers.Schema{
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"id":          {Type: cty.String, Computed: true},
+							"test_string": {Type: cty.String, Optional: true},
+						},
+					},
+					Identity: &configschema.Object{
+						Nesting: configschema.NestingSingle,
+						Attributes: map[string]*configschema.Attribute{
+							"id": {Type: cty.String, Required: true},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p.ImportResourceStateFn = func(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+		if !req.Identity.IsNull() {
+			return providers.ImportResourceStateResponse{
+				ImportedResources: []providers.ImportedResource{
+					{
+						TypeName: "test_object",
+						Identity: cty.ObjectVal(map[string]cty.Value{
+							"id": req.Identity.GetAttr("id"),
+						}),
+						State: cty.ObjectVal(map[string]cty.Value{
+							"test_string": cty.StringVal("importable"),
+							"id":          req.Identity.GetAttr("id"),
+						}),
+					},
+				},
+			}
+		}
+		return providers.ImportResourceStateResponse{
+			ImportedResources: []providers.ImportedResource{
+				{
+					TypeName: "test_object",
+					State: cty.ObjectVal(map[string]cty.Value{
+						"test_string": cty.StringVal("importable"),
+						"id":          cty.StringVal(req.ID),
+					}),
+					Identity: cty.ObjectVal(map[string]cty.Value{
+						"id": cty.StringVal(req.ID),
+					}),
+				},
+			},
+		}
+	}
+	p.ReadResourceFn = func(r providers.ReadResourceRequest) providers.ReadResourceResponse {
+		id := r.PriorState.GetAttr("id")
+		return providers.ReadResourceResponse{
+			NewState: cty.ObjectVal(map[string]cty.Value{
+				"test_string": cty.StringVal("importable"),
+				"id":          id,
+			}),
+			Identity: cty.ObjectVal(map[string]cty.Value{
+				"id": id,
+			}),
+		}
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, nil)
+	tfdiags.AssertNoErrors(t, diags)
+
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode: plans.NormalMode,
+	})
+	tfdiags.AssertNoErrors(t, diags)
+
+	state, diags := ctx.Apply(plan, m, nil)
+	tfdiags.AssertNoErrors(t, diags)
+
+	if !p.ImportResourceStateCalled {
+		t.Fatal("resources not imported")
+	}
+
+	assertImportedId(t, state, "module.child.test_object.child_foo", "foo-123")
+	assertImportedId(t, state, "module.child.test_object.child_bar", "bar-123")
+	assertImportedId(t, state, "module.child.module.grandchild.test_object.grandchild_foo", "foo-456")
+	assertImportedId(t, state, "module.child.module.grandchild.test_object.grandchild_bar", "bar-456")
+}
+
+func TestContextApply_import_into_module_expressions_foreach(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "child" {
+  for_each = local.rep_data
+  source = "./child"
+  rep_data = toset([each.key])
+}
+
+locals {
+  num = 123
+  rep_data = toset(["foo", "bar"])
+}
+import {
+  for_each = local.rep_data
+  to = module.child[each.key].test_object.child_obj[each.key]
+  id = "${each.key}-${local.num}"
+}
+		`,
+		"child/main.tf": `
+variable "rep_data" {
+  type = set(string)
+}
+resource "test_object" "child_obj" {
+  for_each = var.rep_data
+}
+		`,
+	})
+
+	p := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{Body: &configschema.Block{}},
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": providers.Schema{
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"id":          {Type: cty.String, Computed: true},
+							"test_string": {Type: cty.String, Optional: true},
+						},
+					},
+					Identity: &configschema.Object{
+						Nesting: configschema.NestingSingle,
+						Attributes: map[string]*configschema.Attribute{
+							"id": {Type: cty.String, Required: true},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p.ImportResourceStateFn = func(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+		if !req.Identity.IsNull() {
+			return providers.ImportResourceStateResponse{
+				ImportedResources: []providers.ImportedResource{
+					{
+						TypeName: "test_object",
+						Identity: cty.ObjectVal(map[string]cty.Value{
+							"id": req.Identity.GetAttr("id"),
+						}),
+						State: cty.ObjectVal(map[string]cty.Value{
+							"test_string": cty.StringVal("importable"),
+							"id":          req.Identity.GetAttr("id"),
+						}),
+					},
+				},
+			}
+		}
+		return providers.ImportResourceStateResponse{
+			ImportedResources: []providers.ImportedResource{
+				{
+					TypeName: "test_object",
+					State: cty.ObjectVal(map[string]cty.Value{
+						"test_string": cty.StringVal("importable"),
+						"id":          cty.StringVal(req.ID),
+					}),
+					Identity: cty.ObjectVal(map[string]cty.Value{
+						"id": cty.StringVal(req.ID),
+					}),
+				},
+			},
+		}
+	}
+	p.ReadResourceFn = func(r providers.ReadResourceRequest) providers.ReadResourceResponse {
+		id := r.PriorState.GetAttr("id")
+		return providers.ReadResourceResponse{
+			NewState: cty.ObjectVal(map[string]cty.Value{
+				"test_string": cty.StringVal("importable"),
+				"id":          id,
+			}),
+			Identity: cty.ObjectVal(map[string]cty.Value{
+				"id": id,
+			}),
+		}
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, nil)
+	tfdiags.AssertNoErrors(t, diags)
+
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode: plans.NormalMode,
+	})
+	tfdiags.AssertNoErrors(t, diags)
+
+	state, diags := ctx.Apply(plan, m, nil)
+	tfdiags.AssertNoErrors(t, diags)
+
+	if !p.ImportResourceStateCalled {
+		t.Fatal("resources not imported")
+	}
+
+	assertImportedId(t, state, `module.child["foo"].test_object.child_obj["foo"]`, "foo-123")
+	assertImportedId(t, state, `module.child["bar"].test_object.child_obj["bar"]`, "bar-123")
 }
 
 func assertImportedId(t *testing.T, state *states.State, resourceAddr, expectedID string) {

--- a/internal/terraform/context_apply_import_test.go
+++ b/internal/terraform/context_apply_import_test.go
@@ -335,73 +335,7 @@ import {
 		`,
 	})
 
-	p := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{Body: &configschema.Block{}},
-			ResourceTypes: map[string]providers.Schema{
-				"test_object": providers.Schema{
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"id":          {Type: cty.String, Computed: true},
-							"test_string": {Type: cty.String, Optional: true},
-						},
-					},
-					Identity: &configschema.Object{
-						Nesting: configschema.NestingSingle,
-						Attributes: map[string]*configschema.Attribute{
-							"id": {Type: cty.String, Required: true},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	p.ImportResourceStateFn = func(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
-		if !req.Identity.IsNull() {
-			return providers.ImportResourceStateResponse{
-				ImportedResources: []providers.ImportedResource{
-					{
-						TypeName: "test_object",
-						Identity: cty.ObjectVal(map[string]cty.Value{
-							"id": req.Identity.GetAttr("id"),
-						}),
-						State: cty.ObjectVal(map[string]cty.Value{
-							"test_string": cty.StringVal("importable"),
-							"id":          req.Identity.GetAttr("id"),
-						}),
-					},
-				},
-			}
-		}
-		return providers.ImportResourceStateResponse{
-			ImportedResources: []providers.ImportedResource{
-				{
-					TypeName: "test_object",
-					State: cty.ObjectVal(map[string]cty.Value{
-						"test_string": cty.StringVal("importable"),
-						"id":          cty.StringVal(req.ID),
-					}),
-					Identity: cty.ObjectVal(map[string]cty.Value{
-						"id": cty.StringVal(req.ID),
-					}),
-				},
-			},
-		}
-	}
-	p.ReadResourceFn = func(r providers.ReadResourceRequest) providers.ReadResourceResponse {
-		id := r.PriorState.GetAttr("id")
-		return providers.ReadResourceResponse{
-			NewState: cty.ObjectVal(map[string]cty.Value{
-				"test_string": cty.StringVal("importable"),
-				"id":          id,
-			}),
-			Identity: cty.ObjectVal(map[string]cty.Value{
-				"id": id,
-			}),
-		}
-	}
-
+	p := childModuleImportTestProvider()
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
@@ -479,73 +413,7 @@ resource "test_object" "grandchild_bar" {}
 		`,
 	})
 
-	p := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{Body: &configschema.Block{}},
-			ResourceTypes: map[string]providers.Schema{
-				"test_object": providers.Schema{
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"id":          {Type: cty.String, Computed: true},
-							"test_string": {Type: cty.String, Optional: true},
-						},
-					},
-					Identity: &configschema.Object{
-						Nesting: configschema.NestingSingle,
-						Attributes: map[string]*configschema.Attribute{
-							"id": {Type: cty.String, Required: true},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	p.ImportResourceStateFn = func(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
-		if !req.Identity.IsNull() {
-			return providers.ImportResourceStateResponse{
-				ImportedResources: []providers.ImportedResource{
-					{
-						TypeName: "test_object",
-						Identity: cty.ObjectVal(map[string]cty.Value{
-							"id": req.Identity.GetAttr("id"),
-						}),
-						State: cty.ObjectVal(map[string]cty.Value{
-							"test_string": cty.StringVal("importable"),
-							"id":          req.Identity.GetAttr("id"),
-						}),
-					},
-				},
-			}
-		}
-		return providers.ImportResourceStateResponse{
-			ImportedResources: []providers.ImportedResource{
-				{
-					TypeName: "test_object",
-					State: cty.ObjectVal(map[string]cty.Value{
-						"test_string": cty.StringVal("importable"),
-						"id":          cty.StringVal(req.ID),
-					}),
-					Identity: cty.ObjectVal(map[string]cty.Value{
-						"id": cty.StringVal(req.ID),
-					}),
-				},
-			},
-		}
-	}
-	p.ReadResourceFn = func(r providers.ReadResourceRequest) providers.ReadResourceResponse {
-		id := r.PriorState.GetAttr("id")
-		return providers.ReadResourceResponse{
-			NewState: cty.ObjectVal(map[string]cty.Value{
-				"test_string": cty.StringVal("importable"),
-				"id":          id,
-			}),
-			Identity: cty.ObjectVal(map[string]cty.Value{
-				"id": id,
-			}),
-		}
-	}
-
+	p := childModuleImportTestProvider()
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
@@ -602,6 +470,51 @@ resource "test_object" "child_obj" {
 		`,
 	})
 
+	p := childModuleImportTestProvider()
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, nil)
+	tfdiags.AssertNoErrors(t, diags)
+
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode: plans.NormalMode,
+	})
+	tfdiags.AssertNoErrors(t, diags)
+
+	state, diags := ctx.Apply(plan, m, nil)
+	tfdiags.AssertNoErrors(t, diags)
+
+	if !p.ImportResourceStateCalled {
+		t.Fatal("resources not imported")
+	}
+
+	assertImportedId(t, state, `module.child["foo"].test_object.child_obj["foo"]`, "foo-123")
+	assertImportedId(t, state, `module.child["bar"].test_object.child_obj["bar"]`, "bar-123")
+}
+
+func assertImportedId(t *testing.T, state *states.State, resourceAddr, expectedID string) {
+	t.Helper()
+
+	rs := state.ResourceInstance(mustResourceInstanceAddr(resourceAddr))
+	if rs == nil {
+		t.Errorf("imported resource %q not found in module", resourceAddr)
+		return
+	}
+	var attrs map[string]interface{}
+	err := json.Unmarshal(rs.Current.AttrsJSON, &attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := attrs["id"]; got != expectedID {
+		t.Errorf("wrong id for %q got:  %#v  want: %#v\n", resourceAddr, got, expectedID)
+	}
+}
+
+func childModuleImportTestProvider() *testing_provider.MockProvider {
 	p := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{Body: &configschema.Block{}},
@@ -669,45 +582,5 @@ resource "test_object" "child_obj" {
 		}
 	}
 
-	ctx := testContext2(t, &ContextOpts{
-		Providers: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
-		},
-	})
-
-	diags := ctx.Validate(m, nil)
-	tfdiags.AssertNoErrors(t, diags)
-
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
-		Mode: plans.NormalMode,
-	})
-	tfdiags.AssertNoErrors(t, diags)
-
-	state, diags := ctx.Apply(plan, m, nil)
-	tfdiags.AssertNoErrors(t, diags)
-
-	if !p.ImportResourceStateCalled {
-		t.Fatal("resources not imported")
-	}
-
-	assertImportedId(t, state, `module.child["foo"].test_object.child_obj["foo"]`, "foo-123")
-	assertImportedId(t, state, `module.child["bar"].test_object.child_obj["bar"]`, "bar-123")
-}
-
-func assertImportedId(t *testing.T, state *states.State, resourceAddr, expectedID string) {
-	t.Helper()
-
-	rs := state.ResourceInstance(mustResourceInstanceAddr(resourceAddr))
-	if rs == nil {
-		t.Errorf("imported resource %q not found in module", resourceAddr)
-		return
-	}
-	var attrs map[string]interface{}
-	err := json.Unmarshal(rs.Current.AttrsJSON, &attrs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := attrs["id"]; got != expectedID {
-		t.Errorf("wrong id for %q got:  %#v  want: %#v\n", resourceAddr, got, expectedID)
-	}
+	return p
 }

--- a/internal/terraform/eval_import.go
+++ b/internal/terraform/eval_import.go
@@ -24,12 +24,12 @@ import (
 func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData instances.RepetitionData, allowUnknown bool) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	// import blocks only exist in the root module, and must be evaluated in
-	// that context.
-	ctx = evalContextForModuleInstance(ctx, addrs.RootModuleInstance)
 	scope := ctx.EvaluationScope(nil, nil, keyData)
 	importIdVal, evalDiags := scope.EvalExpr(expr, cty.String)
 	diags = diags.Append(evalDiags)
+	if diags.HasErrors() {
+		return cty.NilVal, diags
+	}
 
 	if importIdVal.IsNull() {
 		return cty.NilVal, diags.Append(&hcl.Diagnostic{
@@ -84,9 +84,6 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData in
 func evaluateImportIdentityExpression(expr hcl.Expression, identity *configschema.Object, ctx EvalContext, keyData instances.RepetitionData, allowUnknown bool) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	// import blocks only exist in the root module, and must be evaluated in
-	// that context.
-	ctx = evalContextForModuleInstance(ctx, addrs.RootModuleInstance)
 	scope := ctx.EvaluationScope(nil, nil, keyData)
 	importIdentityVal, evalDiags := scope.EvalExpr(expr, identity.ConfigType())
 	if evalDiags.HasErrors() {

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -277,20 +277,25 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 	return result
 }
 
-func (n *NodeAbstractResource) ImportReferences() []*addrs.Reference {
-	var result []*addrs.Reference
+func (n *NodeAbstractResource) ImportReferences() []ImportReference {
+	var result []ImportReference
 	for _, importTarget := range n.importTargets {
 		// legacy import won't have any config
 		if importTarget.Config == nil {
 			continue
 		}
 
-		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ID)
-		result = append(result, refs...)
-		refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.Identity)
-		result = append(result, refs...)
-		refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ForEach)
-		result = append(result, refs...)
+		var refs []*addrs.Reference
+		idRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ID)
+		refs = append(refs, idRefs...)
+		identityRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.Identity)
+		refs = append(refs, identityRefs...)
+		forEachRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ForEach)
+		refs = append(refs, forEachRefs...)
+
+		for _, ref := range refs {
+			result = append(result, ImportReference{RelModule: importTarget.RelModule, Ref: ref})
+		}
 	}
 	return result
 }

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -152,10 +152,6 @@ func (n *nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, all
 		return knownImports, unknownImports, diags
 	}
 
-	// Import blocks are only valid within the root module, and must be
-	// evaluated within that context
-	ctx = evalContextForModuleInstance(ctx, addrs.RootModuleInstance)
-
 	state := ctx.State()
 
 	for _, imp := range n.importTargets {

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -275,7 +275,7 @@ func (t *ConfigTransformer) validateImportTargets() error {
 		var toResource addrs.ConfigResource
 		switch {
 		case i.Config != nil:
-			toResource = i.Config.ToResource
+			toResource = i.AbsToConfigResource
 		default:
 			toResource = i.LegacyAddr.ConfigResource()
 		}

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -344,8 +344,7 @@ func (m ReferenceMap) References(v dag.Vertex) []dag.Vertex {
 
 	if rn, ok := v.(GraphNodeImportReferencer); ok {
 		for _, ref := range rn.ImportReferences() {
-			// import block references are always in the root module scope
-			referenceKeys = append(referenceKeys, m.referenceMapKey(addrs.RootModule, ref.Subject))
+			referenceKeys = append(referenceKeys, m.referenceMapKey(vertexReferencePath(v), ref.Subject))
 		}
 	}
 

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -42,13 +42,24 @@ type GraphNodeReferencer interface {
 	References() []*addrs.Reference
 }
 
+// ImportReference pairs a reference with the module path of the import block
+// that contains it, which is the correct scope for resolving the reference.
+type ImportReference struct {
+	// RelModule is the path of the module containing the import block.
+	RelModule addrs.Module
+
+	// Ref is a reference found in an import block expressions.
+	Ref *addrs.Reference
+}
+
 // GraphNodeReferencer must be implemented by nodes that import resources.
 type GraphNodeImportReferencer interface {
 	GraphNodeReferencer
 
 	// ImportReferences returns a list of references made by this node's
-	// associated import block.
-	ImportReferences() []*addrs.Reference
+	// associated import block, each paired with the module path of the import
+	// block where the reference was written.
+	ImportReferences() []ImportReference
 }
 
 type GraphNodeAttachDependencies interface {
@@ -343,8 +354,8 @@ func (m ReferenceMap) References(v dag.Vertex) []dag.Vertex {
 	}
 
 	if rn, ok := v.(GraphNodeImportReferencer); ok {
-		for _, ref := range rn.ImportReferences() {
-			referenceKeys = append(referenceKeys, m.referenceMapKey(vertexReferencePath(v), ref.Subject))
+		for _, ir := range rn.ImportReferences() {
+			referenceKeys = append(referenceKeys, m.referenceMapKey(ir.RelModule, ir.Ref.Subject))
 		}
 	}
 

--- a/internal/terraform/transform_reference_test.go
+++ b/internal/terraform/transform_reference_test.go
@@ -418,14 +418,20 @@ resource "test_object" "root_foo" {}
 
 locals {
   root_foo_id = "foo-123"
+  root_bar_id = "bar-123"
 }
 import {
   to  = test_object.root_foo
   id  = local.root_foo_id
 }
+import {
+  to  = module.child.test_object.child_bar
+  id  = local.root_bar_id
+}
 `,
 		"child/main.tf": `
 resource "test_object" "child_foo" {}
+resource "test_object" "child_bar" {}
 
 locals {
   child_foo_id = "foo-456"
@@ -449,17 +455,24 @@ import {
 
 	actual := strings.TrimSpace(g.String())
 	expected := strings.TrimSpace(`
+local.root_bar_id (expand)
 local.root_foo_id (expand)
 module.child (close)
+  module.child.test_object.child_bar (expand)
   module.child.test_object.child_foo (expand)
 module.child (expand)
 module.child.local.child_foo_id (expand)
   module.child (expand)
+module.child.test_object.child_bar (expand)
+  local.root_bar_id (expand)
+  module.child (expand)
+  provider["registry.terraform.io/hashicorp/test"]
 module.child.test_object.child_foo (expand)
   module.child.local.child_foo_id (expand)
   provider["registry.terraform.io/hashicorp/test"]
 provider["registry.terraform.io/hashicorp/test"]
 provider["registry.terraform.io/hashicorp/test"] (close)
+  module.child.test_object.child_bar (expand)
   module.child.test_object.child_foo (expand)
   test_object.root_foo (expand)
 root

--- a/internal/terraform/transform_reference_test.go
+++ b/internal/terraform/transform_reference_test.go
@@ -408,3 +408,69 @@ resource "test_resource" "in_modc" {
 	}
 
 }
+
+// This test verifies that edges are created for import references, both in root and child modules.
+func TestReferenceTransformer_import_references(t *testing.T) {
+	cfg := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "child" { source = "./child" }
+resource "test_object" "root_foo" {}
+
+locals {
+  root_foo_id = "foo-123"
+}
+import {
+  to  = test_object.root_foo
+  id  = local.root_foo_id
+}
+`,
+		"child/main.tf": `
+resource "test_object" "child_foo" {}
+
+locals {
+  child_foo_id = "foo-456"
+}
+import {
+  to  = test_object.child_foo
+  id  = local.child_foo_id
+}
+`,
+	})
+
+	p := testProvider("test_object")
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	g, _, diags := ctx.planGraph(cfg, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
+	tfdiags.AssertNoErrors(t, diags)
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(`
+local.root_foo_id (expand)
+module.child (close)
+  module.child.test_object.child_foo (expand)
+module.child (expand)
+module.child.local.child_foo_id (expand)
+  module.child (expand)
+module.child.test_object.child_foo (expand)
+  module.child.local.child_foo_id (expand)
+  provider["registry.terraform.io/hashicorp/test"]
+provider["registry.terraform.io/hashicorp/test"]
+provider["registry.terraform.io/hashicorp/test"] (close)
+  module.child.test_object.child_foo (expand)
+  test_object.root_foo (expand)
+root
+  module.child (close)
+  provider["registry.terraform.io/hashicorp/test"] (close)
+test_object.root_foo (expand)
+  local.root_foo_id (expand)
+  provider["registry.terraform.io/hashicorp/test"]
+`)
+
+	if actual != expected {
+		t.Fatalf("wrong result\n\ngot:\n%s\n\nwant:\n%s", actual, expected)
+	}
+}


### PR DESCRIPTION
This PR fixes a bug where child modules would evaluate the `id` and `identity` attributes using the root module scope, which was adjusted in #38352 to now support child modules 🎉 .

Prior to the fixes, the context test failure:
```bash
--- FAIL: TestContextApply_import_in_module_expressions (0.01s)
    /Users/austin.valle/code/terraform/internal/terraform/context_apply_import_test.go:417: [ERROR@../../../../../../private/var/folders/t8/1tjpvj_d24x8yl0st5qswzf80000gp/T/TestContextApply_import_in_module_expressions858322557/001/child/main.tf:16,10]
        Reference to undeclared local value: A local value with the name "child_bar_id" has not been declared.
    /Users/austin.valle/code/terraform/internal/terraform/context_apply_import_test.go:417: [ERROR@../../../../../../private/var/folders/t8/1tjpvj_d24x8yl0st5qswzf80000gp/T/TestContextApply_import_in_module_expressions858322557/001/child/main.tf:11,8]
        Reference to undeclared local value: A local value with the name "child_foo_id" has not been declared.
```

---------

This PR also adjusts the reference transformer to ensure the proper graph edges are created for child module import references. I wasn't quite sure the best way to recreate that behavior in a test so I opted to just write a transformer unit test w/ the node order (which previously showed the edges not getting created).

I only noticed because I randomly got an error when running the context test:
```bash
The local value <blah> was not processed by the most recent operation,
this likely means the previous operation either failed or was incomplete
due to targeting.
``` 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

> _I'm not sure if we need to add a changelog for unreleased bug fixes now that we are in `rc`, happy to add one if needed 👍🏻_

- [x] This change is user-facing ~and I added a changelog entry.~ but I opted to skip adding one because it hasn't released yet
- [ ] This change is not user-facing.
