### PR TITLE
refactor: Rename provider installation-related methods

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -963,7 +963,7 @@ func linkFromCacheBeginCallback(view views.ProviderInstallationLogger) func(prov
 // Returns a reused callback function for the FetchPackageBegin event in a providercache.InstallerEvents struct.
 func fetchPackageBeginCallback(view views.ProviderInstallationLogger) func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
 	return func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
-		view.LogInstallingProviderVersion(provider, version)
+		view.LogInstallProviderVersionStart(provider, version)
 	}
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -1209,11 +1209,11 @@ func fetchPackageSuccessCallback(view views.ProviderInstallationLogger) func(pro
 			keyID = authResult.KeyID
 		}
 		if keyID != "" {
-			view.LogProviderVersionSuccessWithKeyID(provider, version, authResult, keyID)
+			view.LogInstallProviderVersionCompleteWithKeyID(provider, version, authResult, keyID)
 			return
 		}
 
-		view.LogProviderVersionSuccess(provider, version, authResult)
+		view.LogInstallProviderVersionComplete(provider, version, authResult)
 	}
 }
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -146,7 +146,7 @@ func (v *InitHuman) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
 	v.print(v.prepareMessage(BuiltInProviderAvailableMessage, params...))
 }
 
-func (v *InitHuman) LogInstallingProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
+func (v *InitHuman) LogInstallProviderVersionStart(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	v.print(v.prepareMessage(InstallingProviderMessage, params...))
 }
@@ -398,7 +398,7 @@ func (v *InitJSON) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
 	v.logInitMessage(BuiltInProviderAvailableMessage, params...)
 }
 
-func (v *InitJSON) LogInstallingProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
+func (v *InitJSON) LogInstallProviderVersionStart(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -156,12 +156,12 @@ func (v *InitHuman) LogReusingPreviousProviderVersion(providerAddr addrs.Provide
 	v.print(v.prepareMessage(ReusingPreviousVersionInfo, params...))
 }
 
-func (v *InitHuman) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+func (v *InitHuman) LogInstallProviderVersionComplete(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	v.print(v.prepareMessage(InstalledProviderVersionInfo, params...))
 }
 
-func (v *InitHuman) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+func (v *InitHuman) LogInstallProviderVersionCompleteWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
 	keyDetails := fmt.Sprintf(", key ID [reset][bold]%s[reset]", keyID) // key id needs to be formatted for human output
 	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 	v.print(v.prepareMessage(InstalledProviderVersionInfo, params...))
@@ -414,7 +414,7 @@ func (v *InitJSON) LogReusingPreviousProviderVersion(providerAddr addrs.Provider
 	v.logInitMessage(ReusingPreviousVersionInfo, params...)
 }
 
-func (v *InitJSON) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+func (v *InitJSON) LogInstallProviderVersionComplete(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method
@@ -422,7 +422,7 @@ func (v *InitJSON) LogProviderVersionSuccess(providerAddr addrs.Provider, versio
 	v.logInitMessage(InstalledProviderVersionInfo, params...)
 }
 
-func (v *InitJSON) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+func (v *InitJSON) LogInstallProviderVersionCompleteWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
 	keyDetails := fmt.Sprintf("key_id: %s", keyID) // key id needs to be formatted for JSON output
 	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -787,14 +787,14 @@ func TestNewInit_LogFindingLatestVersion_json(t *testing.T) {
 	}
 }
 
-func TestNewInit_LogInstallingProviderVersion_json(t *testing.T) {
+func TestNewInit_LogInstallProviderVersionStart_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
 	initView := NewInit(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	v := versions.MustParseVersion("1.0.0")
-	initView.LogInstallingProviderVersion(p, v)
+	initView.LogInstallProviderVersionStart(p, v)
 
 	// Assert output
 	output := done(t)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -474,7 +474,7 @@ func TestNewInit_humanViewOutput(t *testing.T) {
 }
 
 // Assert message content
-func TestNewInit_LogProviderVersionSuccess(t *testing.T) {
+func TestNewInit_LogInstallProviderVersionComplete(t *testing.T) {
 	const verifiedChecksum = 0
 	const officialProvider = 1
 	const noKey = ""
@@ -488,7 +488,7 @@ func TestNewInit_LogProviderVersionSuccess(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		var authResult *getproviders.PackageAuthenticationResult = nil
 
-		initView.LogProviderVersionSuccess(p, ver, authResult)
+		initView.LogInstallProviderVersionComplete(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -506,7 +506,7 @@ func TestNewInit_LogProviderVersionSuccess(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		var authResult *getproviders.PackageAuthenticationResult = nil
 
-		initView.LogProviderVersionSuccess(p, ver, authResult)
+		initView.LogInstallProviderVersionComplete(p, ver, authResult)
 
 		// Assert output - human
 		output := done(t)
@@ -524,7 +524,7 @@ func TestNewInit_LogProviderVersionSuccess(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		authResult := getproviders.NewPackageAuthenticationResult(verifiedChecksum, noKey)
 
-		initView.LogProviderVersionSuccess(p, ver, authResult)
+		initView.LogInstallProviderVersionComplete(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -542,7 +542,7 @@ func TestNewInit_LogProviderVersionSuccess(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		authResult := getproviders.NewPackageAuthenticationResult(verifiedChecksum, noKey)
 
-		initView.LogProviderVersionSuccess(p, ver, authResult)
+		initView.LogInstallProviderVersionComplete(p, ver, authResult)
 
 		// Assert output - human
 		output := done(t)
@@ -561,7 +561,7 @@ func TestNewInit_LogProviderVersionSuccess(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(officialProvider, key)
 
-		initView.LogProviderVersionSuccess(p, ver, authResult)
+		initView.LogInstallProviderVersionComplete(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -580,7 +580,7 @@ func TestNewInit_LogProviderVersionSuccess(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(officialProvider, key)
 
-		initView.LogProviderVersionSuccess(p, ver, authResult)
+		initView.LogInstallProviderVersionComplete(p, ver, authResult)
 
 		// Assert output - human
 		output := done(t)
@@ -592,7 +592,7 @@ func TestNewInit_LogProviderVersionSuccess(t *testing.T) {
 }
 
 // Assert message content
-func TestNewInit_LogProviderVersionSuccessWithKeyID(t *testing.T) {
+func TestNewInit_LogInstallProviderVersionCompleteWithKeyID(t *testing.T) {
 	const partnerProvider = 2
 
 	t.Run("partner provider auth result - human view", func(t *testing.T) {
@@ -605,7 +605,7 @@ func TestNewInit_LogProviderVersionSuccessWithKeyID(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, key)
 
-		initView.LogProviderVersionSuccessWithKeyID(p, ver, authResult, key)
+		initView.LogInstallProviderVersionCompleteWithKeyID(p, ver, authResult, key)
 
 		// Assert output - human
 		output := done(t)
@@ -624,7 +624,7 @@ func TestNewInit_LogProviderVersionSuccessWithKeyID(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, key)
 
-		initView.LogProviderVersionSuccessWithKeyID(p, ver, authResult, key)
+		initView.LogInstallProviderVersionCompleteWithKeyID(p, ver, authResult, key)
 
 		// Assert output - human
 		output := done(t)
@@ -636,7 +636,7 @@ func TestNewInit_LogProviderVersionSuccessWithKeyID(t *testing.T) {
 }
 
 // Assert JSON log content, including log type and additional fields
-func TestNewInit_LogProviderVersionSuccess_json(t *testing.T) {
+func TestNewInit_LogInstallProviderVersionComplete_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
 	initView := NewInit(arguments.ViewJSON, view)
@@ -645,7 +645,7 @@ func TestNewInit_LogProviderVersionSuccess_json(t *testing.T) {
 	v := versions.MustParseVersion("1.0.0")
 	officialProvider := 1
 	authResult := getproviders.NewPackageAuthenticationResult(officialProvider, "key-id-123")
-	initView.LogProviderVersionSuccess(p, v, authResult)
+	initView.LogInstallProviderVersionComplete(p, v, authResult)
 
 	// Assert output
 	output := done(t)
@@ -689,7 +689,7 @@ func TestNewInit_LogProviderVersionAlreadyInstalled_json(t *testing.T) {
 // Assert JSON log content, including log type and additional fields
 //
 // Note - in calling code this is only ever used for partner providers
-func TestNewInit_LogProviderVersionSuccessWithKeyID_json(t *testing.T) {
+func TestNewInit_LogInstallProviderVersionCompleteWithKeyID_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
 	initView := NewInit(arguments.ViewJSON, view)
@@ -699,7 +699,7 @@ func TestNewInit_LogProviderVersionSuccessWithKeyID_json(t *testing.T) {
 	partnerProvider := 2
 	keyID := "key-id-123"
 	authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, keyID)
-	initView.LogProviderVersionSuccessWithKeyID(p, v, authResult, keyID)
+	initView.LogInstallProviderVersionCompleteWithKeyID(p, v, authResult, keyID)
 
 	// Assert output
 	output := done(t)

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -33,8 +33,8 @@ type ProviderInstallationLogger interface {
 	// FindingLatestVersion indicates that Terraform is looking for the latest version of a provider during installation (no constraint nor prior lock was supplied)
 	LogFindingLatestVersion(providerAddr addrs.Provider)
 
-	// LogInstallingProviderVersion indicates that a provider is being installed (from a remote location)
-	LogInstallingProviderVersion(providerAddr addrs.Provider, version getproviders.Version)
+	// LogInstallProviderVersionStart indicates that a provider is being installed (from a remote location)
+	LogInstallProviderVersionStart(providerAddr addrs.Provider, version getproviders.Version)
 
 	// LogBuiltInProviderAvailable indicates a built-in provider is available in the current Terraform core binary and is in use during installation
 	LogBuiltInProviderAvailable(providerAddr addrs.Provider)

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -15,11 +15,11 @@ import (
 type ProviderInstallationLogger interface {
 	Output(messageCode InitMessageCode, params ...any)
 
-	// LogProviderVersionSuccess describes a successfully installed provider along with its version
-	LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
+	// LogInstallProviderVersionComplete describes a successfully installed provider along with its version
+	LogInstallProviderVersionComplete(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
 
-	// LogProviderVersionSuccessWithKeyID describes a successfully installed provider along with its version and the key ID used to verify the provider's authenticity
-	LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
+	// LogInstallProviderVersionCompleteWithKeyID describes a successfully installed provider along with its version and the key ID used to verify the provider's authenticity
+	LogInstallProviderVersionCompleteWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string)
 
 	// LogProviderVersionAlreadyInstalled indicates a provider that is already installed during installation
 	LogProviderVersionAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -241,7 +241,7 @@ func (s *StateMigrateHuman) LogBuiltInProviderAvailable(providerAddr addrs.Provi
 }
 
 // Implements ProviderInstallationLogger interface.
-func (s *StateMigrateHuman) LogInstallingProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
+func (s *StateMigrateHuman) LogInstallProviderVersionStart(providerAddr addrs.Provider, version getproviders.Version) {
 	params := []any{providerAddr.ForDisplay(), version}
 	msg := s.prepareMessage(InstallingProviderMessage, params...)
 	s.log(msg)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -255,14 +255,14 @@ func (s *StateMigrateHuman) LogReusingPreviousProviderVersion(providerAddr addrs
 }
 
 // Implements ProviderInstallationLogger interface.
-func (s *StateMigrateHuman) LogProviderVersionSuccess(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+func (s *StateMigrateHuman) LogInstallProviderVersionComplete(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
 	params := []any{providerAddr.ForDisplay(), version, auth, ""} // add empty key id to the end
 	msg := s.prepareMessage(InstalledProviderVersionInfo, params...)
 	s.log(msg)
 }
 
 // Implements ProviderInstallationLogger interface.
-func (s *StateMigrateHuman) LogProviderVersionSuccessWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+func (s *StateMigrateHuman) LogInstallProviderVersionCompleteWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
 	keyDetails := fmt.Sprintf(", key ID [reset][bold]%s[reset]", keyID) // key id needs to be formatted for human output
 	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/terminal"
 )
 
-func TestNewStateMigrate_LogProviderVersionSuccess(t *testing.T) {
+func TestNewStateMigrate_LogInstallProviderVersionComplete(t *testing.T) {
 	const verifiedChecksum = 0
 	const officialProvider = 1
 	const noKey = ""
@@ -27,7 +27,7 @@ func TestNewStateMigrate_LogProviderVersionSuccess(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		var authResult *getproviders.PackageAuthenticationResult = nil
 
-		smView.LogProviderVersionSuccess(p, ver, authResult)
+		smView.LogInstallProviderVersionComplete(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -45,7 +45,7 @@ func TestNewStateMigrate_LogProviderVersionSuccess(t *testing.T) {
 		ver := getproviders.MustParseVersion("1.2.3")
 		authResult := getproviders.NewPackageAuthenticationResult(verifiedChecksum, noKey)
 
-		smView.LogProviderVersionSuccess(p, ver, authResult)
+		smView.LogInstallProviderVersionComplete(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -64,7 +64,7 @@ func TestNewStateMigrate_LogProviderVersionSuccess(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(officialProvider, key)
 
-		smView.LogProviderVersionSuccess(p, ver, authResult)
+		smView.LogInstallProviderVersionComplete(p, ver, authResult)
 
 		// Assert output
 		output := done(t)
@@ -75,7 +75,7 @@ func TestNewStateMigrate_LogProviderVersionSuccess(t *testing.T) {
 	})
 }
 
-func TestNewStateMigrate_LogProviderVersionSuccessWithKeyID(t *testing.T) {
+func TestNewStateMigrate_LogInstallProviderVersionCompleteWithKeyID(t *testing.T) {
 	const partnerProvider = 2
 
 	t.Run("partner provider auth result - human view", func(t *testing.T) {
@@ -88,7 +88,7 @@ func TestNewStateMigrate_LogProviderVersionSuccessWithKeyID(t *testing.T) {
 		key := "key-id-123"
 		authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, key)
 
-		smView.LogProviderVersionSuccessWithKeyID(p, ver, authResult, key)
+		smView.LogInstallProviderVersionCompleteWithKeyID(p, ver, authResult, key)
 
 		// Assert output - human
 		output := done(t)


### PR DESCRIPTION
This PR is just a global search and replace that causes these changes in method names:
1) `LogInstallingProviderVersion` => `LogInstallProviderVersionStart`
2) `LogProviderVersionSuccess` => `LogInstallProviderVersionComplete`
    * And the related `LogProviderVersionSuccessWithKeyID` => `LogInstallProviderVersionCompleteWithKeyID`


These methods are used to log progress when installing a provider from its source, i.e. the provider isn't already installed from a previous `init`. These methods mark the start and end of that process:

```
- Installing hashicorp/foobar v1.0.0...                         // logged via LogInstallProviderVersionStart
- Installed hashicorp/foobar v1.0.0 (signed by HashiCorp)       // logged via LogInstallProviderVersionComplete
```




## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
