### PR TITLE
Adding provider installation methods to state migrate's JSON view - Part 1

### DIFF
--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -577,8 +577,8 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  logReusingPreviousProviderVersionJSON,
 	},
 	"finding_matching_version_message": {
-		HumanValue: "- Finding %s versions matching %q...",
-		JSONValue:  "Finding matching versions for provider: %s, version_constraint: %q",
+		HumanValue: logFindingMatchingVersionHuman,
+		JSONValue:  logFindingMatchingVersionJSON,
 	},
 	"finding_latest_version_message": {
 		HumanValue: "- Finding latest version of %s...",

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -581,8 +581,8 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  logFindingMatchingVersionJSON,
 	},
 	"finding_latest_version_message": {
-		HumanValue: "- Finding latest version of %s...",
-		JSONValue:  "%s: Finding latest version...",
+		HumanValue: logFindingLatestVersionHuman,
+		JSONValue:  logFindingLatestVersionJSON,
 	},
 	"using_provider_from_cache_dir_info": {
 		HumanValue: "- Using %s v%s from the shared cache directory",

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -573,8 +573,8 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  "%s is built in to Terraform",
 	},
 	"reusing_previous_version_info": {
-		HumanValue: "- Reusing version %s of %s from the dependency lock file",
-		JSONValue:  "%s: Reusing version %s from the dependency lock file",
+		HumanValue: logReusingPreviousProviderVersionHuman,
+		JSONValue:  logReusingPreviousProviderVersionJSON,
 	},
 	"finding_matching_version_message": {
 		HumanValue: "- Finding %s versions matching %q...",

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -70,6 +70,7 @@ const (
 	InstallStateStoreProviderStart    MessageType = "state_store_provider_installation_start"
 	LogReusingPreviousProviderVersion MessageType = "provider_query_use_previous_version"
 	LogFindingMatchingVersion         MessageType = "provider_query_use_constraints"
+	LogFindingLatestVersion           MessageType = "provider_query_use_latest"
 
 	// Dependency lock file messages
 	// Uses provider-oriented language in case we add a module lock file in future.

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -66,8 +66,9 @@ const (
 	MessagePolicyQuerySummary     MessageType = "policy_query_summary"
 
 	// Provider installation messages
-	InstallProvidersStart          MessageType = "provider_installation_start"
-	InstallStateStoreProviderStart MessageType = "state_store_provider_installation_start"
+	InstallProvidersStart             MessageType = "provider_installation_start"
+	InstallStateStoreProviderStart    MessageType = "state_store_provider_installation_start"
+	LogReusingPreviousProviderVersion MessageType = "provider_query_use_previous_version"
 
 	// Dependency lock file messages
 	// Uses provider-oriented language in case we add a module lock file in future.

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -69,6 +69,7 @@ const (
 	InstallProvidersStart             MessageType = "provider_installation_start"
 	InstallStateStoreProviderStart    MessageType = "state_store_provider_installation_start"
 	LogReusingPreviousProviderVersion MessageType = "provider_query_use_previous_version"
+	LogFindingMatchingVersion         MessageType = "provider_query_use_constraints"
 
 	// Dependency lock file messages
 	// Uses provider-oriented language in case we add a module lock file in future.

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -57,4 +57,8 @@ const (
 	// LogInstallProvidersStart
 	logInstallProvidersStartMessageHuman = "[reset][bold]Installing providers..."
 	logInstallProvidersStartMessageJSON  = "Installing providers..."
+
+	// LogReusingPreviousProviderVersion
+	logReusingPreviousProviderVersionHuman = "- Reusing version %s of %s from the dependency lock file"
+	logReusingPreviousProviderVersionJSON  = "%s: Reusing version %s from the dependency lock file"
 )

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -58,6 +58,10 @@ const (
 	logInstallProvidersStartMessageHuman = "[reset][bold]Installing providers..."
 	logInstallProvidersStartMessageJSON  = "Installing providers..."
 
+	// LogFindingMatchingVersion
+	logFindingMatchingVersionHuman = "- Finding %s versions matching %q..."
+	logFindingMatchingVersionJSON  = "Finding matching versions for provider: %s, version_constraint: %q"
+
 	// LogReusingPreviousProviderVersion
 	logReusingPreviousProviderVersionHuman = "- Reusing version %s of %s from the dependency lock file"
 	logReusingPreviousProviderVersionJSON  = "%s: Reusing version %s from the dependency lock file"

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -58,6 +58,10 @@ const (
 	logInstallProvidersStartMessageHuman = "[reset][bold]Installing providers..."
 	logInstallProvidersStartMessageJSON  = "Installing providers..."
 
+	// LogFindingLatestVersion
+	logFindingLatestVersionHuman = "- Finding latest version of %s..."
+	logFindingLatestVersionJSON  = "%s: Finding latest version..."
+
 	// LogFindingMatchingVersion
 	logFindingMatchingVersionHuman = "- Finding %s versions matching %q..."
 	logFindingMatchingVersionJSON  = "Finding matching versions for provider: %s, version_constraint: %q"

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -375,3 +375,12 @@ func (s *StateMigrateJSON) LogReusingPreviousProviderVersion(providerAddr addrs.
 		"type", json.LogReusingPreviousProviderVersion,
 	)
 }
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints) {
+	msg := fmt.Sprintf(logFindingMatchingVersionJSON, providerAddr.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
+	s.view.log.Info(
+		msg,
+		"type", json.LogFindingMatchingVersion,
+	)
+}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -377,6 +377,15 @@ func (s *StateMigrateJSON) LogReusingPreviousProviderVersion(providerAddr addrs.
 }
 
 // Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogFindingLatestVersion(providerAddr addrs.Provider) {
+	msg := fmt.Sprintf(logFindingLatestVersionJSON, providerAddr.ForDisplay())
+	s.view.log.Info(
+		msg,
+		"type", json.LogFindingLatestVersion,
+	)
+}
+
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateJSON) LogFindingMatchingVersion(providerAddr addrs.Provider, versionConstraints getproviders.VersionConstraints) {
 	msg := fmt.Sprintf(logFindingMatchingVersionJSON, providerAddr.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
 	s.view.log.Info(

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -366,3 +366,12 @@ func (s *StateMigrateJSON) LogInstallProvidersStart() {
 		"type", json.InstallProvidersStart,
 	)
 }
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogReusingPreviousProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
+	msg := fmt.Sprintf(logReusingPreviousProviderVersionJSON, providerAddr.ForDisplay(), version)
+	s.view.log.Info(
+		msg,
+		"type", json.LogReusingPreviousProviderVersion,
+	)
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -248,3 +248,27 @@ func TestNewStateMigrate_LogInstallProvidersStart_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogReusingPreviousProviderVersion_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	version := getproviders.MustParseVersion("1.0.0")
+	smView.LogReusingPreviousProviderVersion(p, version)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"hashicorp/test: Reusing version 1.0.0 from the dependency lock file"`,
+		`"@module":"terraform.ui"`,
+		`"type":"provider_query_use_previous_version"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -205,6 +205,28 @@ func TestNewStateMigrate_LogDependencyLockfileCreated_json(t *testing.T) {
 	}
 }
 
+func TestNewStateMigrate_LogDependencyLockfileUpdated_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogProviderLockfileUpdated()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`Terraform has made some changes to the provider dependency selections`, // @message - incomplete but sufficient
+		`"@module":"terraform.ui"`,
+		`"type":"provider_lockfile_updated"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewStateMigrate_LogInstallProvidersStart_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -296,3 +296,26 @@ func TestNewStateMigrate_LogFindingMatchingVersion_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogFindingLatestVersion_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	smView.LogFindingLatestVersion(p)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"hashicorp/test: Finding latest version..."`,
+		`"@module":"terraform.ui"`,
+		`"type":"provider_query_use_latest"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -272,3 +272,27 @@ func TestNewStateMigrate_LogReusingPreviousProviderVersion_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogFindingMatchingVersion_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	constraint, _ := getproviders.ParseVersionConstraints("1.0.0")
+	smView.LogFindingMatchingVersion(p, constraint)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Finding matching versions for provider: hashicorp/test, version_constraint: \"1.0.0\""`,
+		`"@module":"terraform.ui"`,
+		`"type":"provider_query_use_constraints"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}


### PR DESCRIPTION
This PR implements these methods on the state migrate command's JSON view:
- `LogReusingPreviousProviderVersion`
- `LogFindingLatestVersion `
- `LogFindingMatchingVersion `

Alongside each of these changes there are tests asserting that the resulting JSON object has expected message and type data.

To enable message templates to be reused between `init` and `state migrate` commands I've removed template strings from the large `MessageRegistry` map in `internal/command/views/init.go` and instead defined those strings as constants in `internal/command/views/provider_installation_logger.go`. These can be accessed directly or via the map.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
