### PR TITLE
Adding provider installation methods to state migrate's JSON view - Part 2

### DIFF
--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -585,8 +585,8 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  logFindingLatestVersionJSON,
 	},
 	"using_provider_from_cache_dir_info": {
-		HumanValue: "- Using %s v%s from the shared cache directory",
-		JSONValue:  "%s v%s: Using from the shared cache directory",
+		HumanValue: logUsingProviderVersionFromCacheDirHuman,
+		JSONValue:  logUsingProviderVersionFromCacheDirJSON,
 	},
 	"installing_provider_message": {
 		HumanValue: "- Installing %s v%s...",

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -565,8 +565,8 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  previousLockInfoJSON,
 	},
 	"provider_already_installed_message": {
-		HumanValue: "- Using previously-installed %s v%s",
-		JSONValue:  "%s v%s: Using previously-installed provider version",
+		HumanValue: logProviderVersionAlreadyInstalledHuman,
+		JSONValue:  logProviderVersionAlreadyInstalledJSON,
 	},
 	"built_in_provider_available_message": {
 		HumanValue: "- %s is built in to Terraform",

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -589,12 +589,12 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  logUsingProviderVersionFromCacheDirJSON,
 	},
 	"installing_provider_message": {
-		HumanValue: "- Installing %s v%s...",
-		JSONValue:  "Installing provider version: %s v%s...",
+		HumanValue: logInstallProviderVersionStartHuman,
+		JSONValue:  logInstallProviderVersionStartJSON,
 	},
 	"installed_provider_version_info": {
-		HumanValue: "- Installed %s v%s (%s%s)",
-		JSONValue:  "Installed provider version: %s v%s (%s%s)",
+		HumanValue: logInstallProviderVersionCompleteHuman,
+		JSONValue:  logInstallProviderVersionCompleteJSON,
 	},
 	"partner_and_community_providers_message": {
 		HumanValue: partnerAndCommunityProvidersInfo,

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -73,6 +73,8 @@ const (
 	LogFindingLatestVersion             MessageType = "provider_query_use_latest"
 	LogProviderVersionAlreadyInstalled  MessageType = "provider_version_already_installed"
 	LogUsingProviderVersionFromCacheDir MessageType = "provider_version_found_in_cache_dir"
+	LogInstallProviderVersionStart      MessageType = "provider_version_installation_start"
+	LogInstallProviderVersionComplete   MessageType = "provider_version_installation_complete"
 
 	// Dependency lock file messages
 	// Uses provider-oriented language in case we add a module lock file in future.

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -66,12 +66,13 @@ const (
 	MessagePolicyQuerySummary     MessageType = "policy_query_summary"
 
 	// Provider installation messages
-	InstallProvidersStart              MessageType = "provider_installation_start"
-	InstallStateStoreProviderStart     MessageType = "state_store_provider_installation_start"
-	LogReusingPreviousProviderVersion  MessageType = "provider_query_use_previous_version"
-	LogFindingMatchingVersion          MessageType = "provider_query_use_constraints"
-	LogFindingLatestVersion            MessageType = "provider_query_use_latest"
-	LogProviderVersionAlreadyInstalled MessageType = "provider_version_already_installed"
+	InstallProvidersStart               MessageType = "provider_installation_start"
+	InstallStateStoreProviderStart      MessageType = "state_store_provider_installation_start"
+	LogReusingPreviousProviderVersion   MessageType = "provider_query_use_previous_version"
+	LogFindingMatchingVersion           MessageType = "provider_query_use_constraints"
+	LogFindingLatestVersion             MessageType = "provider_query_use_latest"
+	LogProviderVersionAlreadyInstalled  MessageType = "provider_version_already_installed"
+	LogUsingProviderVersionFromCacheDir MessageType = "provider_version_found_in_cache_dir"
 
 	// Dependency lock file messages
 	// Uses provider-oriented language in case we add a module lock file in future.

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -66,11 +66,12 @@ const (
 	MessagePolicyQuerySummary     MessageType = "policy_query_summary"
 
 	// Provider installation messages
-	InstallProvidersStart             MessageType = "provider_installation_start"
-	InstallStateStoreProviderStart    MessageType = "state_store_provider_installation_start"
-	LogReusingPreviousProviderVersion MessageType = "provider_query_use_previous_version"
-	LogFindingMatchingVersion         MessageType = "provider_query_use_constraints"
-	LogFindingLatestVersion           MessageType = "provider_query_use_latest"
+	InstallProvidersStart              MessageType = "provider_installation_start"
+	InstallStateStoreProviderStart     MessageType = "state_store_provider_installation_start"
+	LogReusingPreviousProviderVersion  MessageType = "provider_query_use_previous_version"
+	LogFindingMatchingVersion          MessageType = "provider_query_use_constraints"
+	LogFindingLatestVersion            MessageType = "provider_query_use_latest"
+	LogProviderVersionAlreadyInstalled MessageType = "provider_version_already_installed"
 
 	// Dependency lock file messages
 	// Uses provider-oriented language in case we add a module lock file in future.

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -69,4 +69,9 @@ const (
 	// LogReusingPreviousProviderVersion
 	logReusingPreviousProviderVersionHuman = "- Reusing version %s of %s from the dependency lock file"
 	logReusingPreviousProviderVersionJSON  = "%s: Reusing version %s from the dependency lock file"
+
+	// LogProviderVersionAlreadyInstalled
+	logProviderVersionAlreadyInstalledHuman = "- Using previously-installed %s v%s"
+	logProviderVersionAlreadyInstalledJSON  = "%s v%s: Using previously-installed provider version"
+
 )

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -77,4 +77,12 @@ const (
 	// LogUsingProviderVersionFromCacheDir
 	logUsingProviderVersionFromCacheDirHuman = "- Using %s v%s from the shared cache directory"
 	logUsingProviderVersionFromCacheDirJSON  = "%s v%s: Using from the shared cache directory"
+
+	// LogInstallProviderVersionStart
+	logInstallProviderVersionStartHuman = "- Installing %s v%s..."
+	logInstallProviderVersionStartJSON  = "Installing provider version: %s v%s..."
+
+	// LogInstallProviderVersionComplete
+	logInstallProviderVersionCompleteHuman = "- Installed %s v%s (%s%s)"
+	logInstallProviderVersionCompleteJSON  = "Installed provider version: %s v%s (%s%s)"
 )

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -74,4 +74,7 @@ const (
 	logProviderVersionAlreadyInstalledHuman = "- Using previously-installed %s v%s"
 	logProviderVersionAlreadyInstalledJSON  = "%s v%s: Using previously-installed provider version"
 
+	// LogUsingProviderVersionFromCacheDir
+	logUsingProviderVersionFromCacheDirHuman = "- Using %s v%s from the shared cache directory"
+	logUsingProviderVersionFromCacheDirJSON  = "%s v%s: Using from the shared cache directory"
 )

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -402,3 +402,12 @@ func (s *StateMigrateJSON) LogProviderVersionAlreadyInstalled(providerAddr addrs
 		"type", json.LogProviderVersionAlreadyInstalled,
 	)
 }
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogUsingProviderVersionFromCacheDir(providerAddr addrs.Provider, version getproviders.Version) {
+	msg := fmt.Sprintf(logUsingProviderVersionFromCacheDirJSON, providerAddr.ForDisplay(), version)
+	s.view.log.Info(
+		msg,
+		"type", json.LogUsingProviderVersionFromCacheDir,
+	)
+}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -411,3 +411,32 @@ func (s *StateMigrateJSON) LogUsingProviderVersionFromCacheDir(providerAddr addr
 		"type", json.LogUsingProviderVersionFromCacheDir,
 	)
 }
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogInstallProviderVersionStart(providerAddr addrs.Provider, version getproviders.Version) {
+	msg := fmt.Sprintf(logInstallProviderVersionStartJSON, providerAddr.ForDisplay(), version)
+	s.view.log.Info(
+		msg,
+		"type", json.LogInstallProviderVersionStart,
+	)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogInstallProviderVersionComplete(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult) {
+	keyDetails := "" // This is the version of the method used when no key details are available.
+	msg := fmt.Sprintf(logInstallProviderVersionCompleteJSON, providerAddr.ForDisplay(), version, auth, keyDetails)
+	s.view.log.Info(
+		msg,
+		"type", json.LogInstallProviderVersionComplete,
+	)
+}
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogInstallProviderVersionCompleteWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
+	keyDetails := fmt.Sprintf("key_id: %s", keyID) // key id needs to be formatted for JSON output
+	msg := fmt.Sprintf(logInstallProviderVersionCompleteJSON, providerAddr.ForDisplay(), version, auth, keyDetails)
+	s.view.log.Info(
+		msg,
+		"type", json.LogInstallProviderVersionComplete,
+	)
+}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -393,3 +393,12 @@ func (s *StateMigrateJSON) LogFindingMatchingVersion(providerAddr addrs.Provider
 		"type", json.LogFindingMatchingVersion,
 	)
 }
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogProviderVersionAlreadyInstalled(providerAddr addrs.Provider, version getproviders.Version) {
+	msg := fmt.Sprintf(logProviderVersionAlreadyInstalledJSON, providerAddr.ForDisplay(), version)
+	s.view.log.Info(
+		msg,
+		"type", json.LogProviderVersionAlreadyInstalled,
+	)
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -343,3 +343,27 @@ func TestNewStateMigrate_LogProviderVersionAlreadyInstalled_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogUsingProviderVersionFromCacheDir_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	version := getproviders.MustParseVersion("1.0.0")
+	smView.LogUsingProviderVersionFromCacheDir(p, version)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"hashicorp/test v1.0.0: Using from the shared cache directory"`,
+		`"@module":"terraform.ui"`,
+		`"type":"provider_version_found_in_cache_dir"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -319,3 +319,27 @@ func TestNewStateMigrate_LogFindingLatestVersion_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogProviderVersionAlreadyInstalled_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	version := getproviders.MustParseVersion("1.0.0")
+	smView.LogProviderVersionAlreadyInstalled(p, version)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"hashicorp/test v1.0.0: Using previously-installed provider version"`,
+		`"@module":"terraform.ui"`,
+		`"type":"provider_version_already_installed"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apparentlymart/go-versions/versions"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/getproviders"
@@ -360,6 +361,59 @@ func TestNewStateMigrate_LogUsingProviderVersionFromCacheDir_json(t *testing.T) 
 		`"@message":"hashicorp/test v1.0.0: Using from the shared cache directory"`,
 		`"@module":"terraform.ui"`,
 		`"type":"provider_version_found_in_cache_dir"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewStateMigrate_LogInstallProviderVersionComplete_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	v := versions.MustParseVersion("1.0.0")
+	officialProvider := 1
+	authResult := getproviders.NewPackageAuthenticationResult(officialProvider, "key-id-123")
+	smView.LogInstallProviderVersionComplete(p, v, authResult)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Installed provider version: hashicorp/test v1.0.0 (signed by HashiCorp)"`,
+		`"@module":"terraform.ui"`,
+		`"type":"provider_version_installation_complete"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewStateMigrate_LogInstallProviderVersionCompleteWithKeyID_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	v := versions.MustParseVersion("1.0.0")
+	partnerProvider := 2
+	keyID := "key-id-123"
+	authResult := getproviders.NewPackageAuthenticationResult(partnerProvider, keyID)
+	smView.LogInstallProviderVersionCompleteWithKeyID(p, v, authResult, keyID)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Installed provider version: hashicorp/test v1.0.0 (signed by a HashiCorp partnerkey_id: key-id-123)"`,
+		`"@module":"terraform.ui"`,
+		`"type":"provider_version_installation_complete"`,
 	}
 	for _, snippet := range expectedOutputFields {
 		if !strings.Contains(output.Stdout(), snippet) {


### PR DESCRIPTION
(Stacked PR, see GitHub stacks feature)

This PR implements these methods on the state migrate command's JSON view:

- LogProviderVersionAlreadyInstalled
- LogUsingProviderVersionFromCacheDir 
- LogInstallProviderVersionStart
- LogInstallProviderVersionComplete
- LogInstallProviderVersionCompleteWithKeyID

Just like in https://github.com/hashicorp/terraform/pull/39016, this PR creates new string const variables for the relevant message templates. These replace strings defined inside the `MessageRegistry` map, and enable methods to access template const directly or through the old approach of using a `prepareMessage` intermediate.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
