### PR TITLE
Adding provider installation methods to state migrate's JSON view - Part 3

### DIFF
--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -569,8 +569,8 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  logProviderVersionAlreadyInstalledJSON,
 	},
 	"built_in_provider_available_message": {
-		HumanValue: "- %s is built in to Terraform",
-		JSONValue:  "%s is built in to Terraform",
+		HumanValue: logBuiltInProviderAvailableHuman,
+		JSONValue:  logBuiltInProviderAvailableJSON,
 	},
 	"reusing_previous_version_info": {
 		HumanValue: logReusingPreviousProviderVersionHuman,

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -597,8 +597,8 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  logInstallProviderVersionCompleteJSON,
 	},
 	"partner_and_community_providers_message": {
-		HumanValue: partnerAndCommunityProvidersInfo,
-		JSONValue:  partnerAndCommunityProvidersInfo,
+		HumanValue: logPartnerAndCommunityProviders,
+		JSONValue:  logPartnerAndCommunityProviders,
 	},
 	"state_store_unset": {
 		HumanValue: "[reset][green]\n\nSuccessfully unset the state store %q. Terraform will now operate locally.",
@@ -772,10 +772,6 @@ see any changes that are required for your infrastructure.
 If you ever set or change modules or Terraform Settings, run "terraform init"
 again to reinitialize your working directory.
 `
-
-const partnerAndCommunityProvidersInfo = "\nPartner and community providers are signed by their developers.\n" +
-	"If you'd like to know more about provider signing, you can read about it here:\n" +
-	"https://developer.hashicorp.com/terraform/cli/plugins/signing"
 
 const backendConfiguredSuccessHuman = `[reset][green]
 Successfully configured the backend %q! Terraform will automatically

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -75,6 +75,7 @@ const (
 	LogUsingProviderVersionFromCacheDir MessageType = "provider_version_found_in_cache_dir"
 	LogInstallProviderVersionStart      MessageType = "provider_version_installation_start"
 	LogInstallProviderVersionComplete   MessageType = "provider_version_installation_complete"
+	BuiltInProviderAvailable            MessageType = "built_in_provider_available"
 
 	// Dependency lock file messages
 	// Uses provider-oriented language in case we add a module lock file in future.

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -76,6 +76,7 @@ const (
 	LogInstallProviderVersionStart      MessageType = "provider_version_installation_start"
 	LogInstallProviderVersionComplete   MessageType = "provider_version_installation_complete"
 	BuiltInProviderAvailable            MessageType = "built_in_provider_available"
+	LogPartnerAndCommunityProviders     MessageType = "third_party_providers_installed"
 
 	// Dependency lock file messages
 	// Uses provider-oriented language in case we add a module lock file in future.

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -89,4 +89,9 @@ const (
 	// LogInstallProviderVersionComplete
 	logInstallProviderVersionCompleteHuman = "- Installed %s v%s (%s%s)"
 	logInstallProviderVersionCompleteJSON  = "Installed provider version: %s v%s (%s%s)"
+
+	// LogPartnerAndCommunityProviders
+	logPartnerAndCommunityProviders = "Partner and community providers are signed by their developers.\n" +
+		"If you'd like to know more about provider signing, you can read about it here:\n" +
+		"https://developer.hashicorp.com/terraform/cli/plugins/signing"
 )

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -13,8 +13,6 @@ import (
 //
 // The `Output` method is a constraint from the Init view interface, which will be refactored away soon.
 type ProviderInstallationLogger interface {
-	Output(messageCode InitMessageCode, params ...any)
-
 	// LogInstallProviderVersionComplete describes a successfully installed provider along with its version
 	LogInstallProviderVersionComplete(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult)
 
@@ -47,8 +45,6 @@ type ProviderInstallationLogger interface {
 
 	// LogInstallStateStoreProviderStart indicates progress during installation provider(s)
 	LogInstallProvidersStart()
-
-	prepareMessage(messageCode InitMessageCode, params ...any) string
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines
 }

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -58,6 +58,10 @@ const (
 	logInstallProvidersStartMessageHuman = "[reset][bold]Installing providers..."
 	logInstallProvidersStartMessageJSON  = "Installing providers..."
 
+	// LogBuiltInProviderAvailable
+	logBuiltInProviderAvailableHuman = "- %s is built in to Terraform"
+	logBuiltInProviderAvailableJSON  = "%s is built in to Terraform"
+
 	// LogFindingLatestVersion
 	logFindingLatestVersionHuman = "- Finding latest version of %s..."
 	logFindingLatestVersionJSON  = "%s: Finding latest version..."

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -91,6 +91,7 @@ func NewStateMigrate(viewType arguments.ViewType, view *View) StateMigrate {
 var (
 	_ StateMigrate                  = (*StateMigrateHuman)(nil)
 	_ ProviderInstallationLogger    = (*StateMigrateHuman)(nil)
+	_ ProviderLockingLogger         = (*StateMigrateHuman)(nil)
 	_ StateStoreProviderTrustLogger = (*StateMigrateHuman)(nil)
 	_ Spacer                        = (*StateMigrateHuman)(nil)
 )
@@ -307,6 +308,7 @@ type StateMigrateJSON struct {
 }
 
 var (
+	_ ProviderInstallationLogger    = (*StateMigrateJSON)(nil)
 	_ ProviderLockingLogger         = (*StateMigrateJSON)(nil)
 	_ StateStoreProviderTrustLogger = (*StateMigrateJSON)(nil)
 	_ Spacer                        = (*StateMigrateJSON)(nil)

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -449,3 +449,11 @@ func (s *StateMigrateJSON) LogInstallProviderVersionCompleteWithKeyID(providerAd
 		"type", json.LogInstallProviderVersionComplete,
 	)
 }
+
+// Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogPartnerAndCommunityProviders() {
+	s.view.log.Info(
+		logPartnerAndCommunityProviders,
+		"type", json.LogPartnerAndCommunityProviders,
+	)
+}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -368,6 +368,15 @@ func (s *StateMigrateJSON) LogInstallProvidersStart() {
 }
 
 // Implements ProviderInstallationLogger interface.
+func (s *StateMigrateJSON) LogBuiltInProviderAvailable(providerAddr addrs.Provider) {
+	msg := fmt.Sprintf(logBuiltInProviderAvailableJSON, providerAddr.ForDisplay())
+	s.view.log.Info(
+		msg,
+		"type", json.BuiltInProviderAvailable,
+	)
+}
+
+// Implements ProviderInstallationLogger interface.
 func (s *StateMigrateJSON) LogReusingPreviousProviderVersion(providerAddr addrs.Provider, version getproviders.Version) {
 	msg := fmt.Sprintf(logReusingPreviousProviderVersionJSON, providerAddr.ForDisplay(), version)
 	s.view.log.Info(

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -444,3 +444,25 @@ func TestNewStateMigrate_LogBuiltInProviderAvailable_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogPartnerAndCommunityProviders_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogPartnerAndCommunityProviders()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Partner and community providers are`, // incomplete but sufficient for asserting message
+		`"@module":"terraform.ui"`,
+		`"type":"third_party_providers_installed"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -421,3 +421,26 @@ func TestNewStateMigrate_LogInstallProviderVersionCompleteWithKeyID_json(t *test
 		}
 	}
 }
+
+func TestNewStateMigrate_LogBuiltInProviderAvailable_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	p := addrs.MustParseProviderSourceString("hashicorp/test")
+	smView.LogBuiltInProviderAvailable(p)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"hashicorp/test is built in to Terraform"`,
+		`"@module":"terraform.ui"`,
+		`"type":"built_in_provider_available"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}


### PR DESCRIPTION
(Stacked PR, see GitHub stacks feature)

This PR completes implementing the `ProviderInstallationLogger` interface in the `state migrate` command's JSON view. This was achieved by:

Adding 2 remaining methods to the `StateMigrateJSON` struct:
* `LogBuiltInProviderAvailable`
* `LogPartnerAndCommunityProviders`

Removing 2 methods from the `ProviderInstallationLogger` interface that have become specific to the `init` command and are no longer needed in the `ProviderInstallationLogger` interface:
* `Output`
* `prepareMessage`  


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
