### PR TITLE
Adding state migrate-specific methods to state migrate's JSON view - Part 1

### DIFF
--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -343,7 +343,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	view.LogStateMigrationComplete()
+	view.LogStateMigrationComplete(source, destination)
 
 	// After a successful migration to a state store, we must make sure the dependency lock file contains the
 	// details of the destination state store provider.

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -87,4 +87,7 @@ const (
 	ProviderInteractiveApproval  MessageType = "provider_interactive_approval"
 	ProviderInteractiveRejection MessageType = "provider_interactive_rejection"
 	ProviderAutomaticApproval    MessageType = "provider_automatic_approval"
+
+	// State migration-related messages
+	LogStateMigrationStart     MessageType = "migration_start"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -91,4 +91,5 @@ const (
 	// State migration-related messages
 	LogStateMigrationStart     MessageType = "migration_start"
 	LogStateMigrationComplete  MessageType = "migration_complete"
+	LogStateMigrationFinalized MessageType = "migration_finalized"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -91,5 +91,6 @@ const (
 	// State migration-related messages
 	LogStateMigrationStart     MessageType = "migration_start"
 	LogStateMigrationComplete  MessageType = "migration_complete"
+	LogStateMigrationErrored   MessageType = "migration_errored"
 	LogStateMigrationFinalized MessageType = "migration_finalized"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -90,4 +90,5 @@ const (
 
 	// State migration-related messages
 	LogStateMigrationStart     MessageType = "migration_start"
+	LogStateMigrationComplete  MessageType = "migration_complete"
 )

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -15,10 +15,11 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// Message text used in human output.
+// Message text used in human or machine-readable outputs.
 const (
 	// Notify the user that any preparation steps are over and the migration is starting.
-	StateMigrationStartMessage = "[reset][bold]Migrating state from %s to %s...[reset]"
+	logStateMigrationStartHuman = "[reset][bold]Migrating state from %s to %s...[reset]"
+	logStateMigrationStartJSON  = "Migrating state from %s to %s..."
 
 	// Notify the user that everything has finished successfully; migration and lockfile+backend state file updates.
 	StateMigrationFinalizedMessage = "[reset][bold]Finished migrating state from %s to %s.[reset]"
@@ -105,7 +106,7 @@ func (s *StateMigrateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 }
 
 func (s *StateMigrateHuman) LogStateMigrationStart(source string, destination string) {
-	msg := fmt.Sprintf(StateMigrationStartMessage, source, destination)
+	msg := fmt.Sprintf(logStateMigrationStartHuman, source, destination)
 	s.log(msg)
 }
 
@@ -317,6 +318,14 @@ var (
 // Implements Spacer
 func (s *StateMigrateJSON) Spacer() {
 	// no-op for JSON output, since we don't want to log empty messages in JSON
+}
+
+func (s *StateMigrateJSON) LogStateMigrationStart(source string, destination string) {
+	msg := fmt.Sprintf(logStateMigrationStartJSON, source, destination)
+	s.view.log.Info(
+		msg,
+		"type", json.LogStateMigrationStart,
+	)
 }
 
 // Implements StateStoreProviderTrustLogger interface.

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -21,6 +21,9 @@ const (
 	logStateMigrationStartHuman = "[reset][bold]Migrating state from %s to %s...[reset]"
 	logStateMigrationStartJSON  = "Migrating state from %s to %s..."
 
+	// JSON-only - log when Terraform has copied state from source to destination
+	logStateMigrationCompleteJSON = "The migration process has copied state from the source %s to the destination %s"
+
 	// Notify the user that everything has finished successfully; migration and lockfile+backend state file updates.
 	StateMigrationFinalizedMessage = "[reset][bold]Finished migrating state from %s to %s.[reset]"
 
@@ -63,7 +66,7 @@ type StateMigrate interface {
 	Diagnostics(diags tfdiags.Diagnostics)
 
 	LogStateMigrationStart(source, destination string)
-	LogStateMigrationComplete()
+	LogStateMigrationComplete(source string, destination string)
 	LogStateMigrationErrored(failMode stateMigrationFailureMode, source, destination string)
 	LogStateMigrationFinalized(source, destination string)
 
@@ -110,7 +113,7 @@ func (s *StateMigrateHuman) LogStateMigrationStart(source string, destination st
 	s.log(msg)
 }
 
-func (s *StateMigrateHuman) LogStateMigrationComplete() {
+func (s *StateMigrateHuman) LogStateMigrationComplete(_, _ string) {
 	// no-op in human view
 }
 
@@ -325,6 +328,14 @@ func (s *StateMigrateJSON) LogStateMigrationStart(source string, destination str
 	s.view.log.Info(
 		msg,
 		"type", json.LogStateMigrationStart,
+	)
+}
+
+func (s *StateMigrateJSON) LogStateMigrationComplete(source string, destination string) {
+	msg := fmt.Sprintf(logStateMigrationCompleteJSON, source, destination)
+	s.view.log.Info(
+		msg,
+		"type", json.LogStateMigrationComplete,
 	)
 }
 

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -22,7 +22,7 @@ const (
 	logStateMigrationStartJSON  = "Migrating state from %s to %s..."
 
 	// JSON-only - log when Terraform has copied state from source to destination
-	logStateMigrationCompleteJSON = "The migration process has copied state from the source %s to the destination %s"
+	logStateMigrationCompleteJSON = "The migration process has copied state from the %s to the %s"
 
 	// Notify the user that everything has finished successfully; migration and lockfile+backend state file updates.
 	logStateMigrationFinalizedHuman = "[reset][bold]Finished migrating state from %s to %s.[reset]"

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -30,7 +30,7 @@ const (
 
 	// Notify the user that an error has occurred, but there have been changes to where state is stored.
 	// Hopefully the errors accompanying this message are actionable by users, but if not we expect a bug report.
-	StateMigrationPostStepsInterruptedMessage = `[reset][bold]Finished migrating state from %s to %s, but an error occurred before Terraform was finished.[reset]
+	logStateMigrationPostStepsInterruptedHuman = `[reset][bold]Finished migrating state from %s to %s, but an error occurred before Terraform was finished.[reset]
 
 Your state has been copied to the new destination, but Terraform was unable to perform final operations to enable future commands to use your migrated state. Either Terraform was unable to record the new provider used for the destination state store to your dependency lock file, or the backend state file was unable to be updated. Please check the errors message(s) above for more information.
 
@@ -38,10 +38,11 @@ The successful migration means you will have two copies of your state, both in t
 
 If you can address the errors you can retry this command safely. Otherwise, please report the issue to the Terraform team with the error messages and your configuration.
 `
+	logStateMigrationPostStepsInterruptedJSON = "Finished migrating state from %s to %s, but an error occurred that will prevent running other Terraform commands"
 
 	// Notify the user that the migration failed. This may be due to a misconfiguration, e.g. insufficient permissions to interact with a service.
 	// We expect these errors to either be actionable by users, or to originate from a state store provider (but reports shouldn't come to us unless due to a backend).
-	StateMigrationFailureMessage = `[reset][bold]Failed to migrate state from %s to %s.[reset]
+	logStateMigrationFailureHuman = `[reset][bold]Failed to migrate state from %s to %s.[reset]
 
 Something went wrong while migrating the state. Please check the errors message(s) above for more information.
 
@@ -49,6 +50,7 @@ The "terraform state migrate" command does not modify the source state, so you c
 
 Make sure you're supplying all the necessary attribute values for both the source and destination state stores. Remember, some values may need to be supplied via environment variables for either of the source or destination locations. If you continue to experience issues please report the issue to either the Terraform team when using a backend, or to the relevant provider development team when using a pluggable state store.
 `
+	logStateMigrationFailureJSON = "Failed to migrate state from %s to %s."
 )
 
 type stateMigrationFailureMode string
@@ -124,10 +126,10 @@ func (s *StateMigrateHuman) LogStateMigrationErrored(failMode stateMigrationFail
 	switch failMode {
 	case DuringMigration:
 		// migration itself failed
-		msg = fmt.Sprintf(StateMigrationFailureMessage, source, destination)
+		msg = fmt.Sprintf(logStateMigrationFailureHuman, source, destination)
 	case DuringLockfile, DuringWorkDirStateUpdate:
 		// migration succeeded by updates in the working directory failed
-		msg = fmt.Sprintf(StateMigrationPostStepsInterruptedMessage, source, destination)
+		msg = fmt.Sprintf(logStateMigrationPostStepsInterruptedHuman, source, destination)
 	default:
 		panic(fmt.Sprintf("(*StateMigrateHuman)LogStateMigrationErrored: called incorrectly with unknown failure mode : %q", failMode))
 	}
@@ -319,6 +321,7 @@ func (s *StateMigrateJSON) Spacer() {
 	// no-op for JSON output, since we don't want to log empty messages in JSON
 }
 
+// Implements StateMigrate
 func (s *StateMigrateJSON) LogStateMigrationStart(source string, destination string) {
 	msg := fmt.Sprintf(logStateMigrationStartJSON, source, destination)
 	s.view.log.Info(
@@ -327,6 +330,7 @@ func (s *StateMigrateJSON) LogStateMigrationStart(source string, destination str
 	)
 }
 
+// Implements StateMigrate
 func (s *StateMigrateJSON) LogStateMigrationComplete(source string, destination string) {
 	msg := fmt.Sprintf(logStateMigrationCompleteJSON, source, destination)
 	s.view.log.Info(
@@ -335,11 +339,35 @@ func (s *StateMigrateJSON) LogStateMigrationComplete(source string, destination 
 	)
 }
 
+// Implements StateMigrate
 func (s *StateMigrateJSON) LogStateMigrationFinalized(source string, destination string) {
 	msg := fmt.Sprintf(logStateMigrationFinalizedJSON, source, destination)
 	s.view.log.Info(
 		msg,
 		"type", json.LogStateMigrationFinalized,
+	)
+}
+
+// Implements StateMigrate
+func (s *StateMigrateJSON) LogStateMigrationErrored(failMode stateMigrationFailureMode, source, destination string) {
+	// The JSON object describes slightly different failures that led to an error.
+	// So different messages are be logged depending which happened.
+	var msg string
+	switch failMode {
+	case DuringMigration:
+		// migration itself failed
+		msg = fmt.Sprintf(logStateMigrationFailureJSON, source, destination)
+	case DuringLockfile, DuringWorkDirStateUpdate:
+		// migration succeeded by updates in the working directory failed
+		msg = fmt.Sprintf(logStateMigrationPostStepsInterruptedJSON, source, destination)
+	default:
+		panic(fmt.Sprintf("(*StateMigrateHuman)LogStateMigrationErrored: called incorrectly with unknown failure mode : %q", failMode))
+	}
+
+	s.view.log.Info(
+		msg,
+		"type", json.LogStateMigrationErrored,
+		"failure_mode", failMode,
 	)
 }
 

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -62,7 +62,6 @@ const (
 )
 
 type StateMigrate interface {
-	Log(message string, params ...any)
 	Diagnostics(diags tfdiags.Diagnostics)
 
 	LogStateMigrationStart(source, destination string)
@@ -176,7 +175,7 @@ func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
 	if !ok {
 		panic("missing message for InstallingProviderMessage init message code")
 	}
-	s.Log(msg.HumanValue, params...)
+	s.log(fmt.Sprintf(msg.HumanValue, params...))
 }
 
 // Implements ProviderInstallationLogger interface.

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -25,7 +25,8 @@ const (
 	logStateMigrationCompleteJSON = "The migration process has copied state from the source %s to the destination %s"
 
 	// Notify the user that everything has finished successfully; migration and lockfile+backend state file updates.
-	StateMigrationFinalizedMessage = "[reset][bold]Finished migrating state from %s to %s.[reset]"
+	logStateMigrationFinalizedHuman = "[reset][bold]Finished migrating state from %s to %s.[reset]"
+	logStateMigrationFinalizedJSON  = "Finished migrating state from %s to %s."
 
 	// Notify the user that an error has occurred, but there have been changes to where state is stored.
 	// Hopefully the errors accompanying this message are actionable by users, but if not we expect a bug report.
@@ -151,12 +152,8 @@ func (s *StateMigrateHuman) LogMigrationDestinationInitializationComplete() {
 }
 
 func (s *StateMigrateHuman) LogStateMigrationFinalized(source string, destination string) {
-	msg := fmt.Sprintf(StateMigrationFinalizedMessage, source, destination)
+	msg := fmt.Sprintf(logStateMigrationFinalizedHuman, source, destination)
 	s.log(msg)
-}
-
-func (s *StateMigrateHuman) Log(message string, params ...any) {
-	s.log(fmt.Sprintf(message, params...))
 }
 
 func (s *StateMigrateHuman) log(preparedMessage string) {
@@ -335,6 +332,14 @@ func (s *StateMigrateJSON) LogStateMigrationComplete(source string, destination 
 	s.view.log.Info(
 		msg,
 		"type", json.LogStateMigrationComplete,
+	)
+}
+
+func (s *StateMigrateJSON) LogStateMigrationFinalized(source string, destination string) {
+	msg := fmt.Sprintf(logStateMigrationFinalizedJSON, source, destination)
+	s.view.log.Info(
+		msg,
+		"type", json.LogStateMigrationFinalized,
 	)
 }
 

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -490,3 +490,27 @@ func TestNewStateMigrate_LogStateMigrationStart_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogStateMigrationComplete_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	source := "backend \"s3\""
+	destination := "state store \"test_store\""
+	smView.LogStateMigrationComplete(source, destination)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"The migration process has copied state from the source backend \"s3\" to the destination state store \"test_store\""`,
+		`"@module":"terraform.ui"`,
+		`"type":"migration_complete"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -466,3 +466,27 @@ func TestNewStateMigrate_LogPartnerAndCommunityProviders_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogStateMigrationStart_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	source := "backend \"s3\""
+	destination := "state store \"test_store\""
+	smView.LogStateMigrationStart(source, destination)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Migrating state from backend \"s3\" to state store \"test_store\"..."`,
+		`"@module":"terraform.ui"`,
+		`"type":"migration_start"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -538,3 +538,78 @@ func TestNewStateMigrate_LogStateMigrationFinalized_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogStateMigrationErrored_json(t *testing.T) {
+	t.Run("migration itself fails", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := StateMigrateJSON{view: NewJSONView(view)}
+
+		source := "backend \"s3\""
+		destination := "state store \"test_store\""
+		smView.LogStateMigrationErrored(DuringMigration, source, destination)
+
+		// Assert output
+		output := done(t)
+		expectedOutputFields := []string{
+			`"@level":"info"`,
+			`"@message":"Failed to migrate state from backend \"s3\" to state store \"test_store\"."`,
+			`"@module":"terraform.ui"`,
+			`"failure_mode":"error_during_migration"`,
+			`"type":"migration_errored"`,
+		}
+		for _, snippet := range expectedOutputFields {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
+
+	t.Run("provider lockfile update fails", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := StateMigrateJSON{view: NewJSONView(view)}
+
+		source := "backend \"s3\""
+		destination := "state store \"test_store\""
+		smView.LogStateMigrationErrored(DuringLockfile, source, destination)
+
+		// Assert output
+		output := done(t)
+		expectedOutputFields := []string{
+			`"@level":"info"`,
+			`"@message":"Finished migrating state from backend \"s3\" to state store \"test_store\", but an error occurred that will prevent running other Terraform commands"`,
+			`"failure_mode":"error_updating_provider_lockfile"`,
+			`"type":"migration_errored"`,
+		}
+		for _, snippet := range expectedOutputFields {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
+
+	t.Run("backend state file update fails", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+		view := NewView(streams)
+		smView := StateMigrateJSON{view: NewJSONView(view)}
+
+		source := "backend \"s3\""
+		destination := "state store \"test_store\""
+		smView.LogStateMigrationErrored(DuringWorkDirStateUpdate, source, destination)
+
+		// Assert output
+		output := done(t)
+		expectedOutputFields := []string{
+			`"@level":"info"`,
+			`"@message":"Finished migrating state from backend \"s3\" to state store \"test_store\", but an error occurred that will prevent running other Terraform commands"`,
+			`"failure_mode":"error_updating_workdir_state"`,
+			`"type":"migration_errored"`,
+		}
+		for _, snippet := range expectedOutputFields {
+			if !strings.Contains(output.Stdout(), snippet) {
+				t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+			}
+		}
+	})
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -514,3 +514,27 @@ func TestNewStateMigrate_LogStateMigrationComplete_json(t *testing.T) {
 		}
 	}
 }
+
+func TestNewStateMigrate_LogStateMigrationFinalized_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	source := "backend \"s3\""
+	destination := "state store \"test_store\""
+	smView.LogStateMigrationFinalized(source, destination)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Finished migrating state from backend \"s3\" to state store \"test_store\"."`,
+		`"@module":"terraform.ui"`,
+		`"type":"migration_finalized"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -504,7 +504,7 @@ func TestNewStateMigrate_LogStateMigrationComplete_json(t *testing.T) {
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`"@message":"The migration process has copied state from the source backend \"s3\" to the destination state store \"test_store\""`,
+		`"@message":"The migration process has copied state from the backend \"s3\" to the state store \"test_store\""`,
 		`"@module":"terraform.ui"`,
 		`"type":"migration_complete"`,
 	}


### PR DESCRIPTION
(Stacked PR, see GitHub stacks feature)

This PR implements 4 methods on `state migrate`'s JSON view implementation:

* LogStateMigrationStart 
* LogStateMigrationComplete
* LogStateMigrationErrored
* LogStateMigrationFinalized

This is the start of implementing the methods that are specific to the `StateMigrate` interface, but not the end.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
