### PR TITLE
Adding state migrate-specific methods to state migrate's JSON view - Part 2

### DIFF
--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -89,8 +89,12 @@ const (
 	ProviderAutomaticApproval    MessageType = "provider_automatic_approval"
 
 	// State migration-related messages
-	LogStateMigrationStart     MessageType = "migration_start"
-	LogStateMigrationComplete  MessageType = "migration_complete"
-	LogStateMigrationErrored   MessageType = "migration_errored"
-	LogStateMigrationFinalized MessageType = "migration_finalized"
+	LogStateMigrationStart                        MessageType = "migration_start"
+	LogStateMigrationComplete                     MessageType = "migration_complete"
+	LogStateMigrationErrored                      MessageType = "migration_errored"
+	LogStateMigrationFinalized                    MessageType = "migration_finalized"
+	LogMigrationSourceInitializationStart         MessageType = "migration_source_initialization_start"
+	LogMigrationSourceInitializationComplete      MessageType = "migration_source_initialization_complete"
+	LogMigrationDestinationInitializationStart    MessageType = "migration_destination_initialization_start"
+	LogMigrationDestinationInitializationComplete MessageType = "migration_destination_initialization_complete"
 )

--- a/internal/command/views/provider_installation_logger.go
+++ b/internal/command/views/provider_installation_logger.go
@@ -43,7 +43,7 @@ type ProviderInstallationLogger interface {
 	// Log that a provider successfully fetched in this operation is maintained by third-parties and describe how these are signed
 	LogPartnerAndCommunityProviders()
 
-	// LogInstallStateStoreProviderStart indicates progress during installation provider(s)
+	// LogInstallProvidersStart indicates progress during installation provider(s)
 	LogInstallProvidersStart()
 
 	Spacer // output from provider installation is spaced out from following human-readable output log lines

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -317,11 +317,16 @@ type StateMigrateJSON struct {
 }
 
 var (
+	_ StateMigrate                  = (*StateMigrateJSON)(nil)
 	_ ProviderInstallationLogger    = (*StateMigrateJSON)(nil)
 	_ ProviderLockingLogger         = (*StateMigrateJSON)(nil)
 	_ StateStoreProviderTrustLogger = (*StateMigrateJSON)(nil)
 	_ Spacer                        = (*StateMigrateJSON)(nil)
 )
+
+func (s *StateMigrateJSON) Diagnostics(diags tfdiags.Diagnostics) {
+	s.view.Diagnostics(diags)
+}
 
 // Implements Spacer
 func (s *StateMigrateJSON) Spacer() {

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -17,6 +17,13 @@ import (
 
 // Message text used in human or machine-readable outputs.
 const (
+
+	// JSON only - log the start and end of initializing the source and destination for the migration
+	logMigrationSourceInitializationStartJSON         = "Initializing source..."
+	logMigrationSourceInitializationCompleteJSON      = "Initialized source."
+	logMigrationDestinationInitializationStartJSON    = "Initializing destination..."
+	logMigrationDestinationInitializationCompleteJSON = "Initialized destination."
+
 	// Notify the user that any preparation steps are over and the migration is starting.
 	logStateMigrationStartHuman = "[reset][bold]Migrating state from %s to %s...[reset]"
 	logStateMigrationStartJSON  = "Migrating state from %s to %s..."
@@ -509,5 +516,33 @@ func (s *StateMigrateJSON) LogPartnerAndCommunityProviders() {
 	s.view.log.Info(
 		logPartnerAndCommunityProviders,
 		"type", json.LogPartnerAndCommunityProviders,
+	)
+}
+
+func (s *StateMigrateJSON) LogMigrationSourceInitializationStart() {
+	s.view.log.Info(
+		logMigrationSourceInitializationStartJSON,
+		"type", json.LogMigrationSourceInitializationStart,
+	)
+}
+
+func (s *StateMigrateJSON) LogMigrationSourceInitializationComplete() {
+	s.view.log.Info(
+		logMigrationSourceInitializationCompleteJSON,
+		"type", json.LogMigrationSourceInitializationComplete,
+	)
+}
+
+func (s *StateMigrateJSON) LogMigrationDestinationInitializationStart() {
+	s.view.log.Info(
+		logMigrationDestinationInitializationStartJSON,
+		"type", json.LogMigrationDestinationInitializationStart,
+	)
+}
+
+func (s *StateMigrateJSON) LogMigrationDestinationInitializationComplete() {
+	s.view.log.Info(
+		logMigrationDestinationInitializationCompleteJSON,
+		"type", json.LogMigrationDestinationInitializationComplete,
 	)
 }

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -613,3 +613,91 @@ func TestNewStateMigrate_LogStateMigrationErrored_json(t *testing.T) {
 		}
 	})
 }
+
+func TestNewStateMigrate_LogMigrationSourceInitializationStart_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogMigrationSourceInitializationStart()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Initializing source..."`,
+		`"@module":"terraform.ui"`,
+		`"type":"migration_source_initialization_start"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewStateMigrate_LogMigrationSourceInitializationComplete_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogMigrationSourceInitializationComplete()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Initialized source."`,
+		`"@module":"terraform.ui"`,
+		`"type":"migration_source_initialization_complete"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewStateMigrate_LogMigrationDestinationInitializationStart_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogMigrationDestinationInitializationStart()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Initializing destination..."`,
+		`"@module":"terraform.ui"`,
+		`"type":"migration_destination_initialization_start"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewStateMigrate_LogMigrationDestinationInitializationComplete_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	smView := StateMigrateJSON{view: NewJSONView(view)}
+
+	smView.LogMigrationDestinationInitializationComplete()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Initialized destination."`,
+		`"@module":"terraform.ui"`,
+		`"type":"migration_destination_initialization_complete"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}


### PR DESCRIPTION
(Stacked PR, see GitHub stacks feature)

This PR implements the final methods from the `StateMigrate` interface on `state migrate`'s JSON view implementation:

* LogMigrationSourceInitializationStart 
* LogMigrationSourceInitializationComplete
* LogMigrationDestinationInitializationStart
* LogMigrationDestinationInitializationComplete
* Diagnostics

**This is the end of implementing the JSON view for `state migrate`!! 🎉 🎉 🎉** 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
