### PR TITLE
Prevent tolerant vertices from halting the graph

### DIFF
--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -37,6 +37,15 @@ func (s testNamedString) Name() string {
 	return string(s)
 }
 
+func (v testNamedString) OnErroredDependencies(deps ...Vertex) DependencyResult {
+	for _, dep := range deps {
+		if dep.Name() == "error" {
+			return DependencyResultSoftFailure
+		}
+	}
+	return DependencyResultHardFailure
+}
+
 func TestAyclicGraphTransReduction(t *testing.T) {
 	var g AcyclicGraph
 	g.Add(testV(1))

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -37,14 +37,13 @@ func (s testNamedString) Name() string {
 	return string(s)
 }
 
-func (v testNamedString) OnErroredDependencies(deps ...Vertex) DependencyResult {
-	for _, dep := range deps {
-		if dep.Name() == "error" {
-			return DependencyResultSoftFailure
-		}
-	}
-	return DependencyResultHardFailure
+type testAlwaysRunVertex string
+
+func (v testAlwaysRunVertex) Name() string {
+	return string(v)
 }
+
+func (v testAlwaysRunVertex) AlwaysRun() {}
 
 func TestAyclicGraphTransReduction(t *testing.T) {
 	var g AcyclicGraph

--- a/internal/dag/graph.go
+++ b/internal/dag/graph.go
@@ -31,7 +31,7 @@ type TolerantVertex interface {
 
 	// AllowUpstreamFailure returns true if the receiver vertex can tolerate a
 	// failure in the given vertex.
-	AllowUpstreamFailure(Vertex) bool
+	AllowUpstreamFailure() bool
 }
 
 func (g *Graph) VertexCount() int {

--- a/internal/dag/graph.go
+++ b/internal/dag/graph.go
@@ -24,14 +24,15 @@ type Vertex interface {
 	Name() string
 }
 
-// TolerantVertex is an optional interface that can be implemented by Vertex
-// to allow it to tolerate upstream failures.
-type TolerantVertex interface {
+// ErroredDependencyHandler is implemented by vertices that want to
+// determine their own DependencyResult when one or more of their
+// dependencies have failed, rather than defaulting to a hard failure.
+type ErroredDependencyHandler interface {
 	Vertex
 
-	// AllowUpstreamFailure returns true if the receiver vertex can tolerate a
-	// failure in the given vertex.
-	AllowUpstreamFailure() bool
+	// OnErroredDependencies is called with the set of dependency vertices
+	// that produced errors.
+	OnErroredDependencies(...Vertex) DependencyResult
 }
 
 func (g *Graph) VertexCount() int {

--- a/internal/dag/graph.go
+++ b/internal/dag/graph.go
@@ -24,15 +24,14 @@ type Vertex interface {
 	Name() string
 }
 
-// ErroredDependencyHandler is implemented by vertices that want to
-// determine their own DependencyResult when one or more of their
-// dependencies have failed, rather than defaulting to a hard failure.
-type ErroredDependencyHandler interface {
+// AlwaysRunVertex is implemented by vertices that should be evaluated
+// even when one or more of their dependencies have failed.
+type AlwaysRunVertex interface {
 	Vertex
 
-	// OnErroredDependencies is called with the set of dependency vertices
-	// that produced errors.
-	OnErroredDependencies(...Vertex) DependencyResult
+	// AlwaysRun marks the vertex as always-run,
+	// even when one or more dependencies have failed.
+	AlwaysRun()
 }
 
 func (g *Graph) VertexCount() int {

--- a/internal/dag/walk.go
+++ b/internal/dag/walk.go
@@ -51,21 +51,6 @@ type Walker struct {
 	diagsLock      sync.Mutex
 }
 
-// DependencyResult indicates if a dependency check resulted in success, failure, or tolerance.
-type DependencyResult string
-
-const (
-	// DependencyResultSuccess indicates that all dependencies were satisfied.
-	DependencyResultSuccess DependencyResult = "success"
-
-	// DependencyResultHardFailure indicates that one or more dependencies were not satisfied.
-	DependencyResultHardFailure DependencyResult = "hard-failure"
-
-	// DependencyResultSoftFailure indicates that there exists a dependency that could not be satisfied,
-	// but the current vertex should still be evaluated.
-	DependencyResultSoftFailure DependencyResult = "soft-failure"
-)
-
 // NewWalker creates a new walker with the given callback function.
 func NewWalker(cb walkFunc, opts ...func(*Walker)) *Walker {
 	w := &Walker{
@@ -101,7 +86,7 @@ type walkerVertex struct {
 	// dependencies are complete. No other values will ever be sent again.
 	//
 	// DepsUpdateCh is closed when there is a new DepsCh set.
-	DepsCh chan DependencyResult
+	DepsCh chan bool
 
 	// Below is not safe to read/write in parallel. This behavior is
 	// enforced by changes only happening in Update. Nothing else should
@@ -178,7 +163,7 @@ func (w *Walker) Walk(g *AcyclicGraph) tfdiags.Diagnostics {
 		}
 
 		// Create a new done channel
-		doneCh := make(chan DependencyResult, 1)
+		doneCh := make(chan bool, 1)
 
 		// Create the channel we close for cancellation
 		cancelCh := make(chan struct{})
@@ -236,12 +221,12 @@ func (w *Walker) walkVertex(v Vertex, info *walkerVertex) {
 
 	// Wait for our dependencies. We create a [closed] deps channel so
 	// that we can immediately fall through to load our actual DepsCh.
-	var depsSuccess DependencyResult
+	var depsSuccess bool
 
 	// if there are no deps we have a nil chan, so we need to initialize
 	// something that won't block
-	depsCh := make(chan DependencyResult, 1)
-	depsCh <- DependencyResultSuccess
+	depsCh := make(chan bool, 1)
+	depsCh <- true
 	close(depsCh)
 
 	if info.DepsCh != nil {
@@ -269,16 +254,9 @@ func (w *Walker) walkVertex(v Vertex, info *walkerVertex) {
 	// Run our callback or note that our upstream failed
 	var diags tfdiags.Diagnostics
 	var upstreamFailed bool
-	// We go through a three-way boolean logic here to handle the three possible
-	// dependency results: success, soft failure, and hard failure.
-
-	// We run the callback if the result is success or soft failure.
-	if depsSuccess == DependencyResultSuccess || depsSuccess == DependencyResultSoftFailure {
+	if depsSuccess {
 		diags = w.Callback(v)
-	}
-
-	// We note that our upstream failed if the result is hard failure or soft failure.
-	if depsSuccess == DependencyResultHardFailure || depsSuccess == DependencyResultSoftFailure {
+	} else {
 		log.Printf("[TRACE] dag/walk: upstream of %q errored, so skipping", v.Name())
 		// This won't be displayed to the user because we'll set upstreamFailed,
 		// but we need to ensure there's at least one error in here so that
@@ -306,7 +284,7 @@ func (w *Walker) walkVertex(v Vertex, info *walkerVertex) {
 func (w *Walker) waitDeps(
 	v Vertex,
 	deps map[Vertex]<-chan struct{},
-	doneCh chan<- DependencyResult,
+	doneCh chan<- bool,
 	cancelCh <-chan struct{}) {
 
 	// For each dependency given to us, wait for it to complete
@@ -321,7 +299,7 @@ func (w *Walker) waitDeps(
 			case <-cancelCh:
 				// Wait cancelled. Note that we didn't satisfy dependencies
 				// so that anything waiting on us also doesn't run.
-				doneCh <- DependencyResultHardFailure
+				doneCh <- false
 				return
 
 			case <-time.After(time.Second * 5):
@@ -331,31 +309,24 @@ func (w *Walker) waitDeps(
 		}
 	}
 
+	// If the vertex implements [AlwaysRunVertex], then
+	// return ignore the errored dependecies and return success.
+	if _, ok := v.(AlwaysRunVertex); ok {
+		doneCh <- true
+		return
+	}
+
 	// Dependencies satisfied! We need to check if any errored
 	w.diagsLock.Lock()
 	defer w.diagsLock.Unlock()
-
-	erroredDeps := make([]Vertex, 0)
 	for dep := range deps {
 		if w.diagsMap[dep].HasErrors() {
-			erroredDeps = append(erroredDeps, dep)
+			// One of our dependencies failed, so return false
+			doneCh <- false
+			return
 		}
 	}
 
 	// All dependencies satisfied and successful
-	if len(erroredDeps) == 0 {
-		doneCh <- DependencyResultSuccess
-		return
-	}
-
-	// If the vertex implements [ErroredDependencyHandler], then
-	// give it a chance to handle its own dependency errors.
-	if fv, ok := v.(ErroredDependencyHandler); ok {
-		doneCh <- fv.OnErroredDependencies(erroredDeps...)
-		return
-	}
-
-	// One of our dependencies failed, so return a hard failure result
-	doneCh <- DependencyResultHardFailure
-
+	doneCh <- true
 }

--- a/internal/dag/walk.go
+++ b/internal/dag/walk.go
@@ -240,7 +240,7 @@ func (w *Walker) walkVertex(v Vertex, info *walkerVertex) {
 
 	// if there are no deps we have a nil chan, so we need to initialize
 	// something that won't block
-	depsCh := make(chan DependencyResult, 1) //make(chan DependencyResult, 1)
+	depsCh := make(chan DependencyResult, 1)
 	depsCh <- DependencyResultSuccess
 	close(depsCh)
 
@@ -335,30 +335,27 @@ func (w *Walker) waitDeps(
 	w.diagsLock.Lock()
 	defer w.diagsLock.Unlock()
 
-	var allowUpstreamFailure bool
+	erroredDeps := make([]Vertex, 0)
 	for dep := range deps {
 		if w.diagsMap[dep].HasErrors() {
-
-			// If the vertex allows upstream failures, we can tolerate this error
-			if fv, ok := v.(TolerantVertex); ok && fv.AllowUpstreamFailure() {
-				allowUpstreamFailure = true
-				continue
-			}
-
-			// One of our dependencies failed, so return a hard failure result
-			doneCh <- DependencyResultHardFailure
-			return
+			erroredDeps = append(erroredDeps, dep)
 		}
 	}
 
-	// If we have an error but the node can tolerate failures, return a soft failure result
-	// This allows us to treat such vertices specially, while still maintaining the flow
-	// of errors to dependencies further down the DAG.
-	if allowUpstreamFailure {
-		doneCh <- DependencyResultSoftFailure
+	// All dependencies satisfied and successful
+	if len(erroredDeps) == 0 {
+		doneCh <- DependencyResultSuccess
 		return
 	}
 
-	// All dependencies satisfied and successful
-	doneCh <- DependencyResultSuccess
+	// If the vertex implements [ErroredDependencyHandler], then
+	// give it a chance to handle its own dependency errors.
+	if fv, ok := v.(ErroredDependencyHandler); ok {
+		doneCh <- fv.OnErroredDependencies(erroredDeps...)
+		return
+	}
+
+	// One of our dependencies failed, so return a hard failure result
+	doneCh <- DependencyResultHardFailure
+
 }

--- a/internal/dag/walk.go
+++ b/internal/dag/walk.go
@@ -340,7 +340,7 @@ func (w *Walker) waitDeps(
 		if w.diagsMap[dep].HasErrors() {
 
 			// If the vertex allows upstream failures, we can tolerate this error
-			if fv, ok := v.(TolerantVertex); ok && fv.AllowUpstreamFailure(dep) {
+			if fv, ok := v.(TolerantVertex); ok && fv.AllowUpstreamFailure() {
 				allowUpstreamFailure = true
 				continue
 			}
@@ -351,7 +351,7 @@ func (w *Walker) waitDeps(
 		}
 	}
 
-	// If we have an error from a dependency that we can tolerate, return a soft failure result
+	// If we have an error but the node can tolerate failures, return a soft failure result
 	// This allows us to treat such vertices specially, while still maintaining the flow
 	// of errors to dependencies further down the DAG.
 	if allowUpstreamFailure {

--- a/internal/dag/walk_test.go
+++ b/internal/dag/walk_test.go
@@ -72,30 +72,28 @@ func TestWalker_error(t *testing.T) {
 	}
 }
 
-type tolerantTestVertex string
-
-func (v tolerantTestVertex) Name() string {
-	return string(v)
-}
-
-func (v tolerantTestVertex) AllowUpstreamFailure(dep Vertex) bool {
-	return dep == testV(2)
-}
-
 func TestWalker_tolerantVertex(t *testing.T) {
+	// This tests that a tolerant vertex whose dependencies return a soft failure
+	// still executes, but it does not proceed walking to its downstream dependents.
+	// The graph is a > error > c > d
+	// When b is a soft failure, c executes, but d does not
 	var g AcyclicGraph
-	g.Add(testV(1))
-	g.Add(testV(2))
-	g.Add(tolerantTestVertex("t"))
-	g.Add(testV(4))
-	g.Connect(testV(2), testV(1))
-	g.Connect(tolerantTestVertex("t"), testV(2))
-	g.Connect(testV(4), tolerantTestVertex("t"))
+	resA := testNamedString("a")
+	resErr := testNamedString("error")
+	resC := testNamedString("c")
+	resD := testNamedString("d")
+	g.Add(resA)
+	g.Add(resErr)
+	g.Add(resC)
+	g.Add(resD)
+	g.Connect(resErr, resA)
+	g.Connect(resC, resErr)
+	g.Connect(resD, resC)
 
 	var order []any
 
 	w := NewWalker(func(v Vertex) tfdiags.Diagnostics {
-		if v == testV(2) {
+		if v == testNamedString("error") {
 			var diags tfdiags.Diagnostics
 			diags = diags.Append(fmt.Errorf("error"))
 			return diags
@@ -108,7 +106,7 @@ func TestWalker_tolerantVertex(t *testing.T) {
 		t.Fatal("expect error")
 	}
 
-	expected := []any{testV(1), tolerantTestVertex("t")}
+	expected := []any{resA, resC}
 	if !reflect.DeepEqual(order, expected) {
 		t.Errorf("wrong order\ngot:  %#v\nwant: %#v", order, expected)
 	}

--- a/internal/dag/walk_test.go
+++ b/internal/dag/walk_test.go
@@ -72,15 +72,14 @@ func TestWalker_error(t *testing.T) {
 	}
 }
 
-func TestWalker_tolerantVertex(t *testing.T) {
-	// This tests that a tolerant vertex whose dependencies return a soft failure
-	// still executes, but it does not proceed walking to its downstream dependents.
-	// The graph is a > error > c > d
-	// When b is a soft failure, c executes, but d does not
+func TestWalker_alwaysRunVertex(t *testing.T) {
+	// This tests that an [AlwaysRun] vertex whose dependencies fail still executes.
+	// The graph is a > error > c > d.
+	// When error is a failure, c executes
 	var g AcyclicGraph
 	resA := testNamedString("a")
 	resErr := testNamedString("error")
-	resC := testNamedString("c")
+	resC := testAlwaysRunVertex("c")
 	resD := testNamedString("d")
 	g.Add(resA)
 	g.Add(resErr)
@@ -106,7 +105,7 @@ func TestWalker_tolerantVertex(t *testing.T) {
 		t.Fatal("expect error")
 	}
 
-	expected := []any{resA, resC}
+	expected := []any{resA, resC, resD}
 	if !reflect.DeepEqual(order, expected) {
 		t.Errorf("wrong order\ngot:  %#v\nwant: %#v", order, expected)
 	}

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -1798,6 +1798,7 @@ func TestContext2Plan_PolicyEvaluation_PartialPlan(t *testing.T) {
 
 		resource "test_resource" "fail" {
 			value = "fail"
+			depends_on = [test_resource.ok]
 		}
 		`
 

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -1955,6 +1955,10 @@ func TestContext2Plan_PolicyEvaluation_PartialPlan(t *testing.T) {
 			if len(policyDiags) != 0 {
 				t.Fatalf("expected no policy diagnostics, got %d", len(policyDiags))
 			}
+
+			if !provider.CloseCalled {
+				t.Fatal("Expected provider to be closed, but it was not")
+			}
 		})
 	}
 }

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -1782,86 +1782,148 @@ resource_policy "test_resource" "policy_name" {
 }
 
 func TestContext2Plan_PolicyEvaluation_PartialPlan(t *testing.T) {
-	mainConfig := `
-		terraform {
-			required_providers {
-				test = {
-					source = "hashicorp/test"
-					version = "1.0.0"
+	// This test asserts how policy evaluations work in partial plans.
+	// Policy evaluations still need to run when some resource nodes fail,
+	// and the way we do that is by tolerating failures from the policy eval node.
+	// The policy eval node depends on all resource nodes.
+	// However, due to transitive dependencies, there may be no dependency edges between
+	// a resource node and the policy node, making the graph dependency failure tolerance insufficient.
+	configMap := map[string]string{
+
+		// Here, policy node depends on both resource nodes.
+		"simple config, one fails": `
+			terraform {
+				required_providers {
+					test = {
+						source = "hashicorp/test"
+						version = "1.0.0"
+					}
 				}
 			}
-		}
+	
+			resource "test_resource" "ok" {
+				value = "ok"
+			}
+	
+			resource "test_resource" "fail" {
+				value = "fail"
+			}
+			`,
 
-		resource "test_resource" "ok" {
-			value = "ok"
-		}
-
-		resource "test_resource" "fail" {
-			value = "fail"
-			depends_on = [test_resource.ok]
-		}
-		`
-
-	mod := testModuleInline(t, map[string]string{
-		"main.tf":           mainConfig,
-		"main.tfpolicy.hcl": samplePolicyConfig,
-	})
-
-	providerAddr := addrs.NewDefaultProvider("test")
-	provider := testProvider("test")
-	provider.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
-		planned := req.ProposedNewState.AsValueMap()
-		if planned["value"].AsString() == "fail" {
-			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"plan failed",
-				"simulated provider plan failure",
-			))
-			return resp
-		}
-		planned["id"] = cty.UnknownVal(cty.String)
-		resp.PlannedState = cty.ObjectVal(planned)
-		return resp
+		// In this scenario, the policy dependency on the "ok"
+		// config is omitted in the graph due to the transitivity
+		// via the "fail" resource.
+		"failed config depends on other config": `
+			terraform {
+				required_providers {
+					test = {
+						source = "hashicorp/test"
+						version = "1.0.0"
+					}
+				}
+			}
+	
+			resource "test_resource" "ok" {
+				value = "ok"
+			}
+	
+			resource "test_resource" "fail" {
+				value = "fail"
+				depends_on = [test_resource.ok]
+			}
+			`,
+		// This is similar to the above case, but the dependency
+		// goes through an intermediate object.
+		"failed dependency through intermediate object": `
+				terraform {
+					required_providers {
+						test = {
+							source = "hashicorp/test"
+							version = "1.0.0"
+						}
+					}
+				}
+		
+				locals {
+					intermediate = test_resource.ok.value
+				}
+		
+				resource "test_resource" "ok" {
+					value = "ok"
+				}
+		
+				resource "test_resource" "fail" {
+					value = "fail"
+					defer = local.intermediate == "not_ok"
+					
+				}
+				`,
 	}
 
-	policyClient := policy.NewTestMockClient(t)
-	evaluatedPolicyValues := map[string]struct{}{}
-	policyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
-		evaluatedPolicyValues[req.Attrs.Raw.GetAttr("value").AsString()] = struct{}{}
-		return policy.EvaluationResponse{Overall: policy.AllowResult}
-	}
+	for key, cfg := range configMap {
+		t.Run(key, func(t *testing.T) {
+			mod := testModuleInline(t, map[string]string{
+				"main.tf":           cfg,
+				"main.tfpolicy.hcl": samplePolicyConfig,
+			})
 
-	h := &testHook{}
-	ctx, diags := NewContext(&ContextOpts{
-		Providers: map[addrs.Provider]providers.Factory{
-			providerAddr: testProviderFuncFixed(provider),
-		},
-		Hooks: []Hook{h},
-	})
-	tfdiags.AssertNoDiagnostics(t, diags)
+			providerAddr := addrs.NewDefaultProvider("test")
+			provider := testProvider("test")
+			provider.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+				planned := req.ProposedNewState.AsValueMap()
+				if planned["value"].AsString() == "fail" {
+					resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						"plan failed",
+						"simulated provider plan failure",
+					))
+					return resp
+				}
+				planned["id"] = cty.UnknownVal(cty.String)
+				resp.PlannedState = cty.ObjectVal(planned)
+				return resp
+			}
 
-	_, diags = ctx.Plan(mod, states.NewState(), &PlanOpts{
-		Mode:         plans.NormalMode,
-		SetVariables: testInputValuesUnset(mod.Module.Variables),
-		PolicyClient: policyClient,
-	})
-	if !diags.HasErrors() {
-		t.Fatal("expected plan to fail")
-	}
+			policyClient := policy.NewTestMockClient(t)
+			evaluatedPolicyValues := map[string]struct{}{}
+			policyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				evaluatedPolicyValues[req.Attrs.Raw.GetAttr("value").AsString()] = struct{}{}
+				return policy.EvaluationResponse{Overall: policy.AllowResult}
+			}
 
-	var policyDiags tfdiags.Diagnostics
-	for _, result := range h.PolicyResults {
-		policyDiags = policyDiags.Append(result.Diagnostics.AsTerraformDiags())
-	}
+			h := &testHook{}
+			ctx, diags := NewContext(&ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					providerAddr: testProviderFuncFixed(provider),
+				},
+				Hooks: []Hook{h},
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
 
-	// now check that the policy evaluation results match our expectations
-	// we only expect evaluation for the "ok" resource, not the "fail" resource
-	expectedValues := map[string]struct{}{"ok": {}}
-	if diff := cmp.Diff(evaluatedPolicyValues, expectedValues); diff != "" {
-		t.Errorf("unexpected evaluated policy values: %s", diff)
-	}
-	if len(policyDiags) != 0 {
-		t.Fatalf("expected no policy diagnostics, got %d", len(policyDiags))
+			_, diags = ctx.Plan(mod, states.NewState(), &PlanOpts{
+				Mode:         plans.NormalMode,
+				SetVariables: testInputValuesUnset(mod.Module.Variables),
+				PolicyClient: policyClient,
+			})
+			if !diags.HasErrors() {
+				t.Fatal("expected plan to fail")
+			}
+
+			var policyDiags tfdiags.Diagnostics
+			for _, result := range h.PolicyResults {
+				policyDiags = policyDiags.Append(result.Diagnostics.AsTerraformDiags())
+			}
+
+			// now check that the policy evaluation results match our expectations
+			// we only expect evaluation for the "ok" resource, not the "fail" resource
+			expectedValues := map[string]struct{}{"ok": {}}
+			if diff := cmp.Diff(evaluatedPolicyValues, expectedValues); diff != "" {
+				t.Errorf("unexpected evaluated policy values: %s", diff)
+			}
+			if len(policyDiags) != 0 {
+				t.Fatalf("expected no policy diagnostics, got %d", len(policyDiags))
+			}
+		})
 	}
 }
 

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -1784,12 +1784,12 @@ resource_policy "test_resource" "policy_name" {
 func TestContext2Plan_PolicyEvaluation_PartialPlan(t *testing.T) {
 	// This test asserts how policy evaluations work in partial plans.
 	// Policy evaluations still need to run when some resource nodes fail,
-	// and the way we do that is by tolerating failures from the policy eval node.
+	// and the way we do that is by tolerating failures from the policy eval node's
+	// dependencies.
 	// The policy eval node depends on all resource nodes.
 	// However, due to transitive dependencies, there may be no dependency edges between
 	// a resource node and the policy node, making the graph dependency failure tolerance insufficient.
 	type testCase struct {
-		name     string
 		config   string
 		expected map[string]struct{}
 	}

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -1788,11 +1788,16 @@ func TestContext2Plan_PolicyEvaluation_PartialPlan(t *testing.T) {
 	// The policy eval node depends on all resource nodes.
 	// However, due to transitive dependencies, there may be no dependency edges between
 	// a resource node and the policy node, making the graph dependency failure tolerance insufficient.
-	configMap := map[string]string{
+	type testCase struct {
+		name     string
+		config   string
+		expected map[string]struct{}
+	}
+	configMap := map[string]testCase{
 
 		// Here, policy node depends on both resource nodes.
-		"simple config, one fails": `
-			terraform {
+		"simple config, one fails": {
+			config: `terraform {
 				required_providers {
 					test = {
 						source = "hashicorp/test"
@@ -1809,11 +1814,14 @@ func TestContext2Plan_PolicyEvaluation_PartialPlan(t *testing.T) {
 				value = "fail"
 			}
 			`,
+			expected: map[string]struct{}{"ok": {}},
+		},
 
 		// In this scenario, the policy dependency on the "ok"
-		// config is omitted in the graph due to the transitivity
+		// resource is omitted in the graph due to the transitivity
 		// via the "fail" resource.
-		"failed config depends on other config": `
+		"failed resource depends on other resource": {
+			config: `
 			terraform {
 				required_providers {
 					test = {
@@ -1832,9 +1840,12 @@ func TestContext2Plan_PolicyEvaluation_PartialPlan(t *testing.T) {
 				depends_on = [test_resource.ok]
 			}
 			`,
+			expected: map[string]struct{}{"ok": {}},
+		},
 		// This is similar to the above case, but the dependency
 		// goes through an intermediate object.
-		"failed dependency through intermediate object": `
+		"failed dependency through intermediate object": {
+			config: `
 				terraform {
 					required_providers {
 						test = {
@@ -1858,12 +1869,36 @@ func TestContext2Plan_PolicyEvaluation_PartialPlan(t *testing.T) {
 					
 				}
 				`,
+			expected: map[string]struct{}{"ok": {}},
+		},
+		"failed resource is depended on by other resource": {
+			config: `
+					terraform {
+						required_providers {
+							test = {
+								source = "hashicorp/test"
+								version = "1.0.0"
+							}
+						}
+					}
+			
+					resource "test_resource" "ok" {
+						value = "ok"
+						depends_on = [test_resource.fail]
+					}
+			
+					resource "test_resource" "fail" {
+						value = "fail"
+					}
+					`,
+			expected: map[string]struct{}{},
+		},
 	}
 
-	for key, cfg := range configMap {
+	for key, testCase := range configMap {
 		t.Run(key, func(t *testing.T) {
 			mod := testModuleInline(t, map[string]string{
-				"main.tf":           cfg,
+				"main.tf":           testCase.config,
 				"main.tfpolicy.hcl": samplePolicyConfig,
 			})
 
@@ -1914,10 +1949,7 @@ func TestContext2Plan_PolicyEvaluation_PartialPlan(t *testing.T) {
 				policyDiags = policyDiags.Append(result.Diagnostics.AsTerraformDiags())
 			}
 
-			// now check that the policy evaluation results match our expectations
-			// we only expect evaluation for the "ok" resource, not the "fail" resource
-			expectedValues := map[string]struct{}{"ok": {}}
-			if diff := cmp.Diff(evaluatedPolicyValues, expectedValues); diff != "" {
+			if diff := cmp.Diff(evaluatedPolicyValues, testCase.expected); diff != "" {
 				t.Errorf("unexpected evaluated policy values: %s", diff)
 			}
 			if len(policyDiags) != 0 {

--- a/internal/terraform/node_policy_eval.go
+++ b/internal/terraform/node_policy_eval.go
@@ -6,7 +6,6 @@ package terraform
 import (
 	"log"
 
-	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"go.opentelemetry.io/otel/trace"
@@ -16,8 +15,6 @@ import (
 // with incoming edges from the resource graph so that policy evaluation
 // is performed only when the resource graph is complete.
 type nodePolicyEval struct {
-	// a dependency map of resource nodes. This also includes transitive dependencies.
-	resourceDepMap collections.Map[dag.Vertex, dag.VertexSet]
 }
 
 var _ GraphNodeDynamicExpandable = (*nodePolicyEval)(nil)
@@ -47,34 +44,7 @@ func (n *nodePolicyEval) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnos
 // so that the policy evaluation can proceed even if some resource instance nodes
 // evaluated with error diagnostics.
 func (n *nodePolicyEval) OnErroredDependencies(deps ...dag.Vertex) dag.DependencyResult {
-	dependencyResult := dag.DependencyResultSoftFailure
-	// Loop through all the non-transitive dependencies in the graph
-	for _, dep := range deps {
-		// If a dependency failed and is not a resource instance, then
-		// return a hard failure early
-		if _, ok := dep.(GraphNodeConfigResource); !ok {
-			return dag.DependencyResultHardFailure
-		}
-
-		// Get transitive dependencies as well.
-		depDeps, ok := n.resourceDepMap.GetOk(dep)
-		if !ok {
-			continue
-		}
-
-		for dep := range depDeps.All() {
-			// If a transitive dependency failed and is not a resource instance, then
-			// return a hard failure early
-			if _, ok := dep.(GraphNodeConfigResource); !ok {
-				return dag.DependencyResultHardFailure
-			}
-
-		}
-		// Getting here means we have a node resource, so we will eventually fallback
-		//  to returning a soft failure if all failures are from resource nodes.
-	}
-
-	return dependencyResult
+	return dag.DependencyResultSoftFailure
 }
 
 // nodePolicyEvalFinish is a sentinel node appended to the policy subgraph that

--- a/internal/terraform/node_policy_eval.go
+++ b/internal/terraform/node_policy_eval.go
@@ -18,7 +18,7 @@ type nodePolicyEval struct {
 }
 
 var _ GraphNodeDynamicExpandable = (*nodePolicyEval)(nil)
-var _ dag.ErroredDependencyHandler = (*nodePolicyEval)(nil)
+var _ dag.AlwaysRunVertex = (*nodePolicyEval)(nil)
 
 func (n *nodePolicyEval) Name() string {
 	return "(evaluate policies)"
@@ -40,12 +40,9 @@ func (n *nodePolicyEval) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnos
 	return policyGraph.evalGraph(span), nil
 }
 
-// OnErroredDependencies allows failures from upstream nodes to be tolerated
-// so that the policy evaluation can proceed even if some resource instance nodes
-// evaluated with error diagnostics.
-func (n *nodePolicyEval) OnErroredDependencies(deps ...dag.Vertex) dag.DependencyResult {
-	return dag.DependencyResultSoftFailure
-}
+// AlwaysRun implements [dag.AlwaysRunVertex] so that the policy evaluation
+// can proceed even if some resource instance nodes evaluated with error diagnostics.
+func (n *nodePolicyEval) AlwaysRun() {}
 
 // nodePolicyEvalFinish is a sentinel node appended to the policy subgraph that
 // runs after every policy node and ends the policy-execution phase span. It
@@ -56,7 +53,7 @@ type nodePolicyEvalFinish struct {
 }
 
 var _ GraphNodeExecutable = (*nodePolicyEvalFinish)(nil)
-var _ dag.ErroredDependencyHandler = (*nodePolicyEvalFinish)(nil)
+var _ dag.AlwaysRunVertex = (*nodePolicyEvalFinish)(nil)
 
 func (n *nodePolicyEvalFinish) Name() string {
 	return "(policy evaluation complete)"
@@ -67,8 +64,6 @@ func (n *nodePolicyEvalFinish) Execute(ctx EvalContext, op walkOperation) tfdiag
 	return nil
 }
 
-// OnErroredDependencies returns a soft failure so that this node still executes
+// AlwaysRun implements [dag.AlwaysRunVertex] so that this node still executes
 // even if dependencies errored
-func (n *nodePolicyEvalFinish) OnErroredDependencies(deps ...dag.Vertex) dag.DependencyResult {
-	return dag.DependencyResultSoftFailure
-}
+func (n *nodePolicyEvalFinish) AlwaysRun() {}

--- a/internal/terraform/node_policy_eval.go
+++ b/internal/terraform/node_policy_eval.go
@@ -42,9 +42,8 @@ func (n *nodePolicyEval) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnos
 // AllowUpstreamFailure allows failures from upstream nodes to be tolerated
 // so that the policy evaluation can proceed even if some resource instance nodes
 // evaluated with error diagnostics.
-func (n *nodePolicyEval) AllowUpstreamFailure(dep dag.Vertex) bool {
-	_, ok := dep.(GraphNodeConfigResource)
-	return ok
+func (n *nodePolicyEval) AllowUpstreamFailure() bool {
+	return true
 }
 
 // nodePolicyEvalFinish is a sentinel node appended to the policy subgraph that
@@ -69,10 +68,6 @@ func (n *nodePolicyEvalFinish) Execute(ctx EvalContext, op walkOperation) tfdiag
 
 // AllowUpstreamFailure tolerates failures from the policy nodes so the phase
 // span is always ended.
-func (n *nodePolicyEvalFinish) AllowUpstreamFailure(dep dag.Vertex) bool {
-	switch dep.(type) {
-	case *nodeResourcePolicy, *nodeQueryResourcePolicy:
-		return true
-	}
-	return false
+func (n *nodePolicyEvalFinish) AllowUpstreamFailure() bool {
+	return true
 }

--- a/internal/terraform/node_policy_eval.go
+++ b/internal/terraform/node_policy_eval.go
@@ -6,6 +6,7 @@ package terraform
 import (
 	"log"
 
+	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"go.opentelemetry.io/otel/trace"
@@ -14,10 +15,13 @@ import (
 // nodePolicyEval is a node that completes the building of the policy graph,
 // with incoming edges from the resource graph so that policy evaluation
 // is performed only when the resource graph is complete.
-type nodePolicyEval struct{}
+type nodePolicyEval struct {
+	// a dependency map of resource nodes. This also includes transitive dependencies.
+	resourceDepMap collections.Map[dag.Vertex, dag.VertexSet]
+}
 
 var _ GraphNodeDynamicExpandable = (*nodePolicyEval)(nil)
-var _ dag.TolerantVertex = (*nodePolicyEval)(nil)
+var _ dag.ErroredDependencyHandler = (*nodePolicyEval)(nil)
 
 func (n *nodePolicyEval) Name() string {
 	return "(evaluate policies)"
@@ -39,11 +43,37 @@ func (n *nodePolicyEval) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnos
 	return policyGraph.evalGraph(span), nil
 }
 
-// AllowUpstreamFailure allows failures from upstream nodes to be tolerated
+// OnErroredDependencies allows failures from upstream nodes to be tolerated
 // so that the policy evaluation can proceed even if some resource instance nodes
 // evaluated with error diagnostics.
-func (n *nodePolicyEval) AllowUpstreamFailure() bool {
-	return true
+func (n *nodePolicyEval) OnErroredDependencies(deps ...dag.Vertex) dag.DependencyResult {
+	dependencyResult := dag.DependencyResultSoftFailure
+	// Loop through all the dependencies in the graph
+	for _, dep := range deps {
+		// If a dependency failed and is not a resource instance, then
+		// return a hard failure early
+		if _, ok := dep.(GraphNodeConfigResource); !ok {
+			return dag.DependencyResultHardFailure
+		}
+
+		// Get transitive dependencies as well.
+		depDeps, ok := n.resourceDepMap.GetOk(dep)
+		if !ok {
+			continue
+		}
+
+		for range depDeps.All() {
+			// If a dependency failed and is not a resource instance, then
+			// return a hard failure early
+			if _, ok := dep.(GraphNodeConfigResource); !ok {
+				return dag.DependencyResultHardFailure
+			}
+
+			// this is a node resource, so we are probably returning a soft failure
+		}
+	}
+
+	return dependencyResult
 }
 
 // nodePolicyEvalFinish is a sentinel node appended to the policy subgraph that
@@ -55,7 +85,7 @@ type nodePolicyEvalFinish struct {
 }
 
 var _ GraphNodeExecutable = (*nodePolicyEvalFinish)(nil)
-var _ dag.TolerantVertex = (*nodePolicyEvalFinish)(nil)
+var _ dag.ErroredDependencyHandler = (*nodePolicyEvalFinish)(nil)
 
 func (n *nodePolicyEvalFinish) Name() string {
 	return "(policy evaluation complete)"
@@ -66,8 +96,8 @@ func (n *nodePolicyEvalFinish) Execute(ctx EvalContext, op walkOperation) tfdiag
 	return nil
 }
 
-// AllowUpstreamFailure tolerates failures from the policy nodes so the phase
-// span is always ended.
-func (n *nodePolicyEvalFinish) AllowUpstreamFailure() bool {
-	return true
+// OnErroredDependencies returns a soft failure so that this node still executes
+// even if dependencies errored
+func (n *nodePolicyEvalFinish) OnErroredDependencies(deps ...dag.Vertex) dag.DependencyResult {
+	return dag.DependencyResultSoftFailure
 }

--- a/internal/terraform/node_policy_eval.go
+++ b/internal/terraform/node_policy_eval.go
@@ -48,7 +48,7 @@ func (n *nodePolicyEval) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnos
 // evaluated with error diagnostics.
 func (n *nodePolicyEval) OnErroredDependencies(deps ...dag.Vertex) dag.DependencyResult {
 	dependencyResult := dag.DependencyResultSoftFailure
-	// Loop through all the dependencies in the graph
+	// Loop through all the non-transitive dependencies in the graph
 	for _, dep := range deps {
 		// If a dependency failed and is not a resource instance, then
 		// return a hard failure early
@@ -62,15 +62,16 @@ func (n *nodePolicyEval) OnErroredDependencies(deps ...dag.Vertex) dag.Dependenc
 			continue
 		}
 
-		for range depDeps.All() {
-			// If a dependency failed and is not a resource instance, then
+		for dep := range depDeps.All() {
+			// If a transitive dependency failed and is not a resource instance, then
 			// return a hard failure early
 			if _, ok := dep.(GraphNodeConfigResource); !ok {
 				return dag.DependencyResultHardFailure
 			}
 
-			// this is a node resource, so we are probably returning a soft failure
 		}
+		// Getting here means we have a node resource, so we will eventually fallback
+		//  to returning a soft failure if all failures are from resource nodes.
 	}
 
 	return dependencyResult

--- a/internal/terraform/node_policy_eval_test.go
+++ b/internal/terraform/node_policy_eval_test.go
@@ -7,68 +7,11 @@ import (
 	"context"
 	"testing"
 
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 )
-
-// TestNodePolicyEvalFinish_AllowUpstreamFailure verifies that only
-// nodeResourcePolicy and nodeQueryResourcePolicy return true; all other vertex
-// types return false.
-func TestNodePolicyEvalFinish_AllowUpstreamFailure(t *testing.T) {
-	finish := &nodePolicyEvalFinish{span: trace.SpanFromContext(context.Background())}
-
-	cases := []struct {
-		name string
-		dep  dag.Vertex
-		want bool
-	}{
-		{
-			name: "nodeResourcePolicy",
-			dep: &nodeResourcePolicy{
-				ResourceAddr: addrs.Resource{
-					Mode: addrs.ManagedResourceMode,
-					Type: "aws_instance",
-					Name: "foo",
-				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-			},
-			want: true,
-		},
-		{
-			name: "nodeQueryResourcePolicy",
-			dep: &nodeQueryResourcePolicy{
-				ResourceAddr: addrs.Resource{
-					Mode: addrs.ManagedResourceMode,
-					Type: "aws_instance",
-					Name: "bar",
-				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-			},
-			want: true,
-		},
-		{
-			name: "nodePolicyEvalFinish",
-			dep:  &nodePolicyEvalFinish{},
-			want: false,
-		},
-		{
-			name: "nodePolicyEval",
-			dep:  &nodePolicyEval{},
-			want: false,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := finish.AllowUpstreamFailure()
-			if got != tc.want {
-				t.Errorf("AllowUpstreamFailure(%T) = %v, want %v", tc.dep, got, tc.want)
-			}
-		})
-	}
-}
 
 // TestNodePolicyEval_DynamicExpand_FinishWiring verifies that DynamicExpand
 // appends a nodePolicyEvalFinish node to the policy subgraph and wires it to

--- a/internal/terraform/node_policy_eval_test.go
+++ b/internal/terraform/node_policy_eval_test.go
@@ -62,7 +62,7 @@ func TestNodePolicyEvalFinish_AllowUpstreamFailure(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := finish.AllowUpstreamFailure(tc.dep)
+			got := finish.AllowUpstreamFailure()
 			if got != tc.want {
 				t.Errorf("AllowUpstreamFailure(%T) = %v, want %v", tc.dep, got, tc.want)
 			}

--- a/internal/terraform/transform_policy_eval.go
+++ b/internal/terraform/transform_policy_eval.go
@@ -5,6 +5,8 @@ package terraform
 
 import (
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/collections"
+	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/policy"
 )
 
@@ -26,7 +28,9 @@ func (t *policyEvalTransformer) Transform(g *Graph) error {
 	if t.PolicyClient == nil {
 		return nil
 	}
-	policyNode := &nodePolicyEval{}
+	policyNode := &nodePolicyEval{
+		resourceDepMap: collections.NewMapFunc[dag.Vertex, dag.VertexSet](vertexKeyFunc),
+	}
 	g.Add(policyNode)
 
 	for v := range g.VerticesSeq() {
@@ -58,7 +62,23 @@ func (t *policyEvalTransformer) Transform(g *Graph) error {
 		// executes only after all remaining graph work that can still mutate state
 		// or changes has completed.
 		g.Connect(policyNode, v)
+
+		// Now work out the resource dependency map
+		if _, ok := v.(GraphNodeConfigResource); ok {
+			policyNode.resourceDepMap.Put(v, g.Ancestors(v).Filter(func(v dag.Vertex) bool {
+				_, ok := v.(GraphNodeConfigResource)
+				return ok
+			}))
+		}
 	}
 
 	return nil
+}
+
+type vertexKey string
+
+func (k vertexKey) IsUniqueKey(dag.Vertex) {}
+
+func vertexKeyFunc(v dag.Vertex) collections.UniqueKey[dag.Vertex] {
+	return vertexKey(v.Name())
 }

--- a/internal/terraform/transform_policy_eval.go
+++ b/internal/terraform/transform_policy_eval.go
@@ -5,8 +5,6 @@ package terraform
 
 import (
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/collections"
-	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/policy"
 )
 
@@ -28,9 +26,7 @@ func (t *policyEvalTransformer) Transform(g *Graph) error {
 	if t.PolicyClient == nil {
 		return nil
 	}
-	policyNode := &nodePolicyEval{
-		resourceDepMap: collections.NewMapFunc[dag.Vertex, dag.VertexSet](vertexKeyFunc),
-	}
+	policyNode := &nodePolicyEval{}
 	g.Add(policyNode)
 
 	for v := range g.VerticesSeq() {
@@ -62,23 +58,7 @@ func (t *policyEvalTransformer) Transform(g *Graph) error {
 		// executes only after all remaining graph work that can still mutate state
 		// or changes has completed.
 		g.Connect(policyNode, v)
-
-		// Now work out the resource dependency map
-		if _, ok := v.(GraphNodeConfigResource); ok {
-			policyNode.resourceDepMap.Put(v, g.Ancestors(v).Filter(func(v dag.Vertex) bool {
-				_, ok := v.(GraphNodeConfigResource)
-				return ok
-			}))
-		}
 	}
 
 	return nil
-}
-
-type vertexKey string
-
-func (k vertexKey) IsUniqueKey(dag.Vertex) {}
-
-func vertexKeyFunc(v dag.Vertex) collections.UniqueKey[dag.Vertex] {
-	return vertexKey(v.Name())
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->
This reverts the changes in https://github.com/hashicorp/terraform/pull/38516/changes/d4ca814cbea037dcf2a59d083f8a540bf5d38d3a that introduced a mechanism for allowing upstream failures in certain vertices. Such vertex then halts the graph along its path. The original motivation for the aforementioned change was to ensure that policies evaluate even when resource nodes fail. But halting the graph means that providers were not closed after the policy evaluated.
We can simplify the solution instead of trying to solve this generically in the graph algorithm.

The Policy evaluation node only depends on resource nodes, so we can tolerate any failure whatsoever that it has. The new interface [AlwaysRunVertex] contains a method implemented by the policy node. If any vertex implements that interface, the dependency errors are ignored and the vertex is allowed to execute.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
