### PR TITLE
show token TTL warning message on login

### DIFF
--- a/.changes/v1.17/ENHANCEMENTS-20260817-093229.yaml
+++ b/.changes/v1.17/ENHANCEMENTS-20260817-093229.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'command/login: always display token TTL policy warning after successful login, regardless of organization settings'
+time: 2026-08-17T09:32:29.000000Z
+custom:
+    Issue: ""

--- a/.changes/v1.17/ENHANCEMENTS-20260817-093229.yaml
+++ b/.changes/v1.17/ENHANCEMENTS-20260817-093229.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: 'command/login: always display token TTL policy warning after successful login, regardless of organization settings'
+body: "command/login: display warning after successful login if user is subject to an organization's TTL policy"
 time: 2026-08-17T09:32:29.000000Z
 custom:
     Issue: ""

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -222,11 +222,11 @@ func (c *LoginCommand) Run(args []string) int {
 		))
 	}
 
-	if c.orgsHaveMaxTTLEnabled(host, tfeservice, token) {
+	if org, ok := c.isMemberOfOrgWithMaxTTLEnabled(host, tfeservice, token); ok {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Warning,
-			"Token TTL policy",
-			"If the user token TTL exceeds organization policy, it will be rejected from accessing that organization.",
+			"Token is subject to TTL policy",
+			fmt.Sprintf("You are a member of organization %q, which enforces a maximum TTL policy. If your user token TTL exceeds organization policy, it will be rejected from accessing that organization.", org),
 		))
 	}
 
@@ -310,16 +310,17 @@ authenticated requests to %s.
 	return 0
 }
 
-// orgsHaveMaxTTLEnabled reports whether the logged-in user belongs to an
-// organization with max TTL enforcement enabled. It returns false if
-// organizations cannot be listed, ensuring lookup failures never block login.
-func (c *LoginCommand) orgsHaveMaxTTLEnabled(host *disco.Host, tfeservice *url.URL, token svcauth.HostCredentialsToken) bool {
+// isMemberOfOrgWithMaxTTLEnabled reports whether the logged-in user belongs
+// to an organization with max TTL enforcement enabled, along with its name.
+// Returns ("", false) if not found or if organizations can't be listed, so
+// lookup failures never block login.
+func (c *LoginCommand) isMemberOfOrgWithMaxTTLEnabled(host *disco.Host, tfeservice *url.URL, token svcauth.HostCredentialsToken) (string, bool) {
 	service := tfeservice
 	if service == nil {
 		var err error
 		service, err = host.ServiceURL("tfe.v2")
 		if err != nil {
-			return false
+			return "", false
 		}
 	}
 
@@ -330,7 +331,7 @@ func (c *LoginCommand) orgsHaveMaxTTLEnabled(host *disco.Host, tfeservice *url.U
 		Headers:  make(http.Header),
 	})
 	if err != nil {
-		return false
+		return "", false
 	}
 
 	listOpts := &tfe.OrganizationListOptions{
@@ -339,11 +340,11 @@ func (c *LoginCommand) orgsHaveMaxTTLEnabled(host *disco.Host, tfeservice *url.U
 	for {
 		orgList, err := client.Organizations.List(context.Background(), listOpts)
 		if err != nil {
-			return false
+			return "", false
 		}
 		for _, org := range orgList.Items {
 			if org.MaxTTLEnabled {
-				return true
+				return org.Name, true
 			}
 		}
 		if orgList.NextPage == 0 {
@@ -352,7 +353,7 @@ func (c *LoginCommand) orgsHaveMaxTTLEnabled(host *disco.Host, tfeservice *url.U
 		listOpts.PageNumber = orgList.NextPage
 	}
 
-	return false
+	return "", false
 }
 
 func (c *LoginCommand) outputDefaultTFELoginSuccess(dispHostname string) {

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -222,6 +222,13 @@ func (c *LoginCommand) Run(args []string) int {
 		))
 	}
 
+	// Always warn the user that token TTL policies may apply.
+	diags = diags.Append(tfdiags.Sourceless(
+		tfdiags.Warning,
+		"Token TTL policy",
+		"If the user token TTL exceeds organization policy, it will be rejected from accessing that organization.",
+	))
+
 	c.showDiagnostics(diags)
 	if diags.HasErrors() {
 		return 1

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -222,12 +222,13 @@ func (c *LoginCommand) Run(args []string) int {
 		))
 	}
 
-	// Always warn the user that token TTL policies may apply.
-	diags = diags.Append(tfdiags.Sourceless(
-		tfdiags.Warning,
-		"Token TTL policy",
-		"If the user token TTL exceeds organization policy, it will be rejected from accessing that organization.",
-	))
+	if c.orgsHaveMaxTTLEnabled(host, tfeservice, token) {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Token TTL policy",
+			"If the user token TTL exceeds organization policy, it will be rejected from accessing that organization.",
+		))
+	}
 
 	c.showDiagnostics(diags)
 	if diags.HasErrors() {
@@ -307,6 +308,51 @@ authenticated requests to %s.
 	}
 
 	return 0
+}
+
+// orgsHaveMaxTTLEnabled reports whether the logged-in user belongs to an
+// organization with max TTL enforcement enabled. It returns false if
+// organizations cannot be listed, ensuring lookup failures never block login.
+func (c *LoginCommand) orgsHaveMaxTTLEnabled(host *disco.Host, tfeservice *url.URL, token svcauth.HostCredentialsToken) bool {
+	service := tfeservice
+	if service == nil {
+		var err error
+		service, err = host.ServiceURL("tfe.v2")
+		if err != nil {
+			return false
+		}
+	}
+
+	client, err := tfe.NewClient(&tfe.Config{
+		Address:  service.String(),
+		BasePath: service.Path,
+		Token:    token.Token(),
+		Headers:  make(http.Header),
+	})
+	if err != nil {
+		return false
+	}
+
+	listOpts := &tfe.OrganizationListOptions{
+		ListOptions: tfe.ListOptions{PageSize: 100},
+	}
+	for {
+		orgList, err := client.Organizations.List(context.Background(), listOpts)
+		if err != nil {
+			return false
+		}
+		for _, org := range orgList.Items {
+			if org.MaxTTLEnabled {
+				return true
+			}
+		}
+		if orgList.NextPage == 0 {
+			break
+		}
+		listOpts.PageNumber = orgList.NextPage
+	}
+
+	return false
 }
 
 func (c *LoginCommand) outputDefaultTFELoginSuccess(dispHostname string) {

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -23,11 +23,23 @@ import (
 	"github.com/hashicorp/terraform/version"
 )
 
-// ttlWarning is the warning title emitted by terraform login on every
-// successful login to inform users that token TTL policies may apply.
-// We match on the title rather than the body because the diagnostics renderer
-// word-wraps the body text, making an exact substring match unreliable.
+// ttlWarning is the diagnostic title shown when the logged-in user belongs
+// to an organization with max TTL enforcement enabled. We assert against
+// the title rather than the body, since diagnostic rendering wraps long
+// lines and makes body substring matches unreliable.
 const ttlWarning = "Warning: Token TTL policy"
+
+// setOrgsMaxTTLEnabled sets whether the mock TFE server's /organizations
+// endpoint reports max TTL enforcement, restoring the previous value when
+// the test completes.
+func setOrgsMaxTTLEnabled(t *testing.T, enabled bool) {
+	t.Helper()
+	previous := tfeserver.OrganizationsMaxTTLEnabled
+	tfeserver.OrganizationsMaxTTLEnabled = enabled
+	t.Cleanup(func() {
+		tfeserver.OrganizationsMaxTTLEnabled = previous
+	})
+}
 
 func TestLogin(t *testing.T) {
 	// oauthserver.Handler is a stub OAuth server implementation that will,
@@ -111,7 +123,9 @@ func TestLogin(t *testing.T) {
 		}
 	}
 
-	t.Run("app.terraform.io (no login support)", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
+	t.Run("app.terraform.io (no login support), org has max TTL enabled", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
+		setOrgsMaxTTLEnabled(t, true)
+
 		// Enter "yes" at the consent prompt, then paste a token with some
 		// accidental whitespace.
 		_ = testInputMap(t, map[string]string{
@@ -139,7 +153,35 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
+	t.Run("app.terraform.io (no login support), org has max TTL disabled", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
+		setOrgsMaxTTLEnabled(t, false)
+
+		// Enter "yes" at the consent prompt, then paste a token with some
+		// accidental whitespace.
+		_ = testInputMap(t, map[string]string{
+			"approve": "yes",
+			"token":   "  good-token ",
+		})
+		status := c.Run([]string{"app.terraform.io"})
+		if status != 0 {
+			t.Fatalf("unexpected error code %d\nstderr:\n%s", status, ui.ErrorWriter.String())
+		}
+
+		if got, want := ui.OutputWriter.String(), "Welcome to HCP Terraform!"; !strings.Contains(got, want) {
+			t.Errorf("expected output to contain %q, but was:\n%s", want, got)
+		}
+		// Warning must not appear when no organization enforces max TTL.
+		if got := ui.OutputWriter.String(); strings.Contains(got, ttlWarning) {
+			t.Errorf("unexpected TTL warning when no org enforces max TTL\ngot:\n%s", got)
+		}
+	}))
+
 	t.Run("example.com with authorization code flow", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
+		// example.com only advertises login.v1, not tfe.v2, so there is no
+		// way to look up organizations for this host. The warning must not
+		// appear regardless of the mock server's max TTL setting.
+		setOrgsMaxTTLEnabled(t, true)
+
 		// Enter "yes" at the consent prompt.
 		_ = testInputMap(t, map[string]string{
 			"approve": "yes",
@@ -161,8 +203,8 @@ func TestLogin(t *testing.T) {
 		if got, want := ui.OutputWriter.String(), "Terraform has obtained and saved an API token."; !strings.Contains(got, want) {
 			t.Errorf("expected output to contain %q, but was:\n%s", want, got)
 		}
-		if got, want := ui.OutputWriter.String(), ttlWarning; !strings.Contains(got, want) {
-			t.Errorf("expected TTL warning in output\nwant substring: %s\ngot:\n%s", want, got)
+		if got := ui.OutputWriter.String(); strings.Contains(got, ttlWarning) {
+			t.Errorf("unexpected TTL warning for host without tfe.v2 service\ngot:\n%s", got)
 		}
 	}))
 
@@ -197,8 +239,8 @@ func TestLogin(t *testing.T) {
 		if got, want := ui.OutputWriter.String(), "Terraform has obtained and saved an API token."; !strings.Contains(got, want) {
 			t.Errorf("expected output to contain %q, but was:\n%s", want, got)
 		}
-		if got, want := ui.OutputWriter.String(), ttlWarning; !strings.Contains(got, want) {
-			t.Errorf("expected TTL warning in output\nwant substring: %s\ngot:\n%s", want, got)
+		if got := ui.OutputWriter.String(); strings.Contains(got, ttlWarning) {
+			t.Errorf("unexpected TTL warning for host without tfe.v2 service\ngot:\n%s", got)
 		}
 	}))
 
@@ -216,7 +258,9 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
-	t.Run("TFE host without login support", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
+	t.Run("TFE host without login support, org has max TTL enabled", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
+		setOrgsMaxTTLEnabled(t, true)
+
 		// Enter "yes" at the consent prompt, then paste a token with some
 		// accidental whitespace.
 		_ = testInputMap(t, map[string]string{
@@ -242,6 +286,29 @@ func TestLogin(t *testing.T) {
 		}
 		if got, want := ui.OutputWriter.String(), ttlWarning; !strings.Contains(got, want) {
 			t.Errorf("expected TTL warning in output\nwant substring: %s\ngot:\n%s", want, got)
+		}
+	}))
+
+	t.Run("TFE host without login support, org has max TTL disabled", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
+		setOrgsMaxTTLEnabled(t, false)
+
+		// Enter "yes" at the consent prompt, then paste a token with some
+		// accidental whitespace.
+		_ = testInputMap(t, map[string]string{
+			"approve": "yes",
+			"token":   "  good-token ",
+		})
+		status := c.Run([]string{"tfe.acme.com"})
+		if status != 0 {
+			t.Fatalf("unexpected error code %d\nstderr:\n%s", status, ui.ErrorWriter.String())
+		}
+
+		if got, want := ui.OutputWriter.String(), "Logged in to Terraform Enterprise"; !strings.Contains(got, want) {
+			t.Errorf("expected output to contain %q, but was:\n%s", want, got)
+		}
+		// Warning must not appear when no organization enforces max TTL.
+		if got := ui.OutputWriter.String(); strings.Contains(got, ttlWarning) {
+			t.Errorf("unexpected TTL warning when no org enforces max TTL\ngot:\n%s", got)
 		}
 	}))
 

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -27,7 +27,12 @@ import (
 // to an organization with max TTL enforcement enabled. We assert against
 // the title rather than the body, since diagnostic rendering wraps long
 // lines and makes body substring matches unreliable.
-const ttlWarning = "Warning: Token TTL policy"
+const ttlWarning = "Warning: Token is subject to TTL policy"
+
+// ttlWarningOrg is the organization name the mock TFE server returns from
+// its /organizations endpoint, used to assert that the TTL warning message
+// names the affected organization(s).
+const ttlWarningOrg = "hashicorp"
 
 // setOrgsMaxTTLEnabled sets whether the mock TFE server's /organizations
 // endpoint reports max TTL enforcement, restoring the previous value when
@@ -150,6 +155,9 @@ func TestLogin(t *testing.T) {
 		}
 		if got, want := ui.OutputWriter.String(), ttlWarning; !strings.Contains(got, want) {
 			t.Errorf("expected TTL warning in output\nwant substring: %s\ngot:\n%s", want, got)
+		}
+		if got, want := ui.OutputWriter.String(), ttlWarningOrg; !strings.Contains(got, want) {
+			t.Errorf("expected TTL warning to name the affected organization\nwant substring: %s\ngot:\n%s", want, got)
 		}
 	}))
 
@@ -286,6 +294,9 @@ func TestLogin(t *testing.T) {
 		}
 		if got, want := ui.OutputWriter.String(), ttlWarning; !strings.Contains(got, want) {
 			t.Errorf("expected TTL warning in output\nwant substring: %s\ngot:\n%s", want, got)
+		}
+		if got, want := ui.OutputWriter.String(), ttlWarningOrg; !strings.Contains(got, want) {
+			t.Errorf("expected TTL warning to name the affected organization\nwant substring: %s\ngot:\n%s", want, got)
 		}
 	}))
 

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -23,6 +23,12 @@ import (
 	"github.com/hashicorp/terraform/version"
 )
 
+// ttlWarning is the warning title emitted by terraform login on every
+// successful login to inform users that token TTL policies may apply.
+// We match on the title rather than the body because the diagnostics renderer
+// word-wraps the body text, making an exact substring match unreliable.
+const ttlWarning = "Warning: Token TTL policy"
+
 func TestLogin(t *testing.T) {
 	// oauthserver.Handler is a stub OAuth server implementation that will,
 	// on success, always issue a bearer token named "good-token".
@@ -128,6 +134,9 @@ func TestLogin(t *testing.T) {
 		if got, want := ui.OutputWriter.String(), "Welcome to HCP Terraform!"; !strings.Contains(got, want) {
 			t.Errorf("expected output to contain %q, but was:\n%s", want, got)
 		}
+		if got, want := ui.OutputWriter.String(), ttlWarning; !strings.Contains(got, want) {
+			t.Errorf("expected TTL warning in output\nwant substring: %s\ngot:\n%s", want, got)
+		}
 	}))
 
 	t.Run("example.com with authorization code flow", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
@@ -151,6 +160,9 @@ func TestLogin(t *testing.T) {
 
 		if got, want := ui.OutputWriter.String(), "Terraform has obtained and saved an API token."; !strings.Contains(got, want) {
 			t.Errorf("expected output to contain %q, but was:\n%s", want, got)
+		}
+		if got, want := ui.OutputWriter.String(), ttlWarning; !strings.Contains(got, want) {
+			t.Errorf("expected TTL warning in output\nwant substring: %s\ngot:\n%s", want, got)
 		}
 	}))
 
@@ -184,6 +196,9 @@ func TestLogin(t *testing.T) {
 
 		if got, want := ui.OutputWriter.String(), "Terraform has obtained and saved an API token."; !strings.Contains(got, want) {
 			t.Errorf("expected output to contain %q, but was:\n%s", want, got)
+		}
+		if got, want := ui.OutputWriter.String(), ttlWarning; !strings.Contains(got, want) {
+			t.Errorf("expected TTL warning in output\nwant substring: %s\ngot:\n%s", want, got)
 		}
 	}))
 
@@ -225,6 +240,9 @@ func TestLogin(t *testing.T) {
 		if got, want := ui.OutputWriter.String(), "Logged in to Terraform Enterprise"; !strings.Contains(got, want) {
 			t.Errorf("expected output to contain %q, but was:\n%s", want, got)
 		}
+		if got, want := ui.OutputWriter.String(), ttlWarning; !strings.Contains(got, want) {
+			t.Errorf("expected TTL warning in output\nwant substring: %s\ngot:\n%s", want, got)
+		}
 	}))
 
 	t.Run("TFE host without login support, incorrectly pasted token", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
@@ -246,6 +264,10 @@ func TestLogin(t *testing.T) {
 		if creds != nil {
 			t.Errorf("wrong token %q; should have no token", creds.Token())
 		}
+		// Warning must not appear on failed login.
+		if got := ui.OutputWriter.String(); strings.Contains(got, ttlWarning) {
+			t.Errorf("unexpected TTL warning on failed login\ngot:\n%s", got)
+		}
 	}))
 
 	t.Run("host without login or TFE API support", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
@@ -256,6 +278,10 @@ func TestLogin(t *testing.T) {
 
 		if got, want := ui.ErrorWriter.String(), "Error: Host does not support Terraform tokens API"; !strings.Contains(got, want) {
 			t.Fatalf("missing expected error message\nwant: %s\nfull output:\n%s", want, got)
+		}
+		// Warning must not appear when the host doesn't support login at all.
+		if got := ui.OutputWriter.String(); strings.Contains(got, ttlWarning) {
+			t.Errorf("unexpected TTL warning on failed login\ngot:\n%s", got)
 		}
 	}))
 
@@ -272,6 +298,10 @@ func TestLogin(t *testing.T) {
 		if got, want := ui.ErrorWriter.String(), "Login cancelled"; !strings.Contains(got, want) {
 			t.Fatalf("missing expected error message\nwant: %s\nfull output:\n%s", want, got)
 		}
+		// Warning must not appear when login is cancelled before a token is obtained.
+		if got := ui.OutputWriter.String(); strings.Contains(got, ttlWarning) {
+			t.Errorf("unexpected TTL warning on cancelled login\ngot:\n%s", got)
+		}
 	}))
 
 	t.Run("answering y cancels", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
@@ -286,6 +316,10 @@ func TestLogin(t *testing.T) {
 
 		if got, want := ui.ErrorWriter.String(), "Login cancelled"; !strings.Contains(got, want) {
 			t.Fatalf("missing expected error message\nwant: %s\nfull output:\n%s", want, got)
+		}
+		// Warning must not appear when login is cancelled before a token is obtained.
+		if got := ui.OutputWriter.String(); strings.Contains(got, ttlWarning) {
+			t.Errorf("unexpected TTL warning on cancelled login\ngot:\n%s", got)
 		}
 	}))
 }

--- a/internal/command/testdata/login-tfe-server/tfeserver.go
+++ b/internal/command/testdata/login-tfe-server/tfeserver.go
@@ -12,13 +12,20 @@ const (
 	goodToken      = "good-token"
 	accountDetails = `{"data":{"id":"user-abc123","type":"users","attributes":{"username":"testuser","email":"testuser@example.com"}}}`
 	MOTD           = `{"msg":"Welcome to HCP Terraform!"}`
+
+	organizationsPayloadTemplate = `{"data":[{"id":"hashicorp","type":"organizations","attributes":{"name":"hashicorp","max-ttl-enabled":%t}}],"meta":{"pagination":{"current-page":1,"prev-page":0,"next-page":0,"total-count":1,"total-pages":1}}}`
 )
+
+// Controls whether the mock /organizations endpoint enables max TTL enforcement.
+// Tests can toggle this to exercise both TTL warning branches.
+var OrganizationsMaxTTLEnabled bool
 
 // Handler is an implementation of net/http.Handler that provides a stub
 // TFE API server implementation with the following endpoints:
 //
 //	/ping            - API existence endpoint
 //	/account/details - current user endpoint
+//	/organizations   - organizations list endpoint
 var Handler http.Handler
 
 type handler struct{}
@@ -32,6 +39,8 @@ func (h handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		h.serveAccountDetails(resp, req)
 	case "/api/terraform/motd":
 		h.serveMOTD(resp, req)
+	case "/api/v2/organizations":
+		h.serveOrganizations(resp, req)
 	default:
 		fmt.Printf("404 when fetching %s\n", req.URL.String())
 		http.Error(resp, `{"errors":[{"status":"404","title":"not found"}]}`, http.StatusNotFound)
@@ -55,6 +64,16 @@ func (h handler) serveAccountDetails(resp http.ResponseWriter, req *http.Request
 func (h handler) serveMOTD(resp http.ResponseWriter, req *http.Request) {
 	resp.WriteHeader(http.StatusOK)
 	resp.Write([]byte(MOTD))
+}
+
+func (h handler) serveOrganizations(resp http.ResponseWriter, req *http.Request) {
+	if !strings.Contains(req.Header.Get("Authorization"), goodToken) {
+		http.Error(resp, `{"errors":[{"status":"401","title":"unauthorized"}]}`, http.StatusUnauthorized)
+		return
+	}
+
+	resp.WriteHeader(http.StatusOK)
+	resp.Write([]byte(fmt.Sprintf(organizationsPayloadTemplate, OrganizationsMaxTTLEnabled)))
 }
 
 func init() {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Ensures the token TTL policy warning is displayed when TTL is enabled for the organization after a successful Terraform login.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [X] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.


Output: 


<img width="1228" height="110" alt="Screenshot 2026-08-25 at 1 03 33 PM" src="https://github.com/user-attachments/assets/fc4b1b0e-bcb7-43ea-8d73-b649be324d7f" />


