### PR TITLE
deferred: Hook up deferred change rendering to human and JSON views

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -203,16 +203,16 @@ type variable struct {
 func MarshalForRenderer(
 	p *plans.Plan,
 	schemas *terraform.Schemas,
-) (map[string]Change, []ResourceChange, []ResourceChange, []ResourceAttr, []ActionInvocation, error) {
+) (map[string]Change, []ResourceChange, []ResourceChange, []ResourceAttr, []ActionInvocation, []DeferredResourceChange, error) {
 	output := newPlan()
 
 	var err error
 	if output.OutputChanges, err = MarshalOutputChanges(p.Changes); err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	if output.ResourceChanges, err = MarshalResourceChanges(p.Changes.Resources, schemas); err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	if len(p.DriftedResources) > 0 {
@@ -232,19 +232,26 @@ func MarshalForRenderer(
 		}
 		output.ResourceDrift, err = MarshalResourceChanges(driftedResources, schemas)
 		if err != nil {
-			return nil, nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, nil, err
 		}
 	}
 
 	if err := output.marshalRelevantAttrs(p); err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	if output.ActionInvocations, err = MarshalActionInvocations(p.Changes.ActionInvocations, schemas); err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
-	return output.OutputChanges, output.ResourceChanges, output.ResourceDrift, output.RelevantAttributes, output.ActionInvocations, nil
+	if len(p.DeferredResources) > 0 {
+		output.DeferredChanges, err = MarshalDeferredResourceChanges(p.DeferredResources, schemas)
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, err
+		}
+	}
+
+	return output.OutputChanges, output.ResourceChanges, output.ResourceDrift, output.RelevantAttributes, output.ActionInvocations, output.DeferredChanges, nil
 }
 
 // Marshal returns the json encoding of a terraform plan.

--- a/internal/command/views/json/change.go
+++ b/internal/command/views/json/change.go
@@ -88,7 +88,7 @@ type ActionInvocation struct {
 
 func (c *ActionInvocation) String() string {
 	if c.LifecycleTrigger != nil {
-		return fmt.Sprintf("%s: triggered by %s trigger on %s", c.Action.Addr, c.LifecycleTrigger.TriggeringEvent, c.LifecycleTrigger.TriggeringResource)
+		return fmt.Sprintf("%s: triggered by %s trigger on %s", c.Action.Addr, c.LifecycleTrigger.TriggeringEvent, c.LifecycleTrigger.TriggeringResource.Addr)
 	}
 	return c.Action.Addr
 }

--- a/internal/command/views/json/deferred_change.go
+++ b/internal/command/views/json/deferred_change.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package json
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
+)
+
+func NewDeferredResourceInstanceChange(deferredChange *plans.DeferredResourceInstanceChangeSrc) *DeferredResourceInstanceChange {
+	dc := &DeferredResourceInstanceChange{
+		Reason: deferredReason(deferredChange.DeferredReason),
+		Change: NewResourceInstanceChange(deferredChange.ChangeSrc),
+	}
+
+	return dc
+}
+
+type DeferredResourceInstanceChange struct {
+	Reason DeferredReason          `json:"reason"`
+	Change *ResourceInstanceChange `json:"change"`
+}
+
+func (dc *DeferredResourceInstanceChange) String() string {
+	return fmt.Sprintf("%s: deferred change, reason: %s", dc.Change.Resource.Addr, dc.Reason)
+}
+
+type DeferredReason string
+
+const (
+	DeferredReasonInvalid               DeferredReason = "invalid"
+	DeferredReasonInstanceCountUnknown  DeferredReason = "instance_count_unknown"
+	DeferredReasonResourceConfigUnknown DeferredReason = "resource_config_unknown"
+	DeferredReasonProviderConfigUnknown DeferredReason = "provider_config_unknown"
+	DeferredReasonAbsentPrereq          DeferredReason = "absent_prereq"
+	DeferredReasonDeferredPrereq        DeferredReason = "deferred_prereq"
+)
+
+func deferredReason(reason providers.DeferredReason) DeferredReason {
+	switch reason {
+	case providers.DeferredReasonInvalid:
+		return DeferredReasonInvalid
+	case providers.DeferredReasonInstanceCountUnknown:
+		return DeferredReasonInstanceCountUnknown
+	case providers.DeferredReasonResourceConfigUnknown:
+		return DeferredReasonResourceConfigUnknown
+	case providers.DeferredReasonProviderConfigUnknown:
+		return DeferredReasonProviderConfigUnknown
+	case providers.DeferredReasonAbsentPrereq:
+		return DeferredReasonAbsentPrereq
+	case providers.DeferredReasonDeferredPrereq:
+		return DeferredReasonDeferredPrereq
+	default:
+		// This should never happen, but there's no good way to guarantee
+		// exhaustive handling of the enum, so a generic fall back is better
+		// than a misleading result or a panic
+		return DeferredReasonInvalid
+	}
+}

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -14,6 +14,7 @@ const (
 	// Operation results
 	MessageResourceDrift           MessageType = "resource_drift"
 	MessagePlannedChange           MessageType = "planned_change"
+	MessageDeferredChange          MessageType = "deferred_change"
 	MessagePlannedActionInvocation MessageType = "planned_action_invocation"
 	MessageChangeSummary           MessageType = "change_summary"
 	MessageOutputs                 MessageType = "outputs"

--- a/internal/command/views/json/resource_addr.go
+++ b/internal/command/views/json/resource_addr.go
@@ -4,6 +4,8 @@
 package json
 
 import (
+	"fmt"
+
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
@@ -32,14 +34,15 @@ func newResourceAddr(addr addrs.AbsResourceInstance) ResourceAddr {
 			resourceKeyUnknown = true
 		}
 	}
+	fmt.Println(resourceKeyUnknown)
 	return ResourceAddr{
-		Addr:               addr.String(),
-		Module:             addr.Module.String(),
-		Resource:           addr.Resource.String(),
-		ImpliedProvider:    addr.Resource.Resource.ImpliedProvider(),
-		ResourceType:       addr.Resource.Resource.Type,
-		ResourceName:       addr.Resource.Resource.Name,
-		ResourceKey:        resourceKey,
-		ResourceKeyUnknown: resourceKeyUnknown,
+		Addr:            addr.String(),
+		Module:          addr.Module.String(),
+		Resource:        addr.Resource.String(),
+		ImpliedProvider: addr.Resource.Resource.ImpliedProvider(),
+		ResourceType:    addr.Resource.Resource.Type,
+		ResourceName:    addr.Resource.Resource.Name,
+		ResourceKey:     resourceKey,
+		// ResourceKeyUnknown: resourceKeyUnknown,
 	}
 }

--- a/internal/command/views/json/resource_addr.go
+++ b/internal/command/views/json/resource_addr.go
@@ -4,8 +4,6 @@
 package json
 
 import (
-	"fmt"
-
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
@@ -34,15 +32,15 @@ func newResourceAddr(addr addrs.AbsResourceInstance) ResourceAddr {
 			resourceKeyUnknown = true
 		}
 	}
-	fmt.Println(resourceKeyUnknown)
+
 	return ResourceAddr{
-		Addr:            addr.String(),
-		Module:          addr.Module.String(),
-		Resource:        addr.Resource.String(),
-		ImpliedProvider: addr.Resource.Resource.ImpliedProvider(),
-		ResourceType:    addr.Resource.Resource.Type,
-		ResourceName:    addr.Resource.Resource.Name,
-		ResourceKey:     resourceKey,
-		// ResourceKeyUnknown: resourceKeyUnknown,
+		Addr:               addr.String(),
+		Module:             addr.Module.String(),
+		Resource:           addr.Resource.String(),
+		ImpliedProvider:    addr.Resource.Resource.ImpliedProvider(),
+		ResourceType:       addr.Resource.Resource.Type,
+		ResourceName:       addr.Resource.Resource.Name,
+		ResourceKey:        resourceKey,
+		ResourceKeyUnknown: resourceKeyUnknown,
 	}
 }

--- a/internal/command/views/json/resource_addr.go
+++ b/internal/command/views/json/resource_addr.go
@@ -11,27 +11,35 @@ import (
 )
 
 type ResourceAddr struct {
-	Addr            string                  `json:"addr"`
-	Module          string                  `json:"module"`
-	Resource        string                  `json:"resource"`
-	ImpliedProvider string                  `json:"implied_provider"`
-	ResourceType    string                  `json:"resource_type"`
-	ResourceName    string                  `json:"resource_name"`
-	ResourceKey     ctyjson.SimpleJSONValue `json:"resource_key"`
+	Addr               string                  `json:"addr"`
+	Module             string                  `json:"module"`
+	Resource           string                  `json:"resource"`
+	ImpliedProvider    string                  `json:"implied_provider"`
+	ResourceType       string                  `json:"resource_type"`
+	ResourceName       string                  `json:"resource_name"`
+	ResourceKey        ctyjson.SimpleJSONValue `json:"resource_key"`
+	ResourceKeyUnknown bool                    `json:"resource_key_unknown,omitempty"`
 }
 
 func newResourceAddr(addr addrs.AbsResourceInstance) ResourceAddr {
 	resourceKey := ctyjson.SimpleJSONValue{Value: cty.NilVal}
+	resourceKeyUnknown := false
 	if addr.Resource.Key != nil {
-		resourceKey.Value = addr.Resource.Key.Value()
+		if keyValue := addr.Resource.Key.Value(); keyValue.IsWhollyKnown() {
+			resourceKey.Value = keyValue
+		} else {
+			// Deferred resources use [addrs.WildcardKey] to indicate the resource key is unknown
+			resourceKeyUnknown = true
+		}
 	}
 	return ResourceAddr{
-		Addr:            addr.String(),
-		Module:          addr.Module.String(),
-		Resource:        addr.Resource.String(),
-		ImpliedProvider: addr.Resource.Resource.ImpliedProvider(),
-		ResourceType:    addr.Resource.Resource.Type,
-		ResourceName:    addr.Resource.Resource.Name,
-		ResourceKey:     resourceKey,
+		Addr:               addr.String(),
+		Module:             addr.Module.String(),
+		Resource:           addr.Resource.String(),
+		ImpliedProvider:    addr.Resource.Resource.ImpliedProvider(),
+		ResourceType:       addr.Resource.Resource.Type,
+		ResourceName:       addr.Resource.Resource.Name,
+		ResourceKey:        resourceKey,
+		ResourceKeyUnknown: resourceKeyUnknown,
 	}
 }

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -97,6 +97,14 @@ func (v *JSONView) PlannedChange(c *json.ResourceInstanceChange) {
 	)
 }
 
+func (v *JSONView) DeferredChange(dc *json.DeferredResourceInstanceChange) {
+	v.log.Info(
+		dc.String(),
+		"type", json.MessageDeferredChange,
+		"deferred_change", dc,
+	)
+}
+
 func (v *JSONView) PlannedActionInvocation(action *json.ActionInvocation) {
 	v.log.Info(
 		fmt.Sprintf("planned action invocation: %s", action.Action.Action),

--- a/internal/command/views/json_view_test.go
+++ b/internal/command/views/json_view_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	viewsjson "github.com/hashicorp/terraform/internal/command/views/json"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	tfversion "github.com/hashicorp/terraform/version"
@@ -435,6 +436,99 @@ func TestJSONView_Outputs(t *testing.T) {
 					"sensitive": true,
 					"value":     "horse-battery",
 					"type":      "string",
+				},
+			},
+		},
+	}
+	testJSONViewOutputEquals(t, done(t).Stdout(), want)
+}
+
+func TestJSONView_DeferredChange(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	jv := NewJSONView(NewView(streams))
+
+	foo, diags := addrs.ParseModuleInstanceStr("module.foo")
+	if len(diags) > 0 {
+		t.Fatal(diags.Err())
+	}
+	managed := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_instance", Name: "bar"}
+	cs := &plans.ResourceInstanceChangeSrc{
+		Addr:        managed.Instance(addrs.NoKey).Absolute(foo),
+		PrevRunAddr: managed.Instance(addrs.NoKey).Absolute(foo),
+		ChangeSrc: plans.ChangeSrc{
+			Action: plans.Create,
+		},
+	}
+	dc := &plans.DeferredResourceInstanceChangeSrc{
+		DeferredReason: providers.DeferredReasonResourceConfigUnknown,
+		ChangeSrc:      cs,
+	}
+	jv.DeferredChange(viewsjson.NewDeferredResourceInstanceChange(dc))
+
+	want := []map[string]interface{}{
+		{
+			"@level":   "info",
+			"@message": "module.foo.test_instance.bar: deferred change, reason: resource_config_unknown",
+			"@module":  "terraform.ui",
+			"type":     "deferred_change",
+			"deferred_change": map[string]interface{}{
+				"reason": "resource_config_unknown",
+				"change": map[string]interface{}{
+					"action": "create",
+					"resource": map[string]interface{}{
+						"addr":             "module.foo.test_instance.bar",
+						"implied_provider": "test",
+						"module":           "module.foo",
+						"resource":         "test_instance.bar",
+						"resource_key":     nil,
+						"resource_name":    "bar",
+						"resource_type":    "test_instance",
+					},
+				},
+			},
+		},
+	}
+	testJSONViewOutputEquals(t, done(t).Stdout(), want)
+}
+
+func TestJSONView_DeferredChange_UnknownKey(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	jv := NewJSONView(NewView(streams))
+
+	managed := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_instance", Name: "bar"}
+	cs := &plans.ResourceInstanceChangeSrc{
+		Addr:        managed.Instance(addrs.WildcardKey).Absolute(addrs.RootModuleInstance),
+		PrevRunAddr: managed.Instance(addrs.WildcardKey).Absolute(addrs.RootModuleInstance),
+		ChangeSrc: plans.ChangeSrc{
+			Action: plans.Create,
+		},
+	}
+	dc := &plans.DeferredResourceInstanceChangeSrc{
+		DeferredReason: providers.DeferredReasonInstanceCountUnknown,
+		ChangeSrc:      cs,
+	}
+	jv.DeferredChange(viewsjson.NewDeferredResourceInstanceChange(dc))
+
+	want := []map[string]interface{}{
+		{
+			"@level":   "info",
+			"@message": "test_instance.bar[*]: deferred change, reason: instance_count_unknown",
+			"@module":  "terraform.ui",
+			"type":     "deferred_change",
+			"deferred_change": map[string]interface{}{
+				"reason": "instance_count_unknown",
+				"change": map[string]interface{}{
+					"action": "create",
+					"resource": map[string]interface{}{
+						"addr":                 "test_instance.bar[*]",
+						"implied_provider":     "test",
+						"module":               "",
+						"resource":             "test_instance.bar[*]",
+						"resource_key":         nil,
+						"resource_key_unknown": true,
+						"resource_name":        "bar",
+						"resource_type":        "test_instance",
+					},
 				},
 			},
 		},

--- a/internal/command/views/operation.go
+++ b/internal/command/views/operation.go
@@ -96,7 +96,7 @@ func (v *OperationHuman) EmergencyDumpState(stateFile *statefile.File) error {
 }
 
 func (v *OperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
-	outputs, changed, drift, attrs, actions, err := jsonplan.MarshalForRenderer(plan, schemas)
+	outputs, changed, drift, attrs, actions, deferredChanges, err := jsonplan.MarshalForRenderer(plan, schemas)
 	if err != nil {
 		v.view.streams.Eprintf("Failed to marshal plan to json: %s", err)
 		return
@@ -117,6 +117,7 @@ func (v *OperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
 		ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 		RelevantAttributes:    attrs,
 		ActionInvocations:     actions,
+		DeferredChanges:       deferredChanges,
 	}
 
 	// Side load some data that we can't extract from the JSON plan.
@@ -282,6 +283,10 @@ func (v *OperationJSON) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
 	}
 	if len(rootModuleOutputs) > 0 {
 		v.view.Outputs(json.OutputsFromChanges(rootModuleOutputs))
+	}
+
+	for _, deferredChange := range plan.DeferredResources {
+		v.view.DeferredChange(json.NewDeferredResourceInstanceChange(deferredChange))
 	}
 }
 

--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/lang/globalref"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/terminal"
@@ -470,6 +471,44 @@ func TestOperation_planNextStepInAutomation(t *testing.T) {
 
 	if got := done(t).Stdout(); got != "" {
 		t.Errorf("unexpected output\ngot: %q", got)
+	}
+}
+
+func TestOperation_planWithDeferredChange(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	v := NewOperation(arguments.ViewHuman, true, NewView(streams))
+
+	plan := testPlanWithDeferredChanges(t)
+	schemas := testSchemas()
+	v.Plan(plan, schemas)
+
+	want := `
+Note: This is a partial plan, parts can only be known in the next plan / apply cycle.
+
+
+  # test_resource.deferred was deferred
+  # (because the resource configuration is unknown)
+  + resource "test_resource" "deferred" {}
+
+─────────────────────────────────────────────────────────────────────────────
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # test_resource.foo will be created
+  + resource "test_resource" "foo" {
+      + foo = "bar"
+      + id  = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+`
+
+	if got := done(t).Stdout(); got != want {
+		t.Errorf("unexpected output\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1556,6 +1595,138 @@ func TestOperationJSON_plannedChange(t *testing.T) {
 					"resource_key":     float64(1),
 					"resource_name":    "boop",
 					"resource_type":    "test_instance",
+				},
+			},
+		},
+	}
+
+	testJSONViewOutputEquals(t, done(t).Stdout(), want)
+}
+
+func TestOperationJSON_planWithDeferredChange(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	v := &OperationJSON{view: NewJSONView(NewView(streams))}
+
+	boop := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_instance", Name: "boop"}
+	plan := &plans.Plan{
+		Changes: &plans.ChangesSrc{
+			Resources: []*plans.ResourceInstanceChangeSrc{},
+		},
+		DeferredResources: []*plans.DeferredResourceInstanceChangeSrc{
+			{
+				DeferredReason: providers.DeferredReasonResourceConfigUnknown,
+				ChangeSrc: &plans.ResourceInstanceChangeSrc{
+					Addr:        boop.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					PrevRunAddr: boop.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					ChangeSrc:   plans.ChangeSrc{Action: plans.Create},
+				},
+			},
+		},
+	}
+	schemas := testSchemas()
+	v.Plan(plan, schemas)
+
+	want := []map[string]interface{}{
+		{
+			"@level":   "info",
+			"@message": "Plan: 0 to add, 0 to change, 0 to destroy.",
+			"@module":  "terraform.ui",
+			"type":     "change_summary",
+			"changes": map[string]interface{}{
+				"operation":         "plan",
+				"action_fail":       float64(0),
+				"action_invocation": float64(0),
+				"add":               float64(0),
+				"import":            float64(0),
+				"change":            float64(0),
+				"remove":            float64(0),
+			},
+		},
+		{
+			"@level":   "info",
+			"@message": "test_instance.boop: deferred change, reason: resource_config_unknown",
+			"@module":  "terraform.ui",
+			"type":     "deferred_change",
+			"deferred_change": map[string]interface{}{
+				"reason": "resource_config_unknown",
+				"change": map[string]interface{}{
+					"action": "create",
+					"resource": map[string]interface{}{
+						"addr":             "test_instance.boop",
+						"implied_provider": "test",
+						"module":           "",
+						"resource":         "test_instance.boop",
+						"resource_key":     nil,
+						"resource_name":    "boop",
+						"resource_type":    "test_instance",
+					},
+				},
+			},
+		},
+	}
+
+	testJSONViewOutputEquals(t, done(t).Stdout(), want)
+}
+
+func TestOperationJSON_planWithDeferredChange_unknownKey(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	v := &OperationJSON{view: NewJSONView(NewView(streams))}
+
+	root := addrs.RootModuleInstance
+	boop := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_instance", Name: "boop"}
+
+	plan := &plans.Plan{
+		Changes: &plans.ChangesSrc{
+			Resources: []*plans.ResourceInstanceChangeSrc{},
+		},
+		DeferredResources: []*plans.DeferredResourceInstanceChangeSrc{
+			{
+				DeferredReason: providers.DeferredReasonInstanceCountUnknown,
+				ChangeSrc: &plans.ResourceInstanceChangeSrc{
+					Addr:        boop.Instance(addrs.WildcardKey).Absolute(root),
+					PrevRunAddr: boop.Instance(addrs.WildcardKey).Absolute(root),
+					ChangeSrc:   plans.ChangeSrc{Action: plans.Create},
+				},
+			},
+		},
+	}
+	v.Plan(plan, testSchemas())
+
+	want := []map[string]interface{}{
+		{
+			"@level":   "info",
+			"@message": "Plan: 0 to add, 0 to change, 0 to destroy.",
+			"@module":  "terraform.ui",
+			"type":     "change_summary",
+			"changes": map[string]interface{}{
+				"operation":         "plan",
+				"action_fail":       float64(0),
+				"action_invocation": float64(0),
+				"add":               float64(0),
+				"import":            float64(0),
+				"change":            float64(0),
+				"remove":            float64(0),
+			},
+		},
+		{
+			"@level":   "info",
+			"@message": "test_instance.boop[*]: deferred change, reason: instance_count_unknown",
+			"@module":  "terraform.ui",
+			"type":     "deferred_change",
+			"deferred_change": map[string]interface{}{
+				"reason": "instance_count_unknown",
+				"change": map[string]interface{}{
+					"action": "create",
+					"resource": map[string]interface{}{
+						"addr":                 "test_instance.boop[*]",
+						"implied_provider":     "test",
+						"module":               "",
+						"resource":             "test_instance.boop[*]",
+						"resource_key":         nil,
+						"resource_key_unknown": true,
+						"resource_name":        "boop",
+						"resource_type":        "test_instance",
+					},
 				},
 			},
 		},

--- a/internal/command/views/plan_test.go
+++ b/internal/command/views/plan_test.go
@@ -134,6 +134,37 @@ func testPlanWithDatasource(t *testing.T) *plans.Plan {
 	return plan
 }
 
+func testPlanWithDeferredChanges(t *testing.T) *plans.Plan {
+	t.Helper()
+
+	plan := testPlan(t)
+
+	deferredAddr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "test_resource",
+		Name: "deferred",
+	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
+
+	plan.DeferredResources = []*plans.DeferredResourceInstanceChangeSrc{
+		{
+			DeferredReason: providers.DeferredReasonResourceConfigUnknown,
+			ChangeSrc: &plans.ResourceInstanceChangeSrc{
+				Addr:        deferredAddr,
+				PrevRunAddr: deferredAddr,
+				ProviderAddr: addrs.AbsProviderConfig{
+					Provider: addrs.NewDefaultProvider("test"),
+					Module:   addrs.RootModule,
+				},
+				ChangeSrc: plans.ChangeSrc{
+					Action: plans.Create,
+				},
+			},
+		},
+	}
+
+	return plan
+}
+
 func testSchemas() *terraform.Schemas {
 	provider := testProvider()
 	return &terraform.Schemas{

--- a/internal/command/views/show.go
+++ b/internal/command/views/show.go
@@ -91,7 +91,7 @@ func (v *ShowHuman) Display(config *configs.Config, plan *plans.Plan, planJSON *
 		renderer.RenderHumanPlan(p, planJSON.Mode, planJSON.Qualities...)
 		v.view.streams.Print(v.view.colorize.Color("\n" + planJSON.RunFooter + "\n"))
 	} else if plan != nil {
-		outputs, changed, drift, attrs, actions, err := jsonplan.MarshalForRenderer(plan, schemas)
+		outputs, changed, drift, attrs, actions, deferredChanges, err := jsonplan.MarshalForRenderer(plan, schemas)
 		if err != nil {
 			v.view.streams.Eprintf("Failed to marshal plan to json: %s", err)
 			return 1
@@ -106,6 +106,7 @@ func (v *ShowHuman) Display(config *configs.Config, plan *plans.Plan, planJSON *
 			ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 			RelevantAttributes:    attrs,
 			ActionInvocations:     actions,
+			DeferredChanges:       deferredChanges,
 		}
 
 		var opts []plans.Quality

--- a/internal/command/views/show_test.go
+++ b/internal/command/views/show_test.go
@@ -214,6 +214,76 @@ func TestShowJSON(t *testing.T) {
 	}
 }
 
+func TestShowHuman_planWithDeferredChange(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	view.Configure(&arguments.View{NoColor: true})
+	v := NewShow(arguments.ViewHuman, view)
+
+	code := v.Display(nil, testPlanWithDeferredChanges(t), nil, nil, testSchemas())
+	if code != 0 {
+		t.Errorf("expected 0 return code, got %d", code)
+	}
+
+	want := `
+Note: This is a partial plan, parts can only be known in the next plan / apply cycle.
+
+
+  # test_resource.deferred was deferred
+  # (because the resource configuration is unknown)
+  + resource "test_resource" "deferred" {}
+
+─────────────────────────────────────────────────────────────────────────────
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # test_resource.foo will be created
+  + resource "test_resource" "foo" {
+      + foo = "bar"
+      + id  = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+`
+
+	if got := done(t).Stdout(); got != want {
+		t.Errorf("unexpected output\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestShowJSON_planWithDeferredChange(t *testing.T) {
+	config, _, configCleanup := tftesting.MustLoadConfigForTests(t, "./testdata/show", "tests")
+	defer configCleanup()
+
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	view.Configure(&arguments.View{NoColor: true})
+	v := NewShow(arguments.ViewJSON, view)
+
+	code := v.Display(config, testPlanWithDeferredChanges(t), nil, nil, testSchemas())
+	if code != 0 {
+		t.Errorf("expected 0 return code, got %d", code)
+	}
+
+	var result map[string]interface{}
+	got := done(t).All()
+	if err := json.Unmarshal([]byte(got), &result); err != nil {
+		t.Fatal(err)
+	}
+	deferredChanges, ok := result["deferred_changes"]
+	if !ok {
+		t.Fatalf("expected JSON output to contain 'deferred_changes', got: %s", got)
+	}
+	deferredList, ok := deferredChanges.([]interface{})
+	if !ok || len(deferredList) == 0 {
+		t.Errorf("expected at least one deferred change in output, got: %v", deferredChanges)
+	}
+}
+
 // testState returns a test State structure.
 func testState() *states.State {
 	return states.BuildState(func(s *states.SyncState) {

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -212,7 +212,7 @@ func (t *TestHuman) Run(run *moduletest.Run, file *moduletest.File, progress mod
 			}
 		} else {
 			// We'll print the plan.
-			outputs, changed, drift, attrs, actions, err := jsonplan.MarshalForRenderer(run.Verbose.Plan, schemas)
+			outputs, changed, drift, attrs, actions, deferredChanges, err := jsonplan.MarshalForRenderer(run.Verbose.Plan, schemas)
 			if err != nil {
 				run.Diagnostics = run.Diagnostics.Append(tfdiags.Sourceless(
 					tfdiags.Warning,
@@ -228,6 +228,7 @@ func (t *TestHuman) Run(run *moduletest.Run, file *moduletest.File, progress mod
 					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 					RelevantAttributes:    attrs,
 					ActionInvocations:     actions,
+					DeferredChanges:       deferredChanges,
 				}
 
 				var opts []plans.Quality
@@ -590,7 +591,7 @@ func (t *TestJSON) Run(run *moduletest.Run, file *moduletest.File, progress modu
 					"@testrun", run.Name)
 			}
 		} else {
-			outputs, changed, drift, attrs, actions, err := jsonplan.MarshalForRenderer(run.Verbose.Plan, schemas)
+			outputs, changed, drift, attrs, actions, deferredChanges, err := jsonplan.MarshalForRenderer(run.Verbose.Plan, schemas)
 			if err != nil {
 				run.Diagnostics = run.Diagnostics.Append(tfdiags.Sourceless(
 					tfdiags.Warning,
@@ -606,6 +607,7 @@ func (t *TestJSON) Run(run *moduletest.Run, file *moduletest.File, progress modu
 					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 					RelevantAttributes:    attrs,
 					ActionInvocations:     actions,
+					DeferredChanges:       deferredChanges,
 				}
 
 				t.view.log.Info(


### PR DESCRIPTION
Related PRs:
- https://github.com/hashicorp/terraform/pull/35065
- https://github.com/hashicorp/terraform/pull/35542

This PR hooks up the existing logic for rendering deferred changes to the human and JSON views. The `-allow-deferral` flag is still experimental, so this rendering can only show up in alpha builds for the moment 👍🏻.

### Two things of note in this PR
1. Since the JSON view for resource addresses contains the resource key value, and deferred changes can be caused by unknown index keys 😅 , I added a `resource_key_unknown` field as we can't render unknown values in JSON. It feels likely consumers would want to determine how to display this info rather than just sending `null` 👍🏻
2. I didn't include `plan.Complete` in the JSON output, since you can derive that from checking if `plan.DeferredChanges > 0`, which seems to be how we determine `plan.Applyable` and `plan.Errored` (and there wasn't an obvious place to include it 😅 ) 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x (next alpha)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing. (alpha only)
