### PR TITLE
fix: close plugin manifest cache file after writing to avoid fd leak

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260821-193021.yaml
+++ b/.changes/v1.17/BUG FIXES-20260821-193021.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Close the plugin manifest cache file after writing to avoid leaking file descriptors.
+time: 2026-08-21T19:30:21Z
+custom:
+    Issue: "38302"

--- a/internal/pluginshared/binary.go
+++ b/internal/pluginshared/binary.go
@@ -238,13 +238,7 @@ func (v BinaryManager) latestManifest(ctx context.Context) (*Release, error) {
 			return nil, fmt.Errorf("failed to create %s manifest cache directory: %w", v.pluginName, err)
 		}
 
-		output, err := os.Create(manifestCacheLocation)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create %s manifest cache: %w", v.pluginName, err)
-		}
-
-		_, err = output.Write(data)
-		if err != nil {
+		if err := os.WriteFile(manifestCacheLocation, data, 0666); err != nil {
 			return nil, fmt.Errorf("failed to write %s manifest cache: %w", v.pluginName, err)
 		}
 		log.Printf("[TRACE] wrote %s manifest cache to %q", v.pluginName, manifestCacheLocation)

--- a/internal/pluginshared/binary_fdleak_test.go
+++ b/internal/pluginshared/binary_fdleak_test.go
@@ -1,0 +1,98 @@
+//go:build darwin || linux
+
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package pluginshared
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestBinaryManager_latestManifestClosesCacheFile is a regression test for
+// https://github.com/hashicorp/terraform/issues/38302: writing the plugin
+// manifest cache previously leaked the file descriptor created by os.Create.
+func TestBinaryManager_latestManifestClosesCacheFile(t *testing.T) {
+	oldGCPercent := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(oldGCPercent)
+
+	server, err := newCloudPluginManifestHTTPTestServer(t)
+	if err != nil {
+		t.Fatalf("could not create test server: %s", err)
+	}
+	defer server.Close()
+
+	serverURL, _ := url.Parse(server.URL)
+	serviceURL := serverURL.JoinPath("/api/cloudplugin/v1")
+
+	// Use a single manager so that repeated iterations share the same HTTP
+	// client and connection pool; this test is only interested in leaked file
+	// descriptors from writing the manifest cache.
+	manager, err := NewCloudBinaryManager(context.Background(), t.TempDir(), "", serviceURL, "darwin", "amd64")
+	if err != nil {
+		t.Fatalf("expected no err, got: %s", err)
+	}
+
+	manifestCacheLocation := filepath.Join(manager.pluginDataDir, manager.host.String(), "manifest.json")
+
+	// Do an initial fetch to warm up the HTTP connection pool, then take the
+	// baseline file descriptor count.
+	if _, err := manager.latestManifest(context.Background()); err != nil {
+		t.Fatalf("fetching manifest on warmup iteration: %s", err)
+	}
+	before := countOpenPluginsharedFDs(t)
+
+	const iterations = 16
+	for i := range iterations {
+		// Remove the cache file so that latestManifest takes the path that
+		// writes a new manifest cache file on every iteration.
+		if err := os.RemoveAll(manifestCacheLocation); err != nil {
+			t.Fatalf("removing manifest cache on iteration %d: %s", i, err)
+		}
+
+		if _, err := manager.latestManifest(context.Background()); err != nil {
+			t.Fatalf("fetching manifest on iteration %d: %s", i, err)
+		}
+
+		if _, err := os.Stat(manifestCacheLocation); err != nil {
+			t.Fatalf("expected manifest cache %q to have been written on iteration %d: %s", manifestCacheLocation, i, err)
+		}
+	}
+
+	after := countOpenPluginsharedFDs(t)
+	if leaked := after - before; leaked > 2 {
+		t.Fatalf("expected latestManifest to close its file descriptor, but open descriptor count increased by %d", leaked)
+	}
+}
+
+func countOpenPluginsharedFDs(t *testing.T) int {
+	t.Helper()
+
+	var limit unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &limit); err != nil {
+		t.Fatalf("reading RLIMIT_NOFILE: %s", err)
+	}
+
+	maxFD := int(limit.Cur)
+	if maxFD > 4096 {
+		maxFD = 4096
+	}
+
+	openDescriptors := 0
+	for fd := range maxFD {
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0); err == nil {
+			openDescriptors++
+		} else if err != unix.EBADF {
+			t.Fatalf("checking file descriptor %d: %s", fd, err)
+		}
+	}
+
+	return openDescriptors
+}


### PR DESCRIPTION
## What

`BinaryManager.latestManifest` wrote the plugin manifest cache via `os.Create` + `file.Write` but never closed the file, leaking one file descriptor for every manifest cache refresh. (This is the companion leak called out in the *Additional Context* of #38302 — #38311 fixed the `modsdir.WriteSnapshotToDir` instance; this PR fixes the `internal/pluginshared/binary.go` one.)

## How

Replace the create/write pair with a single `os.WriteFile(..., 0666)` call. It has identical semantics — open/create with truncate, mode 0666 before umask applied only when creating a new file, existing file permissions retained — but closes the descriptor on all paths, including write errors.

## Regression test

`TestBinaryManager_latestManifestClosesCacheFile` repeatedly rewrites the manifest cache (deleting the cache file each iteration, sharing one HTTP client) and asserts the open file descriptor count stays flat. It fails without this change (leaked ~2 fds/iteration in a tighter loop variant) and passes with it. `go test ./internal/pluginshared/` passes at `main` with this change.

## AI assistance

Per the Contributing guide's AI Usage section: this PR was implemented with the help of an AI coding agent. The change is small and was reviewed line-by-line by the human contributor; the test approach mirrors the one in #38311 for the sibling fix.

Changelog entry included via changie (`.changes/v1.17/BUG FIXES-20260821-193021.yaml`), referencing #38302.
