### PR TITLE
checks: hold mutex in State.ObjectFailureMessages (fixes data race)

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260821-195800.yaml
+++ b/.changes/v1.17/BUG FIXES-20260821-195800.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix a data race in checks.State.ObjectFailureMessages by holding the state mutex while reading check statuses and failure messages.
+time: 2026-08-21T19:58:00Z
+custom:
+    Issue: "38578"

--- a/internal/checks/state.go
+++ b/internal/checks/state.go
@@ -260,6 +260,12 @@ func (c *State) ObjectCheckStatus(addr addrs.Checkable) Status {
 func (c *State) ObjectFailureMessages(addr addrs.Checkable) []string {
 	var ret []string
 
+	// We must hold the mutex here, like the other methods that access our
+	// internals, because concurrent graph walk goroutines can be updating
+	// statuses and failure messages while we read them.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	configAddr := addr.ConfigCheckable()
 
 	st, ok := c.statuses.GetOk(configAddr)

--- a/internal/checks/state_test.go
+++ b/internal/checks/state_test.go
@@ -4,6 +4,7 @@
 package checks_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -210,4 +211,53 @@ func TestChecksHappyPath(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestObjectFailureMessagesConcurrent is a regression test for
+// https://github.com/hashicorp/terraform/issues/38578: ObjectFailureMessages
+// previously read the shared state without holding the mutex, so concurrent
+// reporters (as during a graph walk) raced with readers.
+func TestObjectFailureMessagesConcurrent(t *testing.T) {
+	const fixtureDir = "testdata/happypath"
+
+	cfg, _, configCleanup := tftesting.MustLoadConfigForTests(t, fixtureDir, "tests")
+	t.Cleanup(configCleanup)
+
+	state := checks.NewState(cfg)
+
+	resourceInstA := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "null_resource",
+		Name: "a",
+	}.InModule(addrs.RootModule).Resource.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey)
+	resourceA := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "null_resource",
+		Name: "a",
+	}.InModule(addrs.RootModule)
+
+	state.ReportCheckableObjects(resourceA, addrs.MakeSet[addrs.Checkable](resourceInstA))
+
+	var wg sync.WaitGroup
+	// One reporter, simulating a graph walk goroutine. Each check for this
+	// object may only be reported once, and a failure report also writes to
+	// the shared failure message map.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		state.ReportCheckResult(resourceInstA, addrs.ResourcePrecondition, 0, checks.StatusPass)
+		state.ReportCheckResult(resourceInstA, addrs.ResourcePrecondition, 1, checks.StatusPass)
+		state.ReportCheckFailure(resourceInstA, addrs.ResourcePostcondition, 0, "boom")
+	}()
+	// Readers, calling the method that previously did not hold the mutex.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_ = state.ObjectFailureMessages(resourceInstA)
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## What

`checks.State.ObjectFailureMessages` read the shared check status and failure message maps (`c.statuses`, `c.failureMsgs`) without holding `c.mu`, while graph walk goroutines concurrently update them via `ReportCheckResult`/`ReportCheckFailure` under the lock. Detectable with `go test -race ./internal/checks/...`, and reported in #38578.

## How

Hold `c.mu.Lock()` for the duration of `ObjectFailureMessages`, matching every other method on `State`. I verified there is no caller that already holds the mutex: the only in-repo caller is `internal/states.checkResultsSnapshot`, which uses the public API exclusively, so this cannot introduce a deadlock.

## Regression test

`TestObjectFailureMessagesConcurrent` runs one reporter goroutine (matching real use: each check index can only be reported once) while several reader goroutines hammer `ObjectFailureMessages` for the same object. Under `-race` the test produces multiple `WARNING: DATA RACE` reports on the unpatched code and passes cleanly with this change. `go test -race ./internal/checks/` passes at `main`.

## AI assistance

Per the Contributing guide's AI Usage section: this PR was implemented with the help of an AI coding agent, and reviewed line-by-line by the human contributor. (Noting that earlier PRs for the same issue were closed for process reasons; I commented my proposal on #38578 first, and this PR follows the Contributing guide, including the changelog entry.)

Changelog entry included via changie (`.changes/v1.17/BUG FIXES-20260821-195800.yaml`), referencing #38578.

Fixes #38578
