### PR TITLE
🤖🤖🤖 fix: avoid hang reusing cached git modules with nil Version

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260824-164739.yaml
+++ b/.changes/v1.17/BUG FIXES-20260824-164739.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: init no longer hangs when reusing a cached git:: module with no manifest Version
+time: 2026-08-24T16:47:39.000000+00:00
+custom:
+  Issue: "39047"

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -281,20 +281,25 @@ func (i *ModuleInstaller) moduleInstallWalker(ctx context.Context, manifest mods
 						diags = diags.Extend(mDiags)
 					}
 
+					var versionStr string
+					if record.Version != nil {
+						versionStr = record.Version.String()
+					}
+
 					if !diags.HasErrors() {
 						// inform the hooks that the module source has been resolved
 						hookDiags := i.CallHooks(hooks, func(hook ModuleInstallHook) tfdiags.Diagnostics {
-							var versionStr string
-							if record.Version != nil {
-								versionStr = record.Version.String()
-							}
 							inDiags := hook.ModuleSourceResolved(ctx, req, versionStr)
 							return inDiags
 						})
 						diags = diags.Extend(hookDiags.ToHCL())
 					}
 
-					log.Printf("[TRACE] ModuleInstaller: Module installer: %s %s already installed in %s", key, record.Version, record.Dir)
+					if record.Version != nil {
+						log.Printf("[TRACE] ModuleInstaller: Module installer: %s %s already installed in %s", key, versionStr, record.Dir)
+					} else {
+						log.Printf("[TRACE] ModuleInstaller: Module installer: %s already installed in %s", key, record.Dir)
+					}
 					return mod, record.Version, diags
 				}
 			}

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -10,9 +10,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-test/deep"
@@ -1074,6 +1076,78 @@ func TestLoadInstallModules_registryFromTest(t *testing.T) {
 
 	if config.Module.Tests["main.tftest.hcl"].Runs[0].ConfigUnderTest == nil {
 		t.Fatalf("should have loaded config into the relevant run block but did not")
+	}
+}
+
+
+func TestModuleInstaller_reinstallCachedGitModuleNilVersion(t *testing.T) {
+	// Regression for https://github.com/hashicorp/terraform/issues/39047
+	// A second install of a cached git:: module (no Version in the manifest)
+	// used to hang while formatting a nil *version.Version in a TRACE log.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for this test")
+	}
+
+	work := t.TempDir()
+	repo := filepath.Join(work, "fixture-module.git")
+	module := filepath.Join(work, "module")
+	root := filepath.Join(work, "root")
+	for _, d := range []string{module, root} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=fixture",
+			"GIT_AUTHOR_EMAIL=fixture@example.invalid",
+			"GIT_COMMITTER_NAME=fixture",
+			"GIT_COMMITTER_EMAIL=fixture@example.invalid",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v in %s: %s\n%s", args, dir, err, out)
+		}
+	}
+
+	run(work, "git", "init", "--bare", repo)
+	run(module, "git", "init")
+	if err := os.WriteFile(filepath.Join(module, "main.tf"), []byte("terraform {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(module, "git", "add", "main.tf")
+	run(module, "git", "commit", "-m", "fixture")
+	run(module, "git", "remote", "add", "origin", "file://"+repo)
+	run(module, "git", "push", "origin", "HEAD:main")
+
+	mainTF := fmt.Sprintf("module \"fixture\" {\n  source = \"git::file://%s\"\n}\n", repo)
+	if err := os.WriteFile(filepath.Join(root, "main.tf"), []byte(mainTF), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modulesDir := filepath.Join(root, ".terraform/modules")
+	loader, closeLoader := configload.NewLoaderForTests(t)
+	defer closeLoader()
+	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+
+	_, diags := inst.InstallModules(context.Background(), root, "tests", false, false)
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	// Second install must reuse the cached git module (nil Version) without hanging.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, diags = inst.InstallModules(context.Background(), root, "tests", false, false)
+	}()
+	select {
+	case <-done:
+		tfdiags.AssertNoDiagnostics(t, diags)
+	case <-time.After(30 * time.Second):
+		t.Fatal("second InstallModules hung reusing cached git:: module with nil Version")
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes a hang on a second `terraform init` when a `git::` module is already cached and the module manifest has no `Version` (common for non-registry git sources).

A TRACE log was formatting a nil `*version.Version` with `%s`, which calls `go-version`'s `String` method and hangs. The hook path already guarded this; the log line did not.

## Changes
- Guard the “already installed” TRACE log when `record.Version` is nil (same shape as the existing hook path).
- Add a regression test that double-installs a local `git::file://` module and fails if the second install hangs.

Fixes #39047

## Test plan
- [x] `go test ./internal/initwd/ -run TestModuleInstaller_reinstallCachedGitModuleNilVersion`
- [ ] Manual: repro from #39047 (first `init` ok, second `init` no longer hangs)

## AI usage
I used an AI coding assistant to help inspect the hang path and draft the regression test fixture. I reviewed the change, kept the scope to the TRACE nil-guard plus that test, and can explain the logic.

This PR is a **draft** / optional sketch. I should have proposed the approach on #39047 first (see the comment there). Happy to close or reshape this if the maintainers would rather not review an unsolicited PR.
