### PR TITLE
jsonplan: Refactor `MarshalForRenderer` to return the plan struct rather than separate returns

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -55,9 +55,9 @@ const (
 	DeferredReasonAbsentPrereq          = "absent_prereq"
 )
 
-// plan is the top-level representation of the json format of a plan. It includes
+// Plan is the top-level representation of the json format of a plan. It includes
 // the complete config and current state.
-type plan struct {
+type Plan struct {
 	FormatVersion    string      `json:"format_version,omitempty"`
 	TerraformVersion string      `json:"terraform_version,omitempty"`
 	Variables        variables   `json:"variables,omitempty"`
@@ -80,8 +80,8 @@ type plan struct {
 	Errored                   bool                       `json:"errored"`
 }
 
-func newPlan() *plan {
-	return &plan{
+func newPlan() *Plan {
+	return &Plan{
 		FormatVersion: FormatVersion,
 	}
 }
@@ -200,19 +200,16 @@ type variable struct {
 //
 // This function does a small part of the Marshal function, as it only returns
 // the part of the plan required by the jsonformat.Plan renderer.
-func MarshalForRenderer(
-	p *plans.Plan,
-	schemas *terraform.Schemas,
-) (map[string]Change, []ResourceChange, []ResourceChange, []ResourceAttr, []ActionInvocation, []DeferredResourceChange, error) {
+func MarshalForRenderer(p *plans.Plan, schemas *terraform.Schemas) (*Plan, error) {
 	output := newPlan()
 
 	var err error
 	if output.OutputChanges, err = MarshalOutputChanges(p.Changes); err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, err
 	}
 
 	if output.ResourceChanges, err = MarshalResourceChanges(p.Changes.Resources, schemas); err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, err
 	}
 
 	if len(p.DriftedResources) > 0 {
@@ -232,26 +229,26 @@ func MarshalForRenderer(
 		}
 		output.ResourceDrift, err = MarshalResourceChanges(driftedResources, schemas)
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, err
+			return nil, err
 		}
 	}
 
 	if err := output.marshalRelevantAttrs(p); err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, err
 	}
 
 	if output.ActionInvocations, err = MarshalActionInvocations(p.Changes.ActionInvocations, schemas); err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, err
 	}
 
 	if len(p.DeferredResources) > 0 {
 		output.DeferredChanges, err = MarshalDeferredResourceChanges(p.DeferredResources, schemas)
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, err
+			return nil, err
 		}
 	}
 
-	return output.OutputChanges, output.ResourceChanges, output.ResourceDrift, output.RelevantAttributes, output.ActionInvocations, output.DeferredChanges, nil
+	return output, nil
 }
 
 // Marshal returns the json encoding of a terraform plan.
@@ -361,7 +358,7 @@ func Marshal(
 	return json.Marshal(output)
 }
 
-func (p *plan) marshalPlanVariables(vars map[string]plans.DynamicValue, decls map[string]*configs.Variable) error {
+func (p *Plan) marshalPlanVariables(vars map[string]plans.DynamicValue, decls map[string]*configs.Variable) error {
 	p.Variables = make(variables, len(vars))
 
 	for k, v := range vars {
@@ -805,7 +802,7 @@ func MarshalOutputChanges(changes *plans.ChangesSrc) (map[string]Change, error) 
 	return outputChanges, nil
 }
 
-func (p *plan) marshalPlannedValues(changes *plans.ChangesSrc, schemas *terraform.Schemas) error {
+func (p *Plan) marshalPlannedValues(changes *plans.ChangesSrc, schemas *terraform.Schemas) error {
 	// marshal the planned changes into a module
 	plan, err := marshalPlannedValues(changes, schemas)
 	if err != nil {
@@ -823,7 +820,7 @@ func (p *plan) marshalPlannedValues(changes *plans.ChangesSrc, schemas *terrafor
 	return nil
 }
 
-func (p *plan) marshalRelevantAttrs(plan *plans.Plan) error {
+func (p *Plan) marshalRelevantAttrs(plan *plans.Plan) error {
 	for _, ra := range plan.RelevantAttributes {
 		addr := ra.Resource.String()
 		path, err := encodePath(ra.Attr)

--- a/internal/command/views/operation.go
+++ b/internal/command/views/operation.go
@@ -96,7 +96,7 @@ func (v *OperationHuman) EmergencyDumpState(stateFile *statefile.File) error {
 }
 
 func (v *OperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
-	outputs, changed, drift, attrs, actions, deferredChanges, err := jsonplan.MarshalForRenderer(plan, schemas)
+	jsonPlan, err := jsonplan.MarshalForRenderer(plan, schemas)
 	if err != nil {
 		v.view.streams.Eprintf("Failed to marshal plan to json: %s", err)
 		return
@@ -111,13 +111,13 @@ func (v *OperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
 	jplan := jsonformat.Plan{
 		PlanFormatVersion:     jsonplan.FormatVersion,
 		ProviderFormatVersion: jsonprovider.FormatVersion,
-		OutputChanges:         outputs,
-		ResourceChanges:       changed,
-		ResourceDrift:         drift,
+		OutputChanges:         jsonPlan.OutputChanges,
+		ResourceChanges:       jsonPlan.ResourceChanges,
+		ResourceDrift:         jsonPlan.ResourceDrift,
 		ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
-		RelevantAttributes:    attrs,
-		ActionInvocations:     actions,
-		DeferredChanges:       deferredChanges,
+		RelevantAttributes:    jsonPlan.RelevantAttributes,
+		ActionInvocations:     jsonPlan.ActionInvocations,
+		DeferredChanges:       jsonPlan.DeferredChanges,
 	}
 
 	// Side load some data that we can't extract from the JSON plan.

--- a/internal/command/views/show.go
+++ b/internal/command/views/show.go
@@ -91,7 +91,7 @@ func (v *ShowHuman) Display(config *configs.Config, plan *plans.Plan, planJSON *
 		renderer.RenderHumanPlan(p, planJSON.Mode, planJSON.Qualities...)
 		v.view.streams.Print(v.view.colorize.Color("\n" + planJSON.RunFooter + "\n"))
 	} else if plan != nil {
-		outputs, changed, drift, attrs, actions, deferredChanges, err := jsonplan.MarshalForRenderer(plan, schemas)
+		jsonPlan, err := jsonplan.MarshalForRenderer(plan, schemas)
 		if err != nil {
 			v.view.streams.Eprintf("Failed to marshal plan to json: %s", err)
 			return 1
@@ -100,13 +100,13 @@ func (v *ShowHuman) Display(config *configs.Config, plan *plans.Plan, planJSON *
 		jplan := jsonformat.Plan{
 			PlanFormatVersion:     jsonplan.FormatVersion,
 			ProviderFormatVersion: jsonprovider.FormatVersion,
-			OutputChanges:         outputs,
-			ResourceChanges:       changed,
-			ResourceDrift:         drift,
+			OutputChanges:         jsonPlan.OutputChanges,
+			ResourceChanges:       jsonPlan.ResourceChanges,
+			ResourceDrift:         jsonPlan.ResourceDrift,
 			ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
-			RelevantAttributes:    attrs,
-			ActionInvocations:     actions,
-			DeferredChanges:       deferredChanges,
+			RelevantAttributes:    jsonPlan.RelevantAttributes,
+			ActionInvocations:     jsonPlan.ActionInvocations,
+			DeferredChanges:       jsonPlan.DeferredChanges,
 		}
 
 		var opts []plans.Quality

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -212,7 +212,7 @@ func (t *TestHuman) Run(run *moduletest.Run, file *moduletest.File, progress mod
 			}
 		} else {
 			// We'll print the plan.
-			outputs, changed, drift, attrs, actions, deferredChanges, err := jsonplan.MarshalForRenderer(run.Verbose.Plan, schemas)
+			jsonPlan, err := jsonplan.MarshalForRenderer(run.Verbose.Plan, schemas)
 			if err != nil {
 				run.Diagnostics = run.Diagnostics.Append(tfdiags.Sourceless(
 					tfdiags.Warning,
@@ -222,13 +222,13 @@ func (t *TestHuman) Run(run *moduletest.Run, file *moduletest.File, progress mod
 				plan := jsonformat.Plan{
 					PlanFormatVersion:     jsonplan.FormatVersion,
 					ProviderFormatVersion: jsonprovider.FormatVersion,
-					OutputChanges:         outputs,
-					ResourceChanges:       changed,
-					ResourceDrift:         drift,
+					OutputChanges:         jsonPlan.OutputChanges,
+					ResourceChanges:       jsonPlan.ResourceChanges,
+					ResourceDrift:         jsonPlan.ResourceDrift,
 					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
-					RelevantAttributes:    attrs,
-					ActionInvocations:     actions,
-					DeferredChanges:       deferredChanges,
+					RelevantAttributes:    jsonPlan.RelevantAttributes,
+					ActionInvocations:     jsonPlan.ActionInvocations,
+					DeferredChanges:       jsonPlan.DeferredChanges,
 				}
 
 				var opts []plans.Quality
@@ -591,7 +591,7 @@ func (t *TestJSON) Run(run *moduletest.Run, file *moduletest.File, progress modu
 					"@testrun", run.Name)
 			}
 		} else {
-			outputs, changed, drift, attrs, actions, deferredChanges, err := jsonplan.MarshalForRenderer(run.Verbose.Plan, schemas)
+			jsonPlan, err := jsonplan.MarshalForRenderer(run.Verbose.Plan, schemas)
 			if err != nil {
 				run.Diagnostics = run.Diagnostics.Append(tfdiags.Sourceless(
 					tfdiags.Warning,
@@ -601,13 +601,13 @@ func (t *TestJSON) Run(run *moduletest.Run, file *moduletest.File, progress modu
 				plan := jsonformat.Plan{
 					PlanFormatVersion:     jsonplan.FormatVersion,
 					ProviderFormatVersion: jsonprovider.FormatVersion,
-					OutputChanges:         outputs,
-					ResourceChanges:       changed,
-					ResourceDrift:         drift,
+					OutputChanges:         jsonPlan.OutputChanges,
+					ResourceChanges:       jsonPlan.ResourceChanges,
+					ResourceDrift:         jsonPlan.ResourceDrift,
 					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
-					RelevantAttributes:    attrs,
-					ActionInvocations:     actions,
-					DeferredChanges:       deferredChanges,
+					RelevantAttributes:    jsonPlan.RelevantAttributes,
+					ActionInvocations:     jsonPlan.ActionInvocations,
+					DeferredChanges:       jsonPlan.DeferredChanges,
 				}
 
 				t.view.log.Info(


### PR DESCRIPTION
Follow-up PR from https://github.com/hashicorp/terraform/pull/39045#discussion_r3846515155
Just a small refactor that undoes refactoring in #33755, which previously undid refactoring in #33504 😆 

🐢 
🐢 
🐢 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
