### PR TITLE
fix a mutex leak which could potentially create a deadlock

### DIFF
--- a/internal/rpcapi/handles.go
+++ b/internal/rpcapi/handles.go
@@ -219,6 +219,7 @@ func newHandle[ObjT any](t *handleTable, obj ObjT) handle[ObjT] {
 // returned error will be [newHandleErrorNoParent].
 func newHandleWithDependency[ObjT, DepT any](t *handleTable, obj ObjT, dep handle[DepT]) (handle[ObjT], error) {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	if depObjectI, exists := t.handleObjs[int64(dep)]; !exists {
 		return handle[ObjT](0), newHandleErrorNoParent
 	} else if depObject, ok := depObjectI.(DepT); !ok {
@@ -233,7 +234,6 @@ func newHandleWithDependency[ObjT, DepT any](t *handleTable, obj ObjT, dep handl
 		t.handleDeps[int64(dep)] = make(map[int64]struct{})
 	}
 	t.handleDeps[int64(dep)][hnd] = struct{}{}
-	t.mu.Unlock()
 	return handle[ObjT](hnd), nil
 }
 

--- a/internal/rpcapi/handles_test.go
+++ b/internal/rpcapi/handles_test.go
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package rpcapi
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewHandleWithDependency_NoParentDoesNotLeakLock(t *testing.T) {
+
+	// similar to serverHandshake in plugin.go
+	tbl := newHandleTable()
+
+	// Tryong to reproduce a race scenario (eg: closeSourceBundle completes
+	// concurrently with an inflight OpenStackConfiguration)
+	depHnd := newHandle(tbl, "dependency-obj")
+	if err := closeHandle(tbl, depHnd); err != nil {
+		t.Fatalf("close handle errors: %v", err)
+	}
+
+	_, err := newHandleWithDependency(tbl, "obj", depHnd)
+	if err != newHandleErrorNoParent {
+		t.Fatalf("expected no parent error, got %v", err)
+	}
+	// when no parent error is returned newHandleWithDependency does not release the lock. so calls after would block.
+	// adding a timeout here so as not to break ci. 2secs only.
+	done := make(chan handle[string], 1)
+	go func() {
+		hnd := newHandle(tbl, "another-obj")
+		done <- hnd
+	}()
+
+	select {
+	case <-done:
+		// mutex was released correctly
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTable t.mu was not released. deadlocked.")
+	}
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
In the file /internal/rpcapi/handles.go, method newHandleWithdependency method unlocks only on the success path. If newHandleErrorNoparent is raised, the handleTable's mutex is held forever. This is possible if say openStackConfiguration and ClouseSourceBundle competes concurrently ( improbable but nothing prevents it right now)

This can be reproduced via the unit test in this pr

Providing a reproducible unit test.

- Please cp the attached file at internal/rpcapi/ with the name handles_test.go
- execute the test case go test ./internal/rpcapi/...
Error would be 

```
admin@admins-MacBook-Pro terraform % go test ./internal/rpcapi/... 
--- FAIL: TestNewHandleWithDependency_NoParentDoesNotLeakLock (2.00s)
    handles_test.go:48: handleTable.mu was not released after newHandleWithDependency's no-parent error path — deadlock (mutex leak)
FAIL
FAIL    github.com/hashi
```

AI inference: ai was not used to write the code, its a one line fix anyways. 


<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes # https://github.com/hashicorp/terraform/issues/39053

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->



<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
