### PR TITLE
🤖🤖🤖 command/arguments: Report options given after state subcommand arguments

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260825-140000.yaml
+++ b/.changes/v1.17/BUG FIXES-20260825-140000.yaml
@@ -1,0 +1,7 @@
+kind: BUG FIXES
+body: 'command/state: The state subcommands now explain that an option was specified
+    after the address arguments, instead of failing with a confusing address parse
+    error such as "Variable name required"'
+time: 2026-08-25T14:00:00.000000-04:00
+custom:
+    Issue: "29524"

--- a/internal/command/arguments/state.go
+++ b/internal/command/arguments/state.go
@@ -1,0 +1,71 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// checkStateMisplacedOptions returns an error diagnostic for each of the given
+// positional arguments that names one of the options defined in cmdFlags.
+//
+// Option parsing stops at the first positional argument, so an option written
+// after an address is retained as an additional positional argument instead of
+// being applied. Without this check the state subcommands go on to interpret
+// that argument as an address, which fails with a confusing diagnostic such as
+// "Variable name required" that says nothing about the misplaced option.
+//
+// Only arguments naming an option that this command actually defines are
+// reported, because a positional argument may legitimately begin with a dash.
+// An invalid provider address such as "-/-/google" should still be reported as
+// an invalid provider address rather than as a misplaced option.
+//
+// commandName is the subcommand as the user would type it, such as "state rm",
+// and argsUsage describes that subcommand's positional arguments, such as
+// "ADDRESS...", so that we can show the corrected ordering.
+func checkStateMisplacedOptions(cmdFlags *flag.FlagSet, commandName, argsUsage string, args []string) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	for _, arg := range args {
+		name, ok := optionName(arg)
+		if !ok || cmdFlags.Lookup(name) == nil {
+			continue
+		}
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Option specified after arguments",
+			fmt.Sprintf(
+				"Terraform stops interpreting command-line options at the first argument, so %q was treated as an argument to \"terraform %s\" rather than as an option.\n\nSpecify options before the arguments, like this:\n    terraform %s %s %s",
+				arg, commandName, commandName, arg, argsUsage,
+			),
+		))
+	}
+	return diags
+}
+
+// optionName returns the name of the option that the given argument would have
+// set had it appeared before any positional arguments, along with whether the
+// argument has the form of an option at all.
+//
+// A bare "-" is not an option, because some commands use it to mean standard
+// input.
+func optionName(arg string) (string, bool) {
+	name, ok := strings.CutPrefix(arg, "-")
+	if !ok {
+		return "", false
+	}
+	// Terraform accepts both "-name" and "--name" for the same option.
+	name = strings.TrimPrefix(name, "-")
+
+	// "-name=value" sets the option called "name".
+	name, _, _ = strings.Cut(name, "=")
+
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -41,9 +41,15 @@ func ParseStateList(args []string) (*StateList, tfdiags.Diagnostics) {
 		))
 	}
 
+	args = cmdFlags.Args()
+	if moreDiags := checkStateMisplacedOptions(cmdFlags, "state list", "[ADDRESS...]", args); moreDiags.HasErrors() {
+		diags = diags.Append(moreDiags)
+		return list, diags
+	}
+
 	list.StatePath = statePath
 	list.ID = id
-	list.Addrs = cmdFlags.Args()
+	list.Addrs = args
 
 	return list, diags
 }

--- a/internal/command/arguments/state_list_test.go
+++ b/internal/command/arguments/state_list_test.go
@@ -76,6 +76,17 @@ func TestParseStateList_invalid(t *testing.T) {
 		want      *StateList
 		wantDiags tfdiags.Diagnostics
 	}{
+		"option after arguments": {
+			[]string{"test_instance.foo", "-id=bar"},
+			&StateList{},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Option specified after arguments",
+					"Terraform stops interpreting command-line options at the first argument, so \"-id=bar\" was treated as an argument to \"terraform state list\" rather than as an option.\n\nSpecify options before the arguments, like this:\n    terraform state list -id=bar [ADDRESS...]",
+				),
+			},
+		},
 		"unknown flag": {
 			[]string{"-boop"},
 			&StateList{},

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -77,6 +77,11 @@ func ParseStateMv(args []string) (*StateMv, tfdiags.Diagnostics) {
 	}
 
 	args = cmdFlags.Args()
+	if moreDiags := checkStateMisplacedOptions(cmdFlags, "state mv", "SOURCE DESTINATION", args); moreDiags.HasErrors() {
+		diags = diags.Append(moreDiags)
+		return mv, diags
+	}
+
 	if len(args) != 2 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/arguments/state_mv_test.go
+++ b/internal/command/arguments/state_mv_test.go
@@ -137,6 +137,22 @@ func TestParseStateMv_invalid(t *testing.T) {
 		want      *StateMv
 		wantDiags tfdiags.Diagnostics
 	}{
+		"option after arguments": {
+			[]string{"test_instance.foo", "test_instance.bar", "-dry-run"},
+			&StateMv{
+				Vars:          &Vars{},
+				BackupPath:    "-",
+				BackupOutPath: "-",
+				StateLock:     true,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Option specified after arguments",
+					"Terraform stops interpreting command-line options at the first argument, so \"-dry-run\" was treated as an argument to \"terraform state mv\" rather than as an option.\n\nSpecify options before the arguments, like this:\n    terraform state mv -dry-run SOURCE DESTINATION",
+				),
+			},
+		},
 		"no arguments": {
 			nil,
 			&StateMv{

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -69,6 +69,11 @@ func ParseStateReplaceProvider(args []string) (*StateReplaceProvider, tfdiags.Di
 	}
 
 	args = cmdFlags.Args()
+	if moreDiags := checkStateMisplacedOptions(cmdFlags, "state replace-provider", "FROM_PROVIDER_FQN TO_PROVIDER_FQN", args); moreDiags.HasErrors() {
+		diags = diags.Append(moreDiags)
+		return rp, diags
+	}
+
 	if len(args) != 2 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/arguments/state_replace_provider_test.go
+++ b/internal/command/arguments/state_replace_provider_test.go
@@ -130,6 +130,21 @@ func TestParseStateReplaceProvider_invalid(t *testing.T) {
 		want      *StateReplaceProvider
 		wantDiags tfdiags.Diagnostics
 	}{
+		"option after arguments": {
+			[]string{"hashicorp/google", "acmecorp/google", "-auto-approve"},
+			&StateReplaceProvider{
+				Vars:       &Vars{},
+				BackupPath: "-",
+				StateLock:  true,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Option specified after arguments",
+					"Terraform stops interpreting command-line options at the first argument, so \"-auto-approve\" was treated as an argument to \"terraform state replace-provider\" rather than as an option.\n\nSpecify options before the arguments, like this:\n    terraform state replace-provider -auto-approve FROM_PROVIDER_FQN TO_PROVIDER_FQN",
+				),
+			},
+		},
 		"no arguments": {
 			nil,
 			&StateReplaceProvider{

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -65,6 +65,11 @@ func ParseStateRm(args []string) (*StateRm, tfdiags.Diagnostics) {
 	}
 
 	args = cmdFlags.Args()
+	if moreDiags := checkStateMisplacedOptions(cmdFlags, "state rm", "ADDRESS...", args); moreDiags.HasErrors() {
+		diags = diags.Append(moreDiags)
+		return rm, diags
+	}
+
 	if len(args) < 1 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/arguments/state_rm_test.go
+++ b/internal/command/arguments/state_rm_test.go
@@ -120,6 +120,21 @@ func TestParseStateRm_invalid(t *testing.T) {
 		want      *StateRm
 		wantDiags tfdiags.Diagnostics
 	}{
+		"option after arguments": {
+			[]string{"module.eks", "--dry-run"},
+			&StateRm{
+				Vars:       &Vars{},
+				BackupPath: "-",
+				StateLock:  true,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Option specified after arguments",
+					"Terraform stops interpreting command-line options at the first argument, so \"--dry-run\" was treated as an argument to \"terraform state rm\" rather than as an option.\n\nSpecify options before the arguments, like this:\n    terraform state rm --dry-run ADDRESS...",
+				),
+			},
+		},
 		"no arguments": {
 			nil,
 			&StateRm{

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -42,6 +42,11 @@ func ParseStateShow(args []string) (*StateShow, tfdiags.Diagnostics) {
 	}
 
 	args = cmdFlags.Args()
+	if moreDiags := checkStateMisplacedOptions(cmdFlags, "state show", "ADDRESS", args); moreDiags.HasErrors() {
+		diags = diags.Append(moreDiags)
+		return show, diags
+	}
+
 	if len(args) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/arguments/state_show_test.go
+++ b/internal/command/arguments/state_show_test.go
@@ -50,6 +50,17 @@ func TestParseStateShow_invalid(t *testing.T) {
 		want      *StateShow
 		wantDiags tfdiags.Diagnostics
 	}{
+		"option after arguments": {
+			[]string{"test_instance.foo", "-json"},
+			&StateShow{ViewType: ViewHuman},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Option specified after arguments",
+					"Terraform stops interpreting command-line options at the first argument, so \"-json\" was treated as an argument to \"terraform state show\" rather than as an option.\n\nSpecify options before the arguments, like this:\n    terraform state show -json ADDRESS",
+				),
+			},
+		},
 		"no arguments": {
 			nil,
 			&StateShow{ViewType: ViewHuman},

--- a/internal/command/arguments/state_test.go
+++ b/internal/command/arguments/state_test.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestOptionName(t *testing.T) {
+	testCases := map[string]struct {
+		want   string
+		wantOK bool
+	}{
+		"-dry-run":          {"dry-run", true},
+		"--dry-run":         {"dry-run", true},
+		"-id=bar":           {"id", true},
+		"-j":                {"j", true},
+		"module.eks":        {"", false},
+		"test_instance.foo": {"", false},
+		"hashicorp/google":  {"", false},
+		"":                  {"", false},
+
+		// A bare "-" means standard input to some commands, so it must not be
+		// mistaken for an option.
+		"-":  {"", false},
+		"--": {"", false},
+
+		// An invalid provider address may begin with a dash, but it does not
+		// name an option.
+		"-/-/google": {"/-/google", true},
+	}
+
+	for arg, tc := range testCases {
+		t.Run(arg, func(t *testing.T) {
+			got, gotOK := optionName(arg)
+			if got != tc.want || gotOK != tc.wantOK {
+				t.Errorf("optionName(%q) = %q, %v; want %q, %v", arg, got, gotOK, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestCheckStateMisplacedOptions(t *testing.T) {
+	newFlagSet := func() *flag.FlagSet {
+		var dryRun, lock bool
+		fs := defaultFlagSet("state rm")
+		fs.BoolVar(&dryRun, "dry-run", false, "dry run")
+		fs.BoolVar(&lock, "lock", true, "lock state")
+		return fs
+	}
+
+	testCases := map[string]struct {
+		args      []string
+		wantDiags int
+	}{
+		"only addresses": {
+			[]string{"module.eks", "test_instance.foo"},
+			0,
+		},
+		"misplaced option": {
+			[]string{"module.eks", "-dry-run"},
+			1,
+		},
+		"misplaced option with double dash": {
+			[]string{"module.eks", "--dry-run"},
+			1,
+		},
+		"misplaced option with value": {
+			[]string{"module.eks", "-lock=false"},
+			1,
+		},
+		// Every misplaced option is reported, so that a user who moved several
+		// of them after the arguments learns about all of them at once.
+		"several misplaced options": {
+			[]string{"module.eks", "-dry-run", "-lock=false"},
+			2,
+		},
+		// An argument that begins with a dash but does not name an option this
+		// command defines is left alone, so that the command can report it as
+		// the invalid address it is.
+		"dashed argument that is not an option": {
+			[]string{"-/-/google", "acmecorp/google"},
+			0,
+		},
+		"bare dash": {
+			[]string{"module.eks", "-"},
+			0,
+		},
+		"unknown option": {
+			[]string{"module.eks", "-boop"},
+			0,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			diags := checkStateMisplacedOptions(newFlagSet(), "state rm", "ADDRESS...", tc.args)
+			if got := len(diags); got != tc.wantDiags {
+				t.Fatalf("got %d diagnostics, want %d: %s", got, tc.wantDiags, diags.Err())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Option parsing stops at the first positional argument, so an option written *after* an address is kept as an additional positional argument rather than being applied. The `state` subcommands then went on to interpret that argument as an address, which failed with a diagnostic that said nothing about the real mistake:

```
$ terraform state rm module.eks --dry-run

Error: Variable name required

  on  line 1:
  (source code not available)

Must begin with a variable name.
```

Two things are wrong there: the message describes an address parse failure rather than the misplaced option, and `-dry-run` was silently not applied.

With this change:

```
$ terraform state rm module.eks --dry-run

Error: Option specified after arguments

Terraform stops interpreting command-line options at the first argument, so
"--dry-run" was treated as an argument to "terraform state rm" rather than as
an option.

Specify options before the arguments, like this:
    terraform state rm --dry-run ADDRESS...
```

### Approach

A shared helper in `internal/command/arguments` inspects the positional arguments left over after flag parsing and reports any that name an option the command defines, together with the corrected ordering. It is wired into the five `state` subcommands that take addresses: `rm`, `mv`, `show`, `list` and `replace-provider`.

Two deliberate limits, both covered by tests:

- **Only options the command actually defines are reported.** A positional argument may legitimately begin with a dash — `TestStateReplaceProvider/invalid_provider_strings` passes `-/-/google` and expects an *invalid provider address* error. Matching against the command's own `FlagSet` keeps that error intact. A genuinely unknown option after an address is also left alone rather than being mislabelled.
- **`state push` is excluded**, because it uses a bare `-` to mean standard input. A bare `-` is never treated as an option anywhere in the helper.

Exit codes are unchanged: these invocations already failed, they just failed with a confusing message.

### Testing

- New `TestOptionName` and `TestCheckStateMisplacedOptions` covering the helper directly, including the bare-`-`, unknown-option, dashed-non-option, and multiple-misplaced-option cases.
- An `option after arguments` case added to each of the five affected `ParseState*_invalid` tests.
- `go test ./internal/command/... ` and `go vet ./internal/command/arguments/` pass. `TestStateReplaceProvider` (which caught an earlier, broader version of this check) passes.

Fixes #29524

## Target Release

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls. This only affects command-line argument validation and the wording of a diagnostic.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.

## AI Usage

Per the [AI Usage](https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md#ai-usage) section of the contributing guide: this change was prepared with the assistance of an LLM agent (Claude), hence the `🤖🤖🤖` prefix in the title.

Specifically, the agent was used to locate the failing code path from the issue report, draft the helper and the test cases, and run the test suite. The scope decision (five `state` subcommands, excluding `push`) and the diagnostic wording were reviewed and adjusted by me.

Worth calling out for reviewers: the first iteration of this check simply treated any leftover argument starting with `-` as a misplaced option. That broke `TestStateReplaceProvider/invalid_provider_strings`, because `-/-/google` is a legitimately dash-prefixed *address*. Matching against the command's own `FlagSet` instead is what makes the check safe, and that case is now pinned by a test.
