### PR TITLE
Fix: report unknown and N/A policy statuses correctly

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260825-124058.yaml
+++ b/.changes/v1.17/BUG FIXES-20260825-124058.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'query: report Unknown and N/A results for policy evaluations of discovered resources'
+time: 2026-08-25T12:40:58-04:00
+custom:
+    Issue: "39058"

--- a/internal/cloud/backend_query_test.go
+++ b/internal/cloud/backend_query_test.go
@@ -320,6 +320,14 @@ func renderQueryRunLogsForTest(t *testing.T, logContent string) string {
 
 const policySummaryPassLog = `{"@level":"info","@message":"Policy results","type":"policy_query_summary","list_block_address":"list.test.a","overall_result":"pass","results":[{"identity":{"id":"a"},"target_address":"test.a","result":"pass","policies":[{"policy_metadata":{"policy_name":"policy.a","enforcement_level":"mandatory"},"diagnostics":[],"result":"pass"}]}],"passed_policies":[{"policy_name":"policy.a","enforcement_level":"mandatory"}]}`
 
+// policySummaryAllNALog is a wire record where every identity produced n/a
+// (i.e. no policies matched any resource in the list block).
+const policySummaryAllNALog = `{"@level":"info","@message":"Policy results","type":"policy_query_summary","list_block_address":"list.test.b","overall_result":"n/a","results":[{"identity":{"id":"x"},"target_address":"test.b_0","result":"n/a","policies":[]},{"identity":{"id":"y"},"target_address":"test.b_1","result":"n/a","policies":[]}],"passed_policies":[]}`
+
+// policySummaryMixedNALog is a wire record where one identity passed and one
+// produced n/a.
+const policySummaryMixedNALog = `{"@level":"info","@message":"Policy results","type":"policy_query_summary","list_block_address":"list.test.c","overall_result":"pass","results":[{"identity":{"id":"p"},"target_address":"test.c_0","result":"pass","policies":[{"policy_metadata":{"policy_name":"policy.p","enforcement_level":"mandatory"},"diagnostics":[],"result":"pass"}]},{"identity":{"id":"n"},"target_address":"test.c_1","result":"n/a","policies":[]}],"passed_policies":[{"policy_name":"policy.p","enforcement_level":"mandatory"}]}`
+
 func TestCloud_queryWithPolicyPaths(t *testing.T) {
 	var innerFn func(http.ResponseWriter, *http.Request)
 	ih := &indirectHandler{fn: &innerFn}
@@ -600,6 +608,19 @@ Policy results for list.test.a - Passed
 {"@level":"info","@message":"Result found","type":"list_resource_found","list_resource_found":{"address":"list.test.a","display_name":"Alpha","identity":{"id":"a"}}}
 {"@level":"info","@message":"List complete","type":"list_complete","list_complete":{"address":"list.test.a"}}`
 
+	allNAOutput := `Evaluated 0 policies.
+
+Policy results for list.test.b - N/A
+  id=x  N/A
+  id=y  N/A
+`
+	mixedNAOutput := `Evaluated 1 policies.
+
+Policy results for list.test.c - Passed
+  id=p  Passed
+  id=n  N/A
+`
+
 	for _, tc := range []struct {
 		name    string
 		records string
@@ -607,6 +628,8 @@ Policy results for list.test.a - Passed
 	}{
 		{name: "query and summary", records: plainQuery + "\n" + policySummaryPassLog, want: "list.test.a   id=a   Alpha\n\n" + passOutput},
 		{name: "malformed then valid", records: malformed + "\n" + policySummaryPassLog, want: passOutput},
+		{name: "all n/a summary", records: policySummaryAllNALog, want: allNAOutput},
+		{name: "mixed n/a summary", records: policySummaryMixedNALog, want: mixedNAOutput},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := renderQueryRunLogsForTest(t, tc.records); got != tc.want {

--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -21,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/policy"
+	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -611,6 +614,242 @@ func queryFixtureProvider() *testing_provider.MockProvider {
 	}
 
 	return p
+}
+
+func TestQueryPolicyStatusReporting(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath(path.Join("query", "basic")), td)
+	t.Chdir(td)
+
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.0.0"},
+	})
+	p := queryFixtureProvider()
+	p.GetProviderSchemaResponse.ServerCapabilities.GenerateResourceConfig = true
+	p.ListResourceFn = func(request providers.ListResourceRequest) providers.ListResourceResponse {
+		config := request.Config.GetAttr("config")
+		rows := make([]cty.Value, 0, 3)
+		for idx := 1; idx <= 3; idx++ {
+			id := fmt.Sprintf("test-instance-%d", idx)
+			rows = append(rows, cty.ObjectVal(map[string]cty.Value{
+				"identity": cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal(id),
+				}),
+				"state": cty.ObjectVal(map[string]cty.Value{
+					"id":  cty.StringVal(id),
+					"ami": cty.StringVal(id),
+				}),
+				"display_name": cty.StringVal(fmt.Sprintf("Test Instance %d", idx)),
+			}))
+		}
+		return providers.ListResourceResponse{Result: cty.ObjectVal(map[string]cty.Value{
+			"data":   cty.ListVal(rows),
+			"config": config,
+		})}
+	}
+	p.GenerateResourceConfigFn = func(request providers.GenerateResourceConfigRequest) providers.GenerateResourceConfigResponse {
+		id := request.State.GetAttr("id").AsString()
+		if id == "test-instance-1" {
+			return providers.GenerateResourceConfigResponse{Diagnostics: tfdiags.Diagnostics{
+				tfdiags.Sourceless(tfdiags.Error, "config generation failed", "could not generate resource configuration"),
+			}}
+		}
+		return providers.GenerateResourceConfigResponse{Config: cty.ObjectVal(map[string]cty.Value{
+			"id":  cty.NullVal(cty.String),
+			"ami": cty.StringVal(id),
+		})}
+	}
+
+	var evaluated []string
+	policyClient := policy.NewTestMockClient(t)
+	policyClient.EvaluateFn = func(_ context.Context, request policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		id := request.Attrs.Raw.GetAttr("ami").AsString()
+		evaluated = append(evaluated, id)
+		switch id {
+		case "test-instance-2":
+			return policy.ErrorEvalFromDiags([]*proto.Diagnostic{{
+				Severity: proto.Severity_ERROR,
+				Summary:  "Failed to evaluate Terraform Policy",
+				Detail:   "policy transport unavailable",
+			}})
+		case "test-instance-3":
+			return policy.EvaluationFromProtoResponse(proto.EvaluateResult_ALLOW_EVALUATE_RESULT, nil)
+		default:
+			t.Fatalf("unexpected policy evaluation for %q", id)
+			return policy.EvaluationResponse{}
+		}
+	}
+
+	overrides := metaOverridesForProvider(p)
+	overrides.PolicyClient = policyClient
+	view, done := testView(t)
+	meta := Meta{
+		testingOverrides:          overrides,
+		View:                      view,
+		AllowExperimentalFeatures: true,
+		ProviderSource:            providerSource,
+	}
+
+	init := &InitCommand{Meta: meta}
+	if code := init.Run(nil); code != 0 {
+		t.Fatalf("init failed with status %d:\n%s", code, done(t).All())
+	}
+
+	view, done = testView(t)
+	meta.View = view
+	command := &QueryCommand{Meta: meta}
+	code := command.Run([]string{"-no-color", "-json", "-policies=."})
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("query failed with status %d:\n%s", code, output.All())
+	}
+
+	var records []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(output.Stdout()), "\n") {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("failed to decode JSON line %q: %s", line, err)
+		}
+		records = append(records, record)
+	}
+
+	var foundResources, summaries, policyDiagnostics []map[string]any
+	for _, record := range records {
+		switch record["type"] {
+		case "list_resource_found":
+			foundResources = append(foundResources, record)
+		case "policy_query_summary":
+			summaries = append(summaries, record)
+		case "policy_diagnostic":
+			policyDiagnostics = append(policyDiagnostics, record)
+		}
+	}
+	if len(foundResources) != 3 {
+		t.Fatalf("list_resource_found records = %d, want 3", len(foundResources))
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("policy_query_summary records = %d, want 1", len(summaries))
+	}
+	if len(policyDiagnostics) != 1 {
+		t.Fatalf("policy_diagnostic records = %d, want 1", len(policyDiagnostics))
+	}
+	if len(evaluated) != 2 || slices.Contains(evaluated, "test-instance-1") || !slices.Contains(evaluated, "test-instance-2") || !slices.Contains(evaluated, "test-instance-3") {
+		t.Fatalf("evaluated resources = %v, want only test-instance-2 and test-instance-3", evaluated)
+	}
+
+	summary := summaries[0]
+	if summary["overall_result"] != "error" {
+		t.Fatalf("summary overall_result = %v, want error", summary["overall_result"])
+	}
+	passedPolicies, ok := summary["passed_policies"].([]any)
+	if !ok || len(passedPolicies) != 0 {
+		t.Fatalf("passed_policies = %#v, want []", summary["passed_policies"])
+	}
+	rows := summary["results"].([]any)
+	if len(rows) != 3 {
+		t.Fatalf("summary rows = %d, want 3", len(rows))
+	}
+	rowsByID := make(map[string]map[string]any, len(rows))
+	for _, rawRow := range rows {
+		row := rawRow.(map[string]any)
+		identity := row["identity"].(map[string]any)
+		rowsByID[identity["id"].(string)] = row
+		policies, ok := row["policies"].([]any)
+		if !ok || len(policies) != 0 {
+			t.Fatalf("row %v policies = %#v, want []", identity["id"], row["policies"])
+		}
+	}
+	wantResults := map[string]string{
+		"test-instance-1": "unknown",
+		"test-instance-2": "error",
+		"test-instance-3": "n/a",
+	}
+	for id, want := range wantResults {
+		row := rowsByID[id]
+		if row == nil || row["result"] != want {
+			t.Fatalf("row %s = %#v, want result %s", id, row, want)
+		}
+	}
+
+	diagnostic := policyDiagnostics[0]
+	if diagnostic["target_address"] != "test_instance.example_1" {
+		t.Fatalf("policy diagnostic target = %v, want test_instance.example_1", diagnostic["target_address"])
+	}
+}
+
+func TestQueryPolicyStatusReporting_NoPoliciesArgument(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath(path.Join("query", "basic")), td)
+	t.Chdir(td)
+
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.0.0"},
+	})
+	p := queryFixtureProvider()
+	policyClient := policy.NewTestMockClient(t)
+	var policyClientCalled atomic.Bool
+	policyClient.EvaluateFn = func(context.Context, policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		policyClientCalled.Store(true)
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+	policyClient.StopFn = func() {
+		policyClientCalled.Store(true)
+	}
+
+	overrides := metaOverridesForProvider(p)
+	overrides.PolicyClient = policyClient
+	view, done := testView(t)
+	meta := Meta{
+		testingOverrides:          overrides,
+		View:                      view,
+		AllowExperimentalFeatures: true,
+		ProviderSource:            providerSource,
+	}
+
+	init := &InitCommand{Meta: meta}
+	code := init.Run(nil)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("init failed with status %d:\n%s", code, output.All())
+	}
+
+	view, done = testView(t)
+	meta.View = view
+	command := &QueryCommand{Meta: meta}
+	code = command.Run([]string{"-no-color", "-json"})
+	output = done(t)
+	if code != 0 {
+		t.Fatalf("query failed with status %d:\n%s", code, output.All())
+	}
+
+	var foundResources, summaries, policyDiagnostics int
+	for _, line := range strings.Split(strings.TrimSpace(output.Stdout()), "\n") {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("failed to decode JSON line %q: %s", line, err)
+		}
+		switch record["type"] {
+		case "list_resource_found":
+			foundResources++
+		case "policy_query_summary":
+			summaries++
+		case "policy_diagnostic":
+			policyDiagnostics++
+		}
+	}
+
+	if foundResources != 2 {
+		t.Fatalf("list_resource_found records = %d, want 2", foundResources)
+	}
+	if summaries != 0 {
+		t.Fatalf("policy_query_summary records = %d, want 0", summaries)
+	}
+	if policyDiagnostics != 0 {
+		t.Fatalf("policy_diagnostic records = %d, want 0", policyDiagnostics)
+	}
+	if policyClientCalled.Load() {
+		t.Fatal("policy client was called without -policies")
+	}
 }
 
 func TestQuery_JSON(t *testing.T) {

--- a/internal/command/views/query.go
+++ b/internal/command/views/query.go
@@ -94,6 +94,8 @@ type queryUiHook struct {
 }
 
 func (h *queryUiHook) PolicyResult(addr string, resp policy.EvaluationResponse) (terraform.HookAction, error) {
+	h.viewLock.Lock()
+	defer h.viewLock.Unlock()
 	h.op.PolicyResult(addr, resp)
 	return terraform.HookActionContinue, nil
 }

--- a/internal/command/views/query_operation.go
+++ b/internal/command/views/query_operation.go
@@ -109,7 +109,11 @@ func (v *QueryOperationHuman) PolicyResult(addr string, resp policy.EvaluationRe
 		v.view.PolicyResult(addr, resp)
 		return
 	}
-	if v.queryPolicy.AddResult(addr, resp) {
+	handled, unconsumed := v.queryPolicy.AddResult(addr, resp)
+	if handled {
+		if len(unconsumed) > 0 {
+			v.view.PolicyResult(addr, policy.EvaluationResponse{Diagnostics: unconsumed})
+		}
 		return
 	}
 	v.view.PolicyResult(addr, resp)
@@ -168,7 +172,11 @@ func (v *QueryOperationJSON) PolicyResult(addr string, resp policy.EvaluationRes
 		v.view.PolicyResult(addr, resp)
 		return
 	}
-	if v.queryPolicy.AddResult(addr, resp) {
+	handled, unconsumed := v.queryPolicy.AddResult(addr, resp)
+	if handled {
+		if len(unconsumed) > 0 {
+			v.view.PolicyResult(addr, policy.EvaluationResponse{Diagnostics: unconsumed})
+		}
 		return
 	}
 	v.view.PolicyResult(addr, resp)

--- a/internal/command/views/query_policy.go
+++ b/internal/command/views/query_policy.go
@@ -24,6 +24,7 @@ const (
 	queryPolicyResultFail    queryPolicyResult = "fail"
 	queryPolicyResultUnknown queryPolicyResult = "unknown"
 	queryPolicyResultError   queryPolicyResult = "error"
+	queryPolicyResultNA      queryPolicyResult = "n/a"
 )
 
 type PolicyQuerySummary struct {
@@ -83,11 +84,16 @@ func ParsePolicyQuerySummary(line []byte) (PolicyQuerySummary, error) {
 		if result.Policies == nil {
 			return PolicyQuerySummary{}, fmt.Errorf("policy query summary result %d has no policies array", i)
 		}
+		// An N/A row means no policies matched that resource; it must carry an
+		// empty policies array. A non-empty array alongside "n/a" is malformed.
+		if result.Result == queryPolicyResultNA && len(result.Policies) > 0 {
+			return PolicyQuerySummary{}, fmt.Errorf("policy query summary result %d has result %q but non-empty policies array", i, result.Result)
+		}
 		for j, pol := range result.Policies {
 			if strings.TrimSpace(pol.PolicyMetadata.PolicyName) == "" {
 				return PolicyQuerySummary{}, fmt.Errorf("policy query summary result %d policy %d has no policy name", i, j)
 			}
-			if !validQueryPolicyResult(pol.Result) {
+			if !validPerPolicyResult(pol.Result) {
 				return PolicyQuerySummary{}, fmt.Errorf("policy query summary result %d policy %d has invalid result %q", i, j, pol.Result)
 			}
 		}
@@ -113,14 +119,14 @@ func RenderPolicyQuerySummariesHuman(summaries []PolicyQuerySummary) string {
 		return ordered[i].ListBlockAddress < ordered[j].ListBlockAddress
 	})
 
-	policies := make(map[string]struct{})
+	policies := make(map[queryPolicyKey]struct{})
 	for _, summary := range ordered {
 		for _, metadata := range summary.PassedPolicies {
-			policies[metadata.PolicyName] = struct{}{}
+			policies[queryPolicyKeyFromMetadata(metadata)] = struct{}{}
 		}
 		for _, result := range summary.Results {
 			for _, pol := range result.Policies {
-				policies[pol.PolicyMetadata.PolicyName] = struct{}{}
+				policies[queryPolicyKeyFromMetadata(pol.PolicyMetadata)] = struct{}{}
 			}
 		}
 	}
@@ -134,7 +140,22 @@ func RenderPolicyQuerySummariesHuman(summaries []PolicyQuerySummary) string {
 	return buf.String()
 }
 
+// validQueryPolicyResult returns true for any result value that is legal in an
+// overall_result or per-identity result field. "n/a" is an intentional fifth
+// status emitted by the producer when no policies matched a resource; it is
+// valid in both positions but must not appear as a per-policy result.
 func validQueryPolicyResult(result queryPolicyResult) bool {
+	switch result {
+	case queryPolicyResultPass, queryPolicyResultFail, queryPolicyResultUnknown, queryPolicyResultError, queryPolicyResultNA:
+		return true
+	default:
+		return false
+	}
+}
+
+// validPerPolicyResult returns true only for result values that are legal for
+// an individual policy evaluation. "n/a" is not valid at this level.
+func validPerPolicyResult(result queryPolicyResult) bool {
 	switch result {
 	case queryPolicyResultPass, queryPolicyResultFail, queryPolicyResultUnknown, queryPolicyResultError:
 		return true
@@ -143,10 +164,16 @@ func validQueryPolicyResult(result queryPolicyResult) bool {
 	}
 }
 
+type queryPolicyKey struct {
+	Address       string
+	PolicySetName string
+	SourcePath    string
+}
+
 type queryPolicyBlock struct {
 	ListBlockAddress string
 	ResultsByTarget  map[string]*queryPolicyIdentityResult
-	PolicyMetadata   map[string]viewjson.PolicyMetadata
+	PolicyMetadata   map[queryPolicyKey]viewjson.PolicyMetadata
 }
 
 type queryPolicyView struct {
@@ -160,9 +187,9 @@ func newQueryPolicyView() *queryPolicyView {
 	}
 }
 
-func (v *queryPolicyView) AddResult(addr string, resp policy.EvaluationResponse) bool {
+func (v *queryPolicyView) AddResult(addr string, resp policy.EvaluationResponse) (bool, policy.Diagnostics) {
 	if resp.ListBlockAddr == "" {
-		return false
+		return false, nil
 	}
 
 	v.mu.Lock()
@@ -182,33 +209,35 @@ func (v *queryPolicyView) AddResult(addr string, resp policy.EvaluationResponse)
 	}
 
 	identityResult.Result = queryPolicyResultFromEvaluation(resp.Overall)
+	if identityResult.Result == queryPolicyResultPass && len(resp.Policies) == 0 {
+		identityResult.Result = queryPolicyResultNA
+	}
 	// Reset the per-policy slice so that a re-evaluation of the same
 	// identity always reflects only the most-recent response.
 	identityResult.Policies = identityResult.Policies[:0]
 
-	diagsByPolicy := make(map[string][]viewjson.Diagnostic, len(resp.Policies))
-	unmatchedDiags := make([]viewjson.Diagnostic, 0)
-	for _, diag := range resp.Diagnostics {
-		jsonDiag := *viewjson.NewDiagnostic(diag, nil)
+	jsonDiags := make([]viewjson.Diagnostic, len(resp.Diagnostics))
+	diagPolicyKeys := make([]queryPolicyKey, len(resp.Diagnostics))
+	consumedDiags := make([]bool, len(resp.Diagnostics))
+	for idx, diag := range resp.Diagnostics {
+		jsonDiags[idx] = *viewjson.NewDiagnostic(diag, nil)
 		extra := tfdiags.ExtraInfo[*policy.PolicyExtra](diag)
-		if extra == nil || extra.Policy.Address == "" {
-			unmatchedDiags = append(unmatchedDiags, jsonDiag)
-			continue
+		if extra != nil {
+			diagPolicyKeys[idx] = queryPolicyKeyFromPolicy(extra.Policy)
 		}
-		diagsByPolicy[extra.Policy.Address] = append(diagsByPolicy[extra.Policy.Address], jsonDiag)
 	}
 
 	for _, pol := range resp.Policies {
+		policyKey := queryPolicyKeyFromPolicy(*pol)
 		metadata := viewjson.MetadataFromPolicy(*pol)
-		block.PolicyMetadata[pol.Address] = metadata
-		policyDiags := diagsByPolicy[pol.Address]
-		// When there is exactly one policy and no diags matched its address
-		// (e.g. the diagnostic has no extra PolicyExtra metadata), fall back to
-		// the unmatched set so they are still associated with the sole policy.
-		// This handles policy plugins that may omit PolicyExtra from diagnostics
-		// in simpler scenarios, ensuring diagnostics are not lost or orphaned.
-		if len(policyDiags) == 0 && len(unmatchedDiags) > 0 && len(resp.Policies) == 1 {
-			policyDiags = unmatchedDiags
+		block.PolicyMetadata[policyKey] = metadata
+		var policyDiags []viewjson.Diagnostic
+		for idx, diagPolicyKey := range diagPolicyKeys {
+			if consumedDiags[idx] || diagPolicyKey.Address == "" || diagPolicyKey != policyKey {
+				continue
+			}
+			policyDiags = append(policyDiags, jsonDiags[idx])
+			consumedDiags[idx] = true
 		}
 		identityResult.Policies = append(identityResult.Policies, queryPolicyEvalResult{
 			PolicyMetadata: metadata,
@@ -217,7 +246,14 @@ func (v *queryPolicyView) AddResult(addr string, resp policy.EvaluationResponse)
 		})
 	}
 
-	return true
+	unconsumed := make(policy.Diagnostics, 0)
+	for idx, diag := range resp.Diagnostics {
+		if !consumedDiags[idx] {
+			unconsumed = append(unconsumed, diag)
+		}
+	}
+
+	return true, unconsumed
 }
 
 func (v *queryPolicyView) Flush(flush func(summary PolicyQuerySummary)) {
@@ -252,7 +288,7 @@ func (v *queryPolicyView) block(addr string) *queryPolicyBlock {
 	block = &queryPolicyBlock{
 		ListBlockAddress: addr,
 		ResultsByTarget:  make(map[string]*queryPolicyIdentityResult),
-		PolicyMetadata:   make(map[string]viewjson.PolicyMetadata),
+		PolicyMetadata:   make(map[queryPolicyKey]viewjson.PolicyMetadata),
 	}
 	v.blocks[addr] = block
 	return block
@@ -263,7 +299,7 @@ func (b *queryPolicyBlock) summary() PolicyQuerySummary {
 	for _, result := range b.ResultsByTarget {
 		policies := append(make([]queryPolicyEvalResult, 0, len(result.Policies)), result.Policies...)
 		sort.Slice(policies, func(i, j int) bool {
-			return policies[i].PolicyMetadata.PolicyName < policies[j].PolicyMetadata.PolicyName
+			return queryPolicyMetadataLess(policies[i].PolicyMetadata, policies[j].PolicyMetadata)
 		})
 		results = append(results, queryPolicyIdentityResult{
 			Identity:      maps.Clone(result.Identity),
@@ -283,7 +319,7 @@ func (b *queryPolicyBlock) summary() PolicyQuerySummary {
 		passedPolicies = append(passedPolicies, metadata)
 	}
 	sort.Slice(passedPolicies, func(i, j int) bool {
-		return passedPolicies[i].PolicyName < passedPolicies[j].PolicyName
+		return queryPolicyMetadataLess(passedPolicies[i], passedPolicies[j])
 	})
 
 	return PolicyQuerySummary{
@@ -294,8 +330,41 @@ func (b *queryPolicyBlock) summary() PolicyQuerySummary {
 	}
 }
 
+func queryPolicyKeyFromPolicy(pol policy.Policy) queryPolicyKey {
+	return queryPolicyKey{
+		Address:       pol.Address,
+		PolicySetName: pol.PolicySetName,
+		SourcePath:    pol.Directory,
+	}
+}
+
+func queryPolicyKeyFromMetadata(metadata viewjson.PolicyMetadata) queryPolicyKey {
+	return queryPolicyKey{
+		Address:       metadata.PolicyName,
+		PolicySetName: metadata.PolicySetName,
+		SourcePath:    metadata.PolicySetPath,
+	}
+}
+
+func queryPolicyMetadataLess(left, right viewjson.PolicyMetadata) bool {
+	if left.PolicyName != right.PolicyName {
+		return left.PolicyName < right.PolicyName
+	}
+	if left.PolicySetPath != right.PolicySetPath {
+		return left.PolicySetPath < right.PolicySetPath
+	}
+	return left.PolicySetName < right.PolicySetName
+}
+
 func queryPolicySummaryOverall(results []queryPolicyIdentityResult) queryPolicyResult {
-	overall := queryPolicyResultPass
+	if len(results) == 0 {
+		// N/A describes an evaluated identity that matched no policies. With no
+		// identities there was nothing to evaluate, so preserve the empty summary's
+		// historical Pass result.
+		return queryPolicyResultPass
+	}
+
+	overall := queryPolicyResultNA
 	for _, result := range results {
 		switch result.Result {
 		case queryPolicyResultError:
@@ -303,8 +372,12 @@ func queryPolicySummaryOverall(results []queryPolicyIdentityResult) queryPolicyR
 		case queryPolicyResultFail:
 			overall = queryPolicyResultFail
 		case queryPolicyResultUnknown:
-			if overall == queryPolicyResultPass {
+			if overall == queryPolicyResultNA || overall == queryPolicyResultPass {
 				overall = queryPolicyResultUnknown
+			}
+		case queryPolicyResultPass:
+			if overall == queryPolicyResultNA {
+				overall = queryPolicyResultPass
 			}
 		}
 	}
@@ -317,10 +390,10 @@ func queryPolicyResultFromEvaluation(result policy.EvaluateResult) queryPolicyRe
 		return queryPolicyResultPass
 	case policy.DenyResult:
 		return queryPolicyResultFail
-	case policy.PolicyErrorResult, policy.SetupErrorResult:
-		return queryPolicyResultError
-	default:
+	case policy.UnknownResult:
 		return queryPolicyResultUnknown
+	default:
+		return queryPolicyResultError
 	}
 }
 
@@ -364,6 +437,8 @@ func toPolicyResultLabel(r queryPolicyResult) string {
 		return "Failed"
 	case queryPolicyResultError:
 		return "Error"
+	case queryPolicyResultNA:
+		return "N/A"
 	default:
 		return "Unknown"
 	}

--- a/internal/command/views/query_policy_test.go
+++ b/internal/command/views/query_policy_test.go
@@ -5,6 +5,7 @@ package views
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	viewjson "github.com/hashicorp/terraform/internal/command/views/json"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/policy"
+	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -75,12 +77,22 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 		{
 			name: "unknown",
 			responses: []policy.EvaluationResponse{
-				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.EvaluateResult(999), []policyResultSpec{{address: "policy.unknown", result: policy.EvaluateResult(999)}}),
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.UnknownResult, []policyResultSpec{{address: "policy.unknown", result: policy.UnknownResult}}),
 			},
 			targets:      []string{"aws_instance.example_0"},
 			wantOverall:  "unknown",
 			wantResults:  1,
 			wantPolicies: 1,
+		},
+		{
+			name: "no matching policies",
+			responses: []policy.EvaluationResponse{
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, nil),
+			},
+			targets:      []string{"aws_instance.example_0"},
+			wantOverall:  "n/a",
+			wantResults:  1,
+			wantPolicies: 0,
 		},
 		{
 			name: "error",
@@ -91,16 +103,6 @@ func TestQueryOperationJSON_policySummary(t *testing.T) {
 			wantOverall:  "error",
 			wantResults:  1,
 			wantPolicies: 1,
-		},
-		{
-			name: "unmatched",
-			responses: []policy.EvaluationResponse{
-				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, nil),
-			},
-			targets:      []string{"aws_instance.example_0"},
-			wantOverall:  "pass",
-			wantResults:  1,
-			wantPolicies: 0,
 		},
 		{
 			name: "multiple list blocks",
@@ -274,13 +276,44 @@ func TestQueryOperationHuman_policySummary(t *testing.T) {
 		{
 			name: "unknown_result",
 			setup: func(v *QueryOperationHuman) {
-				v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.EvaluateResult(999), []policyResultSpec{{address: "policy.unknown", result: policy.EvaluateResult(999)}}))
+				v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.UnknownResult, nil))
 			},
 			want: []string{
-				"Evaluated 1 policies.",
+				"Evaluated 0 policies.",
 				"Policy results for aws_instance.example - Unknown",
 				"id=i-1",
 				"Unknown",
+			},
+			notWant: []string{"N/A"},
+		},
+		{
+			name: "policy_diagnostics_are_status_gated",
+			setup: func(v *QueryOperationHuman) {
+				v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, map[string]string{"id": "i-pass"}, policy.AllowResult, []policyResultSpec{{address: "policy.pass", result: policy.AllowResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("pass diagnostic", "detail", policy.AllowResult)}}}))
+				v.PolicyResult("aws_instance.example_1", queryEvalResp(listBlockAddr, map[string]string{"id": "i-unknown"}, policy.UnknownResult, []policyResultSpec{{address: "policy.unknown", result: policy.UnknownResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("unknown diagnostic", "detail", policy.UnknownResult)}}}))
+				v.PolicyResult("aws_instance.example_2", queryEvalResp(listBlockAddr, map[string]string{"id": "i-fail"}, policy.DenyResult, []policyResultSpec{{address: "policy.fail", result: policy.DenyResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("fail diagnostic", "detail", policy.DenyResult)}}}))
+				v.PolicyResult("aws_instance.example_3", queryEvalResp(listBlockAddr, map[string]string{"id": "i-error"}, policy.PolicyErrorResult, []policyResultSpec{{address: "policy.error", result: policy.PolicyErrorResult, diagnostics: []policy.Diagnostic{policy.NewErrorDiagnostic("error diagnostic", "detail", policy.PolicyErrorResult)}}}))
+			},
+			want: []string{
+				"Policy results for aws_instance.example - Error",
+				"  id=i-pass     Passed",
+				"  id=i-unknown  Unknown",
+				"  id=i-fail     Failed",
+				"  id=i-error    Error",
+				"policy.fail: fail diagnostic (mandatory)",
+				"policy.error: error diagnostic (mandatory)",
+			},
+			notWant: []string{
+				"policy.pass: pass diagnostic (mandatory)",
+				"policy.unknown: unknown diagnostic (mandatory)",
+			},
+			countOnce: []string{
+				"  id=i-pass     Passed",
+				"  id=i-unknown  Unknown",
+				"  id=i-fail     Failed",
+				"  id=i-error    Error",
+				"policy.fail: fail diagnostic (mandatory)",
+				"policy.error: error diagnostic (mandatory)",
 			},
 		},
 		{
@@ -298,18 +331,6 @@ func TestQueryOperationHuman_policySummary(t *testing.T) {
 			notWant: []string{"Error: evaluation failed"},
 		},
 		{
-			name: "unmatched_result",
-			setup: func(v *QueryOperationHuman) {
-				v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, nil))
-			},
-			want: []string{
-				"Evaluated 0 policies.",
-				"id=i-1",
-				"N/A",
-			},
-			notWant: []string{"id=i-1  Passed"},
-		},
-		{
 			name: "error_without_policy_details",
 			setup: func(v *QueryOperationHuman) {
 				resp := queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.PolicyErrorResult, nil)
@@ -320,8 +341,9 @@ func TestQueryOperationHuman_policySummary(t *testing.T) {
 				"Evaluated 0 policies.",
 				"id=i-1",
 				"Error",
+				"Error: evaluation failed",
 			},
-			notWant: []string{"N/A", "Error: evaluation failed"},
+			notWant: []string{"N/A"},
 		},
 		{
 			name:    "no_policies",
@@ -346,6 +368,37 @@ func TestQueryOperationHuman_policySummary(t *testing.T) {
 				"Evaluated",
 				"Policy results for",
 			},
+		},
+		{
+			name: "all_na",
+			setup: func(v *QueryOperationHuman) {
+				v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, nil))
+				v.PolicyResult("aws_instance.example_1", queryEvalResp(listBlockAddr, map[string]string{"id": "i-2"}, policy.AllowResult, nil))
+			},
+			want: []string{
+				"Evaluated 0 policies.",
+				"Policy results for aws_instance.example - N/A",
+				"id=i-1",
+				"id=i-2",
+				"N/A",
+			},
+			notWant: []string{"Unknown"},
+		},
+		{
+			name: "mixed_na_and_pass",
+			setup: func(v *QueryOperationHuman) {
+				v.PolicyResult("aws_instance.example_0", queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.allow", result: policy.AllowResult}}))
+				v.PolicyResult("aws_instance.example_1", queryEvalResp(listBlockAddr, map[string]string{"id": "i-2"}, policy.AllowResult, nil))
+			},
+			want: []string{
+				"Evaluated 1 policies.",
+				"Policy results for aws_instance.example - Passed",
+				"id=i-1",
+				"Passed",
+				"id=i-2",
+				"N/A",
+			},
+			notWant: []string{"Unknown"},
 		},
 		{
 			name: "warning_only",
@@ -410,7 +463,7 @@ func TestQueryOperationJSON_warningDiagnostic(t *testing.T) {
 	}
 }
 
-func TestQueryOperationJSON_policyFailuresOnlyEmitSummary(t *testing.T) {
+func TestQueryOperationJSON_policyFailuresRouteDiagnostics(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	v := &QueryOperationJSON{view: NewJSONView(NewView(streams)), queryPolicy: newQueryPolicyView()}
 	v.PolicyResult("aws_instance.example_0", queryEvalResp("aws_instance.example", map[string]string{"id": "i-1"}, policy.DenyResult, []policyResultSpec{{
@@ -440,7 +493,7 @@ func TestQueryOperationJSON_policyFailuresOnlyEmitSummary(t *testing.T) {
 			policyResults++
 		}
 	}
-	if summaries != 1 || diagnostics != 0 || policyDiagnostics != 0 || policyResults != 0 {
+	if summaries != 1 || diagnostics != 0 || policyDiagnostics != 1 || policyResults != 0 {
 		t.Fatalf("records: summaries=%d diagnostics=%d policy diagnostics=%d policy results=%d", summaries, diagnostics, policyDiagnostics, policyResults)
 	}
 }
@@ -478,6 +531,9 @@ func queryEvalResp(listBlockAddr string, identity map[string]string, overall pol
 		pol := &policy.Policy{Address: spec.address, Filename: "policy.tfpolicy.hcl", EnforcementLevel: "mandatory", Result: spec.result}
 		resp.Policies = append(resp.Policies, pol)
 		for _, diag := range spec.diagnostics {
+			if extra := tfdiags.ExtraInfo[*policy.PolicyExtra](diag); extra != nil {
+				extra.Policy = *pol
+			}
 			resp.Diagnostics = append(resp.Diagnostics, diag)
 		}
 	}
@@ -654,6 +710,50 @@ func TestNewQueryJSON_noDuplicateRecords(t *testing.T) {
 	}
 }
 
+func TestQueryUiHook_concurrentUnassociatedDiagnostics(t *testing.T) {
+	const goroutines = 20
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	op := &QueryOperationHuman{view: view, queryPolicy: newQueryPolicyView()}
+	hook := &queryUiHook{UiHook: NewUiHook(view), op: op}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for idx := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			resp := queryEvalResp(
+				"aws_instance.block",
+				map[string]string{"id": fmt.Sprintf("i-%d", idx)},
+				policy.PolicyErrorResult,
+				nil,
+			)
+			resp.Diagnostics = policy.Diagnostics{
+				policy.NewErrorDiagnostic("evaluation failed", "transport unavailable", policy.PolicyErrorResult),
+			}
+			if _, err := hook.PolicyResult(fmt.Sprintf("aws_instance.block_%d", idx), resp); err != nil {
+				t.Errorf("PolicyResult returned an error: %s", err)
+			}
+		}(idx)
+	}
+	wg.Wait()
+	op.Plan(nil, nil)
+
+	output := done(t).All()
+	if got := strings.Count(output, "evaluation failed"); got != goroutines {
+		t.Fatalf("rendered diagnostics = %d, want %d", got, goroutines)
+	}
+	var errorRows int
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "  id=i-") && strings.HasSuffix(line, "  Error") {
+			errorRows++
+		}
+	}
+	if errorRows != goroutines {
+		t.Fatalf("rendered Error rows = %d, want %d", errorRows, goroutines)
+	}
+}
+
 // TestQueryPolicySummaryOverall covers each branch of the roll-up logic.
 func TestQueryPolicySummaryOverall(t *testing.T) {
 	tests := []struct {
@@ -665,6 +765,51 @@ func TestQueryPolicySummaryOverall(t *testing.T) {
 			name:    "no results → pass",
 			results: []queryPolicyIdentityResult{},
 			want:    queryPolicyResultPass,
+		},
+		{
+			name:    "all N/A → N/A",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultNA}, {Result: queryPolicyResultNA}},
+			want:    queryPolicyResultNA,
+		},
+		{
+			name:    "pass overrides N/A",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultNA}, {Result: queryPolicyResultPass}},
+			want:    queryPolicyResultPass,
+		},
+		{
+			name:    "N/A does not override pass",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultPass}, {Result: queryPolicyResultNA}},
+			want:    queryPolicyResultPass,
+		},
+		{
+			name:    "unknown overrides N/A",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultNA}, {Result: queryPolicyResultUnknown}},
+			want:    queryPolicyResultUnknown,
+		},
+		{
+			name:    "N/A does not override unknown",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultUnknown}, {Result: queryPolicyResultNA}},
+			want:    queryPolicyResultUnknown,
+		},
+		{
+			name:    "fail overrides N/A",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultNA}, {Result: queryPolicyResultFail}},
+			want:    queryPolicyResultFail,
+		},
+		{
+			name:    "N/A does not override fail",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultFail}, {Result: queryPolicyResultNA}},
+			want:    queryPolicyResultFail,
+		},
+		{
+			name:    "error overrides N/A",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultNA}, {Result: queryPolicyResultError}},
+			want:    queryPolicyResultError,
+		},
+		{
+			name:    "N/A does not override error",
+			results: []queryPolicyIdentityResult{{Result: queryPolicyResultError}, {Result: queryPolicyResultNA}},
+			want:    queryPolicyResultError,
 		},
 		{
 			name:    "all pass",
@@ -715,9 +860,10 @@ func TestQueryPolicyResultFromEvaluation(t *testing.T) {
 	}{
 		{policy.AllowResult, queryPolicyResultPass},
 		{policy.DenyResult, queryPolicyResultFail},
+		{policy.UnknownResult, queryPolicyResultUnknown},
 		{policy.PolicyErrorResult, queryPolicyResultError},
 		{policy.SetupErrorResult, queryPolicyResultError},
-		{policy.EvaluateResult(999), queryPolicyResultUnknown},
+		{policy.InvalidResult, queryPolicyResultError},
 	}
 	for _, tc := range tests {
 		got := queryPolicyResultFromEvaluation(tc.input)
@@ -732,11 +878,162 @@ func TestQueryPolicyResultFromEvaluation(t *testing.T) {
 func TestQueryPolicyView_addResultNoListBlock(t *testing.T) {
 	v := newQueryPolicyView()
 	resp := queryEvalResp("", nil, policy.AllowResult, []policyResultSpec{{address: "p", result: policy.AllowResult}})
-	if v.AddResult("target", resp) {
+	handled, unconsumed := v.AddResult("target", resp)
+	if handled {
 		t.Fatal("AddResult should return false when ListBlockAddr is empty")
+	}
+	if len(unconsumed) != 0 {
+		t.Fatalf("AddResult returned %d unconsumed diagnostics for an unhandled response", len(unconsumed))
 	}
 	if v.HasResults() {
 		t.Fatal("HasResults should be false when no results with a list block have been added")
+	}
+}
+
+func TestQueryPolicyView_routesDiagnosticsByPolicyAddress(t *testing.T) {
+	associated := policy.NewErrorDiagnostic("same summary", "same detail", policy.PolicyErrorResult)
+	unassociated := policy.NewErrorDiagnostic("same summary", "same detail", policy.PolicyErrorResult)
+	resp := queryEvalResp("aws_instance.block", nil, policy.PolicyErrorResult, []policyResultSpec{{
+		address:     "policy.error",
+		result:      policy.PolicyErrorResult,
+		diagnostics: []policy.Diagnostic{associated},
+	}})
+	resp.Diagnostics = append(resp.Diagnostics, unassociated)
+
+	v := newQueryPolicyView()
+	handled, unconsumed := v.AddResult("aws_instance.block_0", resp)
+	if !handled {
+		t.Fatal("expected query response to be handled")
+	}
+	if len(unconsumed) != 1 {
+		t.Fatalf("unconsumed diagnostics count = %d, want 1", len(unconsumed))
+	}
+
+	var summary PolicyQuerySummary
+	v.Flush(func(got PolicyQuerySummary) { summary = got })
+	if len(summary.Results) != 1 || len(summary.Results[0].Policies) != 1 {
+		t.Fatalf("unexpected summary: %#v", summary)
+	}
+	if len(summary.Results[0].Policies[0].Diagnostics) != 1 {
+		t.Fatalf("associated diagnostic count = %d, want 1", len(summary.Results[0].Policies[0].Diagnostics))
+	}
+	if got := unconsumed[0].Description(); got.Summary != "same summary" || got.Detail != "same detail" {
+		t.Fatalf("unexpected unconsumed diagnostic: %#v", got)
+	}
+}
+
+func TestQueryPolicyView_routesSameAddressDiagnosticsByPolicyIdentity(t *testing.T) {
+	resp := policy.EvaluationFromProtoResponse(proto.EvaluateResult_DENY_EVALUATE_RESULT, []*proto.PolicyEvaluationDetail{
+		{
+			Address:       "policy.shared",
+			File:          "/policies/first/policy.tfpolicy.hcl",
+			PolicySetName: "first",
+			Result:        proto.EvaluateResult_DENY_EVALUATE_RESULT,
+			Diagnostics: []*proto.Diagnostic{{
+				Severity: proto.Severity_ERROR,
+				Summary:  "first diagnostic",
+				Detail:   "from the first policy set",
+				Result: &proto.DiagnosticResult{
+					Result: proto.EvaluateResult_DENY_EVALUATE_RESULT,
+				},
+			}},
+		},
+		{
+			Address:       "policy.shared",
+			File:          "/policies/second/policy.tfpolicy.hcl",
+			PolicySetName: "second",
+			Result:        proto.EvaluateResult_DENY_EVALUATE_RESULT,
+			Diagnostics: []*proto.Diagnostic{{
+				Severity: proto.Severity_ERROR,
+				Summary:  "second diagnostic",
+				Detail:   "from the second policy set",
+				Result: &proto.DiagnosticResult{
+					Result: proto.EvaluateResult_DENY_EVALUATE_RESULT,
+				},
+			}},
+		},
+	}).WithQueryMetadata(nil, "aws_instance.block")
+
+	v := newQueryPolicyView()
+	handled, unconsumed := v.AddResult("aws_instance.block_0", resp)
+	if !handled {
+		t.Fatal("expected query response to be handled")
+	}
+	if len(unconsumed) != 0 {
+		t.Fatalf("unconsumed diagnostics count = %d, want 0", len(unconsumed))
+	}
+	var summary PolicyQuerySummary
+	v.Flush(func(got PolicyQuerySummary) { summary = got })
+	if len(summary.Results) != 1 || len(summary.Results[0].Policies) != 2 {
+		t.Fatalf("unexpected row policy metadata: %#v", summary.Results)
+	}
+	if len(summary.PassedPolicies) != 2 {
+		t.Fatalf("evaluated policy metadata count = %d, want 2", len(summary.PassedPolicies))
+	}
+	if got := RenderPolicyQuerySummariesHuman([]PolicyQuerySummary{summary}); !strings.HasPrefix(got, "Evaluated 2 policies.") {
+		t.Fatalf("same-named policies from distinct sets were not counted independently:\n%s", got)
+	}
+
+	wantDiagnostics := map[string]string{
+		"first":  "first diagnostic",
+		"second": "second diagnostic",
+	}
+	for _, result := range summary.Results[0].Policies {
+		if result.PolicyMetadata.PolicyName != "policy.shared" {
+			t.Fatalf("policy name = %q, want policy.shared", result.PolicyMetadata.PolicyName)
+		}
+		if len(result.Diagnostics) != 1 {
+			t.Fatalf("diagnostics for policy set %q = %d, want 1", result.PolicyMetadata.PolicySetName, len(result.Diagnostics))
+		}
+		if got, want := result.Diagnostics[0].Summary, wantDiagnostics[result.PolicyMetadata.PolicySetName]; got != want {
+			t.Fatalf("diagnostic for policy set %q = %q, want %q", result.PolicyMetadata.PolicySetName, got, want)
+		}
+	}
+}
+
+func TestQueryOperationJSON_unassociatedErrorDiagnostic(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	op := &QueryOperationJSON{view: NewJSONView(NewView(streams)), queryPolicy: newQueryPolicyView()}
+	resp := queryEvalResp("aws_instance.example", map[string]string{"id": "i-1"}, policy.PolicyErrorResult, nil)
+	resp.Diagnostics = policy.Diagnostics{
+		policy.NewErrorDiagnostic("evaluation failed", "transport unavailable", policy.PolicyErrorResult),
+	}
+	op.PolicyResult("aws_instance.example_0", resp)
+	op.Plan(nil, nil)
+
+	var summaries, diagnostics, genericResults []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(done(t).Stdout()), "\n") {
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+			t.Fatalf("failed to decode JSON line %q: %s", line, err)
+		}
+		switch decoded["type"] {
+		case string(viewjson.MessagePolicyQuerySummary):
+			summaries = append(summaries, decoded)
+		case string(viewjson.MessagePolicyDiagnostic):
+			diagnostics = append(diagnostics, decoded)
+		case string(viewjson.MessagePolicyEvaluationResult):
+			genericResults = append(genericResults, decoded)
+		}
+	}
+
+	if len(summaries) != 1 || len(diagnostics) != 1 || len(genericResults) != 0 {
+		t.Fatalf("got %d summaries, %d diagnostics, and %d generic results", len(summaries), len(diagnostics), len(genericResults))
+	}
+	if diagnostics[0]["target_address"] != "aws_instance.example_0" {
+		t.Fatalf("diagnostic target = %v, want aws_instance.example_0", diagnostics[0]["target_address"])
+	}
+	if diagnostics[0]["result"] != policy.PolicyErrorResult.String() {
+		t.Fatalf("diagnostic result = %v, want %s", diagnostics[0]["result"], policy.PolicyErrorResult)
+	}
+	results := summaries[0]["results"].([]any)
+	row := results[0].(map[string]any)
+	if row["result"] != "error" {
+		t.Fatalf("summary row result = %v, want error", row["result"])
+	}
+	policies, ok := row["policies"].([]any)
+	if !ok || len(policies) != 0 {
+		t.Fatalf("summary policies = %#v, want []", row["policies"])
 	}
 }
 
@@ -1080,6 +1377,123 @@ func TestParsePolicyQuerySummary_acceptsUnmatchedResult(t *testing.T) {
 	}
 }
 
+// TestParsePolicyQuerySummary_acceptsNAResults verifies that "n/a" is valid in
+// overall_result and per-identity result fields, and that an all-N/A summary
+// produced by the local producer round-trips through the parser.
+func TestParsePolicyQuerySummary_acceptsNAResults(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		raw         string
+		wantOverall queryPolicyResult
+		wantResults int
+	}{
+		{
+			name:        "n/a overall result",
+			raw:         `{"list_block_address":"list.test.x","overall_result":"n/a","results":[],"passed_policies":[]}`,
+			wantOverall: queryPolicyResultNA,
+			wantResults: 0,
+		},
+		{
+			name:        "n/a identity result with empty policies",
+			raw:         `{"list_block_address":"list.test.x","overall_result":"n/a","results":[{"target_address":"test.x","result":"n/a","policies":[]}],"passed_policies":[]}`,
+			wantOverall: queryPolicyResultNA,
+			wantResults: 1,
+		},
+		{
+			name:        "mixed n/a and pass",
+			raw:         `{"list_block_address":"list.test.x","overall_result":"pass","results":[{"target_address":"test.a","result":"pass","policies":[{"policy_metadata":{"policy_name":"p.a"},"result":"pass","diagnostics":[]}]},{"target_address":"test.b","result":"n/a","policies":[]}],"passed_policies":[{"policy_name":"p.a"}]}`,
+			wantOverall: queryPolicyResultPass,
+			wantResults: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			summary, err := ParsePolicyQuerySummary([]byte(tc.raw))
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if summary.OverallResult != tc.wantOverall {
+				t.Errorf("overall_result = %q, want %q", summary.OverallResult, tc.wantOverall)
+			}
+			if len(summary.Results) != tc.wantResults {
+				t.Errorf("results count = %d, want %d", len(summary.Results), tc.wantResults)
+			}
+		})
+	}
+}
+
+// TestPolicyQuerySummaryProducerConsumerRoundTrip exercises the local JSON
+// producer, NDJSON parser, and human renderer as one boundary.
+func TestPolicyQuerySummaryProducerConsumerRoundTrip(t *testing.T) {
+	listBlockAddr := "aws_instance.example"
+
+	for _, tc := range []struct {
+		name      string
+		responses []policy.EvaluationResponse
+		targets   []string
+		want      string
+	}{
+		{
+			name: "all n/a (no matching policies)",
+			responses: []policy.EvaluationResponse{
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, nil),
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-2"}, policy.AllowResult, nil),
+			},
+			targets: []string{"aws_instance.example_0", "aws_instance.example_1"},
+			want: `Evaluated 0 policies.
+
+Policy results for aws_instance.example - N/A
+  id=i-1  N/A
+  id=i-2  N/A`,
+		},
+		{
+			name: "mixed n/a and pass",
+			responses: []policy.EvaluationResponse{
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-1"}, policy.AllowResult, []policyResultSpec{{address: "policy.a", result: policy.AllowResult}}),
+				queryEvalResp(listBlockAddr, map[string]string{"id": "i-2"}, policy.AllowResult, nil),
+			},
+			targets: []string{"aws_instance.example_0", "aws_instance.example_1"},
+			want: `Evaluated 1 policies.
+
+Policy results for aws_instance.example - Passed
+  id=i-1  Passed
+  id=i-2  N/A`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			op := &QueryOperationJSON{view: NewJSONView(NewView(streams)), queryPolicy: newQueryPolicyView()}
+			for i, resp := range tc.responses {
+				op.PolicyResult(tc.targets[i], resp)
+			}
+			op.Plan(nil, nil)
+
+			var summaries []PolicyQuerySummary
+			for _, line := range strings.Split(strings.TrimSpace(done(t).Stdout()), "\n") {
+				var record struct {
+					Type string `json:"type"`
+				}
+				if err := json.Unmarshal([]byte(line), &record); err != nil {
+					t.Fatalf("failed to decode NDJSON record: %s", err)
+				}
+				if record.Type != string(viewjson.MessagePolicyQuerySummary) {
+					continue
+				}
+				summary, err := ParsePolicyQuerySummary([]byte(line))
+				if err != nil {
+					t.Fatalf("ParsePolicyQuerySummary rejected producer output: %s\nraw: %s", err, line)
+				}
+				summaries = append(summaries, summary)
+			}
+			if len(summaries) != 1 {
+				t.Fatalf("policy summary records = %d, want 1", len(summaries))
+			}
+			if got := RenderPolicyQuerySummariesHuman(summaries); got != tc.want {
+				t.Fatalf("unexpected rendered summary\nwant:\n%s\n\ngot:\n%s", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestParsePolicyQuerySummary_rejectsMalformedRecords(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -1092,7 +1506,8 @@ func TestParsePolicyQuerySummary_rejectsMalformedRecords(t *testing.T) {
 		{name: "invalid overall result", raw: `{"list_block_address":"list.test.x","overall_result":"maybe","results":[],"passed_policies":[]}`},
 		{name: "missing target address", raw: `{"list_block_address":"list.test.x","overall_result":"pass","results":[{"result":"pass","policies":[]}],"passed_policies":[]}`},
 		{name: "invalid identity result", raw: `{"list_block_address":"list.test.x","overall_result":"pass","results":[{"target_address":"test.x","result":"maybe","policies":[]}],"passed_policies":[]}`},
-		{name: "n/a identity result", raw: `{"list_block_address":"list.test.x","overall_result":"pass","results":[{"target_address":"test.x","result":"n/a","policies":[]}],"passed_policies":[]}`},
+		{name: "n/a identity result with non-empty policies", raw: `{"list_block_address":"list.test.x","overall_result":"n/a","results":[{"target_address":"test.x","result":"n/a","policies":[{"policy_metadata":{"policy_name":"p.x"},"result":"pass","diagnostics":[]}]}],"passed_policies":[]}`},
+		{name: "per-policy n/a result", raw: `{"list_block_address":"list.test.x","overall_result":"pass","results":[{"target_address":"test.x","result":"pass","policies":[{"policy_metadata":{"policy_name":"policy.x"},"result":"n/a","diagnostics":[]}]}],"passed_policies":[{"policy_name":"policy.x"}]}`},
 		{name: "missing policies", raw: `{"list_block_address":"list.test.x","overall_result":"pass","results":[{"target_address":"test.x","result":"pass"}],"passed_policies":[]}`},
 		{name: "null policies", raw: `{"list_block_address":"list.test.x","overall_result":"pass","results":[{"target_address":"test.x","result":"pass","policies":null}],"passed_policies":[]}`},
 		{name: "policies wrong type", raw: `{"list_block_address":"list.test.x","overall_result":"pass","results":[{"target_address":"test.x","result":"pass","policies":{}}],"passed_policies":[]}`},

--- a/internal/terraform/node_query_resource_policy.go
+++ b/internal/terraform/node_query_resource_policy.go
@@ -4,10 +4,13 @@
 package terraform
 
 import (
+	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/policy/callback"
 	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -34,6 +37,9 @@ type nodeQueryResourcePolicy struct {
 	// ListBlockAddr is the AbsResourceInstance address of the originating list
 	// block. It is attached to every EvaluationResponse to group results.
 	ListBlockAddr addrs.AbsResourceInstance
+	// Unknown is true when Terraform could not produce the configuration needed
+	// to evaluate this resource.
+	Unknown bool
 }
 
 var _ GraphNodeExecutable = (*nodeQueryResourcePolicy)(nil)
@@ -59,33 +65,58 @@ func (n *nodeQueryResourcePolicy) Execute(ctx EvalContext, op walkOperation) tfd
 	var diags tfdiags.Diagnostics
 
 	client := ctx.PolicyClient()
-	config := ctx.Config()
-
 	if client == nil {
 		log.Printf("[DEBUG] No policy client configured, skipping query policy evaluation")
 		return nil
 	}
-	if config == nil {
-		log.Printf("[DEBUG] No configuration available, skipping query policy evaluation")
-		return nil
+
+	emitResult := func(result policy.EvaluationResponse) tfdiags.Diagnostics {
+		result = result.WithQueryMetadata(
+			ctyIdentityToStringMap(n.Identity),
+			n.ListBlockAddr.String(),
+		)
+		hookErr := ctx.Hook(func(h Hook) (HookAction, error) {
+			return h.PolicyResult(n.ResourceAddr.String(), result)
+		})
+		return diags.Append(hookErr)
+	}
+	emitError := func(detail string) tfdiags.Diagnostics {
+		result := policy.EvaluationResponse{
+			Overall: policy.PolicyErrorResult,
+			Diagnostics: policy.Diagnostics{
+				policy.NewErrorDiagnostic(
+					"Failed to evaluate Terraform Policy",
+					detail,
+					policy.PolicyErrorResult,
+				),
+			},
+		}
+		if n.ResourceConfig != nil {
+			result = result.WithLocalRange(n.ResourceConfig.DeclRange.Ptr())
+		}
+		return emitResult(result)
 	}
 
-	// Acquire the policy semaphore to limit concurrent policy evaluations.
-	// The nil-config guard above must remain before this acquire so that a
-	// missing config does not consume a semaphore slot for no work.
-	policySem := ctx.PolicySemaphore()
-	if policySem != nil {
-		policySem.Acquire()
-		defer policySem.Release()
+	if n.Unknown || n.GeneratedConfig == cty.NilVal || n.GeneratedConfig.IsNull() {
+		return emitResult(policy.EvaluationResponse{Overall: policy.UnknownResult})
+	}
+
+	config := ctx.Config()
+	if config == nil {
+		return emitError(fmt.Sprintf(
+			"Terraform could not prepare policy evaluation for %s because the configuration is unavailable.",
+			n.ResourceAddr,
+		))
 	}
 
 	providerAddr := n.ProviderAddr
 	provider, schema, err := getProvider(ctx, providerAddr)
 	if err != nil {
-		return diags.Append(err)
+		return emitError(fmt.Sprintf(
+			"Terraform could not prepare policy evaluation for %s: %s.",
+			n.ResourceAddr, err,
+		))
 	}
-
-	modCfg := config.DescendantForInstance(n.ResourceAddr.Module)
 
 	// Query resources are always evaluated as CREATE operations since they
 	// represent discovered resources that don't exist in the configuration.
@@ -95,40 +126,39 @@ func (n *nodeQueryResourcePolicy) Execute(ctx EvalContext, op walkOperation) tfd
 		ModulePath:   n.ResourceAddr.Module.String(),
 	}
 
-	// The resource config may be nil if the list block has been removed from
-	// the configuration. In that case we proceed without source information
-	// in diagnostics.
-	var resourceConfig *configs.Resource
-	if modCfg != nil {
-		resourceConfig = modCfg.Module.ResourceByAddr(n.ResourceAddr.Resource.Resource)
-	}
+	getResources := getResourcesForPolicyCallback(ctx, op, provider, schema, config)
 
 	callbacks := callback.Functions{
-		GetResources:  getResourcesForPolicyCallback(ctx, op, provider, schema, config),
+		GetResources:  queryGetResourcesCallback(getResources),
 		GetDataSource: getDataSourceForPolicyCallback(ctx, provider, schema),
+	}
+
+	// Only actual policy evaluations consume the policy semaphore.
+	policySem := ctx.PolicySemaphore()
+	if policySem != nil {
+		policySem.Acquire()
+		defer policySem.Release()
 	}
 
 	// Evaluate policies with the generated config as the "after" state
 	// and null as the "before" state (since these are discovered resources).
 	// evaluatePolicies already applies WithLocalRange internally; do not reapply.
-	result := evaluatePolicies(ctx, n.ResourceAddr, resourceConfig, n.GeneratedConfig, cty.NullVal(n.GeneratedConfig.Type()), meta, callbacks)
+	result := evaluatePolicies(ctx, n.ResourceAddr, n.ResourceConfig, n.GeneratedConfig, cty.NullVal(n.GeneratedConfig.Type()), meta, callbacks)
+	return emitResult(result)
+}
 
-	// Annotate the result with query correlation metadata so that downstream
-	// consumers (UI, cloud backend) can identify which list-block row this
-	// result belongs to.
-	result = result.WithQueryMetadata(ctyIdentityToStringMap(n.Identity), n.ListBlockAddr.String())
-
-	// Always emit for query policy nodes. WithQueryMetadata always sets
-	// ListBlockAddr to a non-empty string, so every result has identity.
-	// Query nodes always emit so downstream aggregators can include passing
-	// resources in summary records; the !result.Empty() gate must not be
-	// applied here.
-	hookErr := ctx.Hook(func(h Hook) (HookAction, error) {
-		return h.PolicyResult(n.ResourceAddr.String(), result)
-	})
-	diags = diags.Append(hookErr)
-
-	return diags
+func queryGetResourcesCallback(getResources func(context.Context, string, cty.Value) ([]cty.Value, bool, error)) func(context.Context, string, cty.Value) ([]cty.Value, bool, error) {
+	return func(callbackCtx context.Context, target string, attrs cty.Value) ([]cty.Value, bool, error) {
+		resources, partial, err := getResources(callbackCtx, target, attrs)
+		// The shared callback only inspects objects represented in Terraform's
+		// configuration and state or plan. During a query, an empty result cannot
+		// prove that no unmanaged matching objects exist, so report it as partial;
+		// the policy plugin treats an incomplete relationship set as unknown.
+		if err == nil && len(resources) == 0 {
+			partial = true
+		}
+		return resources, partial, err
+	}
 }
 
 // ctyIdentityToStringMap converts a cty object value that represents a resource

--- a/internal/terraform/node_query_resource_policy_test.go
+++ b/internal/terraform/node_query_resource_policy_test.go
@@ -5,10 +5,10 @@ package terraform
 
 import (
 	"context"
+	"errors"
 	"runtime"
+	"strings"
 	"testing"
-
-	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -22,6 +22,8 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // insertQueryPolicyNodes test helper mirrors the insertion loop in listResourceExecute,
@@ -32,9 +34,6 @@ func insertQueryPolicyNodes(t *testing.T, inputs []listResourcePolicy, ctx *Mock
 		return
 	}
 	for _, input := range inputs {
-		if input.Unknown {
-			continue
-		}
 		ctx.PolicyGraph().AddQuery(&nodeQueryResourcePolicy{
 			ResourceAddr:    input.SyntheticAddr,
 			ProviderAddr:    n.ResolvedProvider,
@@ -42,6 +41,7 @@ func insertQueryPolicyNodes(t *testing.T, inputs []listResourcePolicy, ctx *Mock
 			Identity:        input.Identity,
 			ResourceConfig:  input.ResourceConfig,
 			ListBlockAddr:   input.ListBlockAddr,
+			Unknown:         input.Unknown,
 		})
 	}
 }
@@ -88,10 +88,9 @@ func TestQueryPolicyNodeInsertion_CountMatchesResources(t *testing.T) {
 	}
 }
 
-// TestQueryPolicyNodeInsertion_UnknownResourcesSkipped verifies that policy
-// inputs with Unknown == true do not produce a nodeQueryResourcePolicy in the
-// policy subgraph.
-func TestQueryPolicyNodeInsertion_UnknownResourcesSkipped(t *testing.T) {
+// TestQueryPolicyNodeInsertion_UnknownResourcesIncluded verifies that every
+// discovered row produces a policy node, including pre-evaluation Unknown rows.
+func TestQueryPolicyNodeInsertion_UnknownResourcesIncluded(t *testing.T) {
 	p := &testing_provider.MockProvider{}
 	schema := listPolicyTestProviderSchema(false)
 	n := listPolicyTestNode("test_resource", "mylist")
@@ -124,9 +123,21 @@ func TestQueryPolicyNodeInsertion_UnknownResourcesSkipped(t *testing.T) {
 
 	nodes := dag.SelectSeq[*nodeQueryResourcePolicy](ps.graph.VerticesSeq()).Collect()
 
-	// Verify N nodes in policy subgraph, accounting for skipped unknowns
-	if len(nodes) != 2 {
-		t.Errorf("expected 2 policy nodes (unknown skipped), got %d", len(nodes))
+	if len(nodes) != 3 {
+		t.Fatalf("expected 3 policy nodes, got %d", len(nodes))
+	}
+	var unknown *nodeQueryResourcePolicy
+	for _, node := range nodes {
+		if node.ResourceAddr.String() == "test_resource.mylist_1" {
+			unknown = node
+			break
+		}
+	}
+	if unknown == nil {
+		t.Fatal("expected a policy node for the Unknown row")
+	}
+	if !unknown.Unknown {
+		t.Fatal("expected the Unknown flag to be propagated to the policy node")
 	}
 }
 
@@ -452,6 +463,7 @@ func TestNodeQueryResourcePolicy_Fields(t *testing.T) {
 		GeneratedConfig: generatedConfig,
 		Identity:        identity,
 		ListBlockAddr:   listBlockAddr,
+		Unknown:         true,
 	}
 
 	// Verify all fields are accessible
@@ -470,9 +482,23 @@ func TestNodeQueryResourcePolicy_Fields(t *testing.T) {
 	if node.ListBlockAddr.String() != listBlockAddr.String() {
 		t.Error("ListBlockAddr not set correctly")
 	}
+	if !node.Unknown {
+		t.Error("Unknown not set correctly")
+	}
 }
 
 // --- Execute() tests ---
+
+type queryPolicySemaphoreHook struct {
+	testHook
+	sem      Semaphore
+	occupied bool
+}
+
+func (h *queryPolicySemaphoreHook) PolicyResult(addr string, resp policy.EvaluationResponse) (HookAction, error) {
+	h.occupied = len(h.sem) > 0
+	return h.testHook.PolicyResult(addr, resp)
+}
 
 // executeTestCtx builds a minimal MockEvalContext suitable for nodeQueryResourcePolicy.Execute()
 // tests. It wires up a mock provider, schema, policy client, policy graph, and a
@@ -674,10 +700,52 @@ func TestNodeQueryResourcePolicy_Execute_UnknownResult(t *testing.T) {
 	}
 }
 
-// TestNodeQueryResourcePolicy_Execute_DenyNoEnforcements verifies that a DenyResult
-// with no enforcement details and no diagnostics is NOT dropped by the gate.
-// Previously the gate used len(Diagnostics)>0 || len(Enforcements)>0, which would
-// silently drop a bare DenyResult. The fix uses !result.Empty().
+func TestNodeQueryResourcePolicy_Execute_PreEvaluationUnknown(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+	mockClient := policy.NewTestMockClient(t)
+	mockClient.EvaluateFn = func(context.Context, policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		t.Fatal("policy client must not be called for a pre-evaluation Unknown")
+		return policy.EvaluationResponse{}
+	}
+
+	sem := NewSemaphore(1)
+	hook := &queryPolicySemaphoreHook{sem: sem}
+	ctx := executeTestCtx(t, mockClient, hook)
+	ctx.ProviderProvider = nil
+	ctx.PolicySemaphoreValue = sem
+
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-unknown"),
+	}))
+	n.Unknown = true
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+	resp, ok := hook.PolicyResults[resourceAddr.String()]
+	if !ok {
+		t.Fatal("expected an Unknown PolicyResult hook call")
+	}
+	if resp.Overall != policy.UnknownResult {
+		t.Fatalf("overall result = %s, want %s", resp.Overall, policy.UnknownResult)
+	}
+	if len(hook.Calls) != 1 {
+		t.Fatalf("hook calls = %d, want 1", len(hook.Calls))
+	}
+	if len(sem) != 0 {
+		t.Fatal("pre-evaluation Unknown consumed a policy semaphore slot")
+	}
+	if hook.occupied {
+		t.Fatal("policy semaphore was occupied while emitting pre-evaluation Unknown")
+	}
+	if ctx.ProviderCalled || ctx.ProviderSchemaCalled {
+		t.Fatal("pre-evaluation Unknown attempted provider preparation")
+	}
+}
+
+// TestNodeQueryResourcePolicy_Execute_DenyNoEnforcements verifies that policy
+// evaluation runs and a bare DenyResult is emitted unchanged.
 func TestNodeQueryResourcePolicy_Execute_DenyNoEnforcements(t *testing.T) {
 	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
 
@@ -693,15 +761,30 @@ func TestNodeQueryResourcePolicy_Execute_DenyNoEnforcements(t *testing.T) {
 
 	hook := &testHook{}
 	ctx := executeTestCtx(t, mockClient, hook)
-	n := makeExecuteNode(resourceAddr, cty.NilVal)
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-deny"),
+	}))
 
 	diags := n.Execute(ctx, walkPlan)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	if _, ok := hook.PolicyResults[resourceAddr.String()]; !ok {
-		t.Errorf("DenyResult with no enforcement details was silently dropped; expected PolicyResult hook call")
+	if !mockClient.EvaluateCalled {
+		t.Fatal("policy client was not called")
+	}
+	if got := len(hook.Calls); got != 1 {
+		t.Fatalf("hook calls = %d, want 1", got)
+	}
+	resp, ok := hook.PolicyResults[resourceAddr.String()]
+	if !ok {
+		t.Fatal("DenyResult with no enforcement details was silently dropped; expected PolicyResult hook call")
+	}
+	if resp.Overall != policy.DenyResult {
+		t.Fatalf("overall result = %s, want %s", resp.Overall, policy.DenyResult)
+	}
+	if len(resp.Policies) != 0 || len(resp.Enforcements) != 0 || len(resp.Diagnostics) != 0 {
+		t.Fatalf("bare DenyResult gained details: %#v", resp)
 	}
 }
 
@@ -786,11 +869,14 @@ func TestNodeQueryResourcePolicy_Execute_ListBlockAddrAnnotation(t *testing.T) {
 	}
 }
 
-// TestNodeQueryResourcePolicy_Execute_ProviderError verifies that a getProvider error
-// is returned as a diagnostic (not a panic) and that the semaphore is correctly
-// released even when getProvider fails.
+// TestNodeQueryResourcePolicy_Execute_ProviderError verifies that a provider
+// preparation failure is emitted as a row-local policy Error.
 func TestNodeQueryResourcePolicy_Execute_ProviderError(t *testing.T) {
 	mockClient := policy.NewTestMockClient(t)
+	mockClient.EvaluateFn = func(context.Context, policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		t.Fatal("policy client must not be called after provider preparation fails")
+		return policy.EvaluationResponse{}
+	}
 	hook := &testHook{}
 	ctx := executeTestCtx(t, mockClient, hook)
 
@@ -805,19 +891,85 @@ func TestNodeQueryResourcePolicy_Execute_ProviderError(t *testing.T) {
 	}))
 
 	diags := n.Execute(ctx, walkPlan)
-	if !diags.HasErrors() {
-		t.Fatal("expected an error diagnostic when provider is nil, got none")
+	if diags.HasErrors() {
+		t.Fatalf("provider preparation failure escaped as graph diagnostics: %s", diags.Err())
 	}
 
-	// Semaphore must be released even when getProvider fails.
-	if !sem.TryAcquire() {
-		t.Error("semaphore was not released after getProvider error; possible leak")
+	if len(sem) != 0 {
+		t.Fatal("provider preparation failure consumed a policy semaphore slot")
 	}
-	sem.Release()
+	resp, ok := hook.PolicyResults[n.ResourceAddr.String()]
+	if !ok {
+		t.Fatal("expected a PolicyResult hook call after provider preparation failure")
+	}
+	if resp.Overall != policy.PolicyErrorResult || len(resp.Diagnostics) != 1 {
+		t.Fatalf("unexpected policy response: %#v", resp)
+	}
+}
 
-	// No hook call should have been made.
-	if len(hook.Calls) != 0 {
-		t.Errorf("expected no hook calls after provider error, got %d", len(hook.Calls))
+func TestNodeQueryResourcePolicy_Execute_ProviderSchemaError(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+	schemaErr := errors.New("schema unavailable")
+	mockClient := policy.NewTestMockClient(t)
+	sem := NewSemaphore(1)
+	hook := &queryPolicySemaphoreHook{sem: sem}
+	ctx := executeTestCtx(t, mockClient, hook)
+	ctx.ProviderSchemaError = schemaErr
+	ctx.PolicySemaphoreValue = sem
+
+	listRange := hcl.Range{
+		Filename: "query.tfquery.hcl",
+		Start:    hcl.Pos{Line: 3, Column: 1, Byte: 20},
+		End:      hcl.Pos{Line: 5, Column: 2, Byte: 80},
+	}
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-schema-error"),
+	}))
+	n.ResourceConfig = &configs.Resource{
+		Mode:      addrs.ListResourceMode,
+		Type:      "test_resource",
+		Name:      "mylist",
+		Config:    hcl.EmptyBody(),
+		DeclRange: listRange,
+	}
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("provider schema failure escaped as graph diagnostics: %s", diags.Err())
+	}
+	if mockClient.EvaluateCalled {
+		t.Fatal("policy client was called after provider schema lookup failed")
+	}
+	if len(sem) != 0 {
+		t.Fatal("provider schema failure consumed a policy semaphore slot")
+	}
+	if hook.occupied {
+		t.Fatal("policy semaphore was occupied while emitting the provider schema Error")
+	}
+	if len(hook.Calls) != 1 {
+		t.Fatalf("hook calls = %d, want 1", len(hook.Calls))
+	}
+	resp := hook.PolicyResults[resourceAddr.String()]
+	if resp.Overall != policy.PolicyErrorResult || len(resp.Diagnostics) != 1 {
+		t.Fatalf("unexpected policy response: %#v", resp)
+	}
+	diag := resp.Diagnostics[0]
+	if !strings.Contains(diag.Description().Detail, schemaErr.Error()) {
+		t.Fatalf("diagnostic detail = %q, want schema error", diag.Description().Detail)
+	}
+	extra, ok := diag.ExtraInfo().(*policy.PolicyExtra)
+	if !ok || extra.Result != policy.PolicyErrorResult {
+		t.Fatalf("diagnostic result metadata = %#v, want %s", extra, policy.PolicyErrorResult)
+	}
+	wantRange := tfdiags.SourceRangeFromHCL(listRange)
+	if got := diag.Source().Subject; got == nil || *got != wantRange {
+		t.Fatalf("diagnostic local range = %#v, want %#v", got, wantRange)
+	}
+	if resp.Identity["id"] != "i-schema-error" {
+		t.Fatalf("identity = %#v, want id=i-schema-error", resp.Identity)
+	}
+	if resp.ListBlockAddr != n.ListBlockAddr.String() {
+		t.Fatalf("list block address = %q, want %q", resp.ListBlockAddr, n.ListBlockAddr)
 	}
 }
 
@@ -828,6 +980,7 @@ func TestNodeQueryResourcePolicy_Execute_NilClient(t *testing.T) {
 	ctx := executeTestCtx(t, nil, hook)
 
 	n := makeExecuteNode(mustResourceInstanceAddr("test_resource.mylist_0"), cty.NilVal)
+	n.Unknown = true
 	diags := n.Execute(ctx, walkPlan)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors with nil client: %s", diags.Err())
@@ -837,10 +990,14 @@ func TestNodeQueryResourcePolicy_Execute_NilClient(t *testing.T) {
 	}
 }
 
-// TestNodeQueryResourcePolicy_Execute_NilConfig verifies that Execute() is a no-op
-// when no configuration is available.
+// TestNodeQueryResourcePolicy_Execute_NilConfig verifies that missing
+// configuration after a row exists is emitted as a row-local policy Error.
 func TestNodeQueryResourcePolicy_Execute_NilConfig(t *testing.T) {
 	mockClient := policy.NewTestMockClient(t)
+	mockClient.EvaluateFn = func(context.Context, policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		t.Fatal("policy client must not be called without configuration")
+		return policy.EvaluationResponse{}
+	}
 	hook := &testHook{}
 	ctx := executeTestCtx(t, mockClient, hook)
 	ctx.ConfigValue = nil // override to nil
@@ -850,19 +1007,28 @@ func TestNodeQueryResourcePolicy_Execute_NilConfig(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors with nil config: %s", diags.Err())
 	}
-	if len(hook.Calls) != 0 {
-		t.Errorf("expected no hook calls with nil config, got %d", len(hook.Calls))
+	resp, ok := hook.PolicyResults[n.ResourceAddr.String()]
+	if !ok {
+		t.Fatal("expected a PolicyResult hook call with nil config")
+	}
+	if resp.Overall != policy.PolicyErrorResult || len(resp.Diagnostics) != 1 {
+		t.Fatalf("unexpected policy response: %#v", resp)
 	}
 }
 
 // TestNodeQueryResourcePolicy_Execute_SemaphoreAcquired verifies that Execute()
 // acquires and releases the policy semaphore exactly once per invocation.
 func TestNodeQueryResourcePolicy_Execute_SemaphoreAcquired(t *testing.T) {
+	sem := NewSemaphore(1)
 	mockClient := policy.NewTestMockClient(t)
+	mockClient.EvaluateFn = func(context.Context, policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		if len(sem) != 1 {
+			t.Errorf("policy semaphore occupancy = %d, want 1 during evaluation", len(sem))
+		}
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
 	hook := &testHook{}
 	ctx := executeTestCtx(t, mockClient, hook)
-
-	sem := NewSemaphore(1)
 	ctx.PolicySemaphoreValue = sem
 
 	n := makeExecuteNode(mustResourceInstanceAddr("test_resource.mylist_0"), cty.NilVal)
@@ -871,12 +1037,9 @@ func TestNodeQueryResourcePolicy_Execute_SemaphoreAcquired(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	// After Execute() the semaphore must be fully released — we should be
-	// able to acquire it again.
-	if !sem.TryAcquire() {
-		t.Error("semaphore was not released after Execute(); expected it to be available")
+	if len(sem) != 0 {
+		t.Error("semaphore was not released after Execute()")
 	}
-	sem.Release()
 }
 
 // TestNodeQueryResourcePolicy_Execute_NilPolicyGraph verifies that Execute() does not
@@ -913,17 +1076,17 @@ func TestNodeQueryResourcePolicy_Execute_ResourceConfigSetsRange(t *testing.T) {
 		}
 	}
 
-	declRange := hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 10}, End: hcl.Pos{Line: 12}}
-	resourceCfg := &configs.Resource{
+	managedRange := hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 10}, End: hcl.Pos{Line: 12}}
+	managedResourceCfg := &configs.Resource{
 		Mode:      addrs.ManagedResourceMode,
 		Type:      "test_resource",
-		Name:      "mylist",
+		Name:      "mylist_0",
 		Config:    hcl.EmptyBody(),
-		DeclRange: declRange,
+		DeclRange: managedRange,
 	}
 	rootModule := &configs.Module{
 		ManagedResources: map[string]*configs.Resource{
-			"test_resource.mylist_0": resourceCfg,
+			"test_resource.mylist_0": managedResourceCfg,
 		},
 	}
 	rootCfg := &configs.Config{
@@ -937,15 +1100,30 @@ func TestNodeQueryResourcePolicy_Execute_ResourceConfigSetsRange(t *testing.T) {
 	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
 		"id": cty.StringVal("i-abc"),
 	}))
+	listRange := hcl.Range{Filename: "query.tfquery.hcl", Start: hcl.Pos{Line: 3}, End: hcl.Pos{Line: 5}}
+	n.ResourceConfig = &configs.Resource{
+		Mode:      addrs.ListResourceMode,
+		Type:      "test_resource",
+		Name:      "mylist",
+		Config:    hcl.EmptyBody(),
+		DeclRange: listRange,
+	}
 
 	diags := n.Execute(ctx, walkPlan)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	// Verify the hook was called — result propagation was not broken.
-	if _, ok := hook.PolicyResults[resourceAddr.String()]; !ok {
+	resp, ok := hook.PolicyResults[resourceAddr.String()]
+	if !ok {
 		t.Error("expected PolicyResult hook call, got none")
+		return
+	}
+	if len(resp.Enforcements) != 1 || resp.Enforcements[0].LocalRange == nil {
+		t.Fatalf("expected one enforcement with a local range, got %#v", resp.Enforcements)
+	}
+	if *resp.Enforcements[0].LocalRange != listRange {
+		t.Fatalf("local range = %#v, want list block range %#v", *resp.Enforcements[0].LocalRange, listRange)
 	}
 }
 
@@ -1024,7 +1202,7 @@ func TestCtyIdentityToStringMap(t *testing.T) {
 // ReadInstancesForConfigResource). The configs.Config contains a single managed resource
 // declaration for "test_resource" (type) / "target" (name) in the root module, matching
 // the synthetic resource instances appended to the change set.
-func executeTestCtxWithState(t *testing.T, policyClient policy.Client, hook Hook, changes []*plans.ResourceInstanceChange, deferred *deferring.Deferred) *MockEvalContext {
+func executeTestCtxWithState(t *testing.T, policyClient policy.Client, hook Hook, changes []*plans.ResourceInstanceChange) *MockEvalContext {
 	t.Helper()
 
 	ctx := executeTestCtx(t, policyClient, hook)
@@ -1037,10 +1215,7 @@ func executeTestCtxWithState(t *testing.T, policyClient policy.Client, hook Hook
 	changesSync.Close()
 	ctx.ChangesChanges = changesSync
 
-	if deferred == nil {
-		deferred = deferring.NewDeferred(false)
-	}
-	ctx.DeferralsState = deferred
+	ctx.DeferralsState = deferring.NewDeferred(false)
 
 	// Populate a configs.Config whose Module.ManagedResources contains a resource entry
 	// for "test_resource.target" so that config.DeepEach finds it during callback iteration.
@@ -1057,6 +1232,7 @@ func executeTestCtxWithState(t *testing.T, policyClient policy.Client, hook Hook
 			},
 		},
 	}
+	ctx.InstanceExpanderExpander.SetResourceSingle(addrs.RootModuleInstance, resourceCfg.Addr())
 
 	return ctx
 }
@@ -1120,7 +1296,7 @@ func TestNodeQueryResourcePolicy_Execute_GetResources_Pass(t *testing.T) {
 	}
 
 	hook := &testHook{}
-	ctx := executeTestCtxWithState(t, mockClient, hook, []*plans.ResourceInstanceChange{change}, nil)
+	ctx := executeTestCtxWithState(t, mockClient, hook, []*plans.ResourceInstanceChange{change})
 	ctx.StateState = states.NewState().SyncWrapper()
 	defer ctx.StateState.Close()
 
@@ -1184,7 +1360,7 @@ func TestNodeQueryResourcePolicy_Execute_GetResources_Fail(t *testing.T) {
 	}
 
 	hook := &testHook{}
-	ctx := executeTestCtxWithState(t, mockClient, hook, []*plans.ResourceInstanceChange{change}, nil)
+	ctx := executeTestCtxWithState(t, mockClient, hook, []*plans.ResourceInstanceChange{change})
 	ctx.StateState = states.NewState().SyncWrapper()
 	defer ctx.StateState.Close()
 
@@ -1208,38 +1384,14 @@ func TestNodeQueryResourcePolicy_Execute_GetResources_Fail(t *testing.T) {
 	}
 }
 
-// TestNodeQueryResourcePolicy_Execute_GetResources_Unknown verifies that when the policy
-// plugin calls req.Callbacks.GetResources(...) and the callback returns partial=true
-// (because the resource address has a deferral), the plugin maps this to UnknownResult
-// and a hook event is emitted.
-//
-// This exercises the GetResources callback path within a query policy node's Execute()
-// under a deferral — the callback receives an empty-or-partial result set and the plugin
-// signals UnknownResult.
+// TestNodeQueryResourcePolicy_Execute_GetResources_Unknown verifies that a
+// successful zero-resource query callback is reported as partial and can be
+// classified as Unknown by the policy client.
 func TestNodeQueryResourcePolicy_Execute_GetResources_Unknown(t *testing.T) {
 	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
 
-	// Set up a Deferred with deferral enabled so DependenciesDeferred returns true
-	// for our target resource, causing the callback to set isPartialResult=true.
-	deferred := deferring.NewDeferred(true)
-	targetAddr := mustResourceInstanceAddr("test_resource.target")
-	deferredChange := &plans.ResourceInstanceChange{
-		Addr:        targetAddr,
-		PrevRunAddr: targetAddr,
-		ProviderAddr: addrs.AbsProviderConfig{
-			Provider: addrs.NewDefaultProvider("test"),
-			Module:   addrs.RootModule,
-		},
-		Change: plans.Change{
-			Action: plans.Create,
-			Before: cty.NullVal(cty.DynamicPseudoType),
-			After:  cty.DynamicVal,
-		},
-	}
-	deferred.ReportResourceInstanceDeferred(targetAddr, providers.DeferredReasonProviderConfigUnknown, deferredChange)
-
-	var callbackInvoked bool
 	var gotPartial bool
+	var gotResourceCount int
 	mockClient := &policy.MockClient{}
 	mockClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
 		if req.Callbacks.GetResources == nil {
@@ -1247,13 +1399,12 @@ func TestNodeQueryResourcePolicy_Execute_GetResources_Unknown(t *testing.T) {
 			return policy.EvaluationResponse{Overall: policy.UnknownResult}
 		}
 
-		_, partial, err := req.Callbacks.GetResources(ctx, "test_resource", cty.NullVal(cty.DynamicPseudoType))
+		resources, partial, err := req.Callbacks.GetResources(ctx, "test_resource", cty.NullVal(cty.DynamicPseudoType))
 		if err != nil {
 			t.Errorf("GetResources returned unexpected error: %v", err)
 		}
+		gotResourceCount = len(resources)
 		gotPartial = partial
-		callbackInvoked = true
-
 		// A real policy plugin would return UnknownResult when partial=true because
 		// it cannot determine compliance with incomplete data.
 		if partial {
@@ -1268,7 +1419,7 @@ func TestNodeQueryResourcePolicy_Execute_GetResources_Unknown(t *testing.T) {
 	}
 
 	hook := &testHook{}
-	ctx := executeTestCtxWithState(t, mockClient, hook, nil, deferred)
+	ctx := executeTestCtxWithState(t, mockClient, hook, nil)
 	ctx.StateState = states.NewState().SyncWrapper()
 	defer ctx.StateState.Close()
 
@@ -1279,11 +1430,11 @@ func TestNodeQueryResourcePolicy_Execute_GetResources_Unknown(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	if !callbackInvoked {
-		t.Error("EvaluateFn never invoked GetResources callback")
+	if gotResourceCount != 0 {
+		t.Fatalf("GetResources returned %d resources, want zero", gotResourceCount)
 	}
 	if !gotPartial {
-		t.Error("expected partial=true from GetResources when resource is deferred, got false")
+		t.Error("expected partial=true for a successful zero-resource query callback")
 	}
 
 	resp, ok := hook.PolicyResults[resourceAddr.String()]
@@ -1292,5 +1443,80 @@ func TestNodeQueryResourcePolicy_Execute_GetResources_Unknown(t *testing.T) {
 	}
 	if resp.Overall != policy.UnknownResult {
 		t.Errorf("expected UnknownResult, got %v", resp.Overall)
+	}
+	if len(hook.Calls) != 1 {
+		t.Fatalf("hook calls = %d, want 1", len(hook.Calls))
+	}
+}
+
+func TestNodeQueryResourcePolicy_Execute_CallbackError(t *testing.T) {
+	resourceAddr := mustResourceInstanceAddr("test_resource.mylist_0")
+	var callbackInvoked bool
+	var callbackErr error
+	mockClient := policy.NewTestMockClient(t)
+	mockClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		callbackInvoked = true
+		_, partial, err := req.Callbacks.GetDataSource(ctx, "missing_data_source", cty.EmptyObjectVal)
+		if partial {
+			t.Error("GetDataSource returned partial=true with an error")
+		}
+		callbackErr = err
+		if err == nil {
+			err = errors.New("GetDataSource unexpectedly returned no error")
+		}
+		return policy.EvaluationResponse{
+			Overall: policy.PolicyErrorResult,
+			Diagnostics: policy.Diagnostics{
+				policy.NewErrorDiagnostic("Failed to evaluate Terraform Policy", err.Error(), policy.PolicyErrorResult),
+			},
+		}
+	}
+
+	sem := NewSemaphore(1)
+	hook := &queryPolicySemaphoreHook{sem: sem}
+	ctx := executeTestCtx(t, mockClient, hook)
+	ctx.PolicySemaphoreValue = sem
+	n := makeExecuteNode(resourceAddr, cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("i-callback-error"),
+	}))
+
+	diags := n.Execute(ctx, walkPlan)
+	if diags.HasErrors() {
+		t.Fatalf("callback error escaped as graph diagnostics: %s", diags.Err())
+	}
+	if !callbackInvoked {
+		t.Fatal("policy client did not invoke GetDataSource")
+	}
+	if callbackErr == nil || !strings.Contains(callbackErr.Error(), "no data source found for missing_data_source") {
+		t.Fatalf("callback error = %v, want missing data source error", callbackErr)
+	}
+	if len(sem) != 0 {
+		t.Fatal("policy semaphore was not released after callback error")
+	}
+	if len(hook.Calls) != 1 {
+		t.Fatalf("hook calls = %d, want 1", len(hook.Calls))
+	}
+}
+
+func TestNodeQueryResourcePolicy_GetResourcesCallback_PreservesPartialWithResources(t *testing.T) {
+	wantResources := []cty.Value{cty.StringVal("resource")}
+	callback := queryGetResourcesCallback(func(context.Context, string, cty.Value) ([]cty.Value, bool, error) {
+		return wantResources, true, nil
+	})
+
+	resources, partial, err := callback(t.Context(), "test_resource", cty.NullVal(cty.DynamicPseudoType))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !partial {
+		t.Fatal("partial = false, want true")
+	}
+	if len(resources) != len(wantResources) {
+		t.Fatalf("resources = %d, want %d", len(resources), len(wantResources))
+	}
+	for idx := range resources {
+		if !resources[idx].RawEquals(wantResources[idx]) {
+			t.Fatalf("resource %d = %#v, want %#v", idx, resources[idx], wantResources[idx])
+		}
 	}
 }

--- a/internal/terraform/node_resource_list_policy.go
+++ b/internal/terraform/node_resource_list_policy.go
@@ -38,8 +38,8 @@ type listResourcePolicy struct {
 	// ListBlockAddr is the AbsResourceInstance address of the originating list block.
 	ListBlockAddr addrs.AbsResourceInstance
 
-	// Unknown is true when the resource had no "state" attribute in the list
-	// response (include_resource = false), preventing config generation.
+	// Unknown is true when resource state is unavailable or configuration
+	// generation failed, preventing policy evaluation.
 	Unknown bool
 }
 

--- a/internal/terraform/node_resource_list_policy_test.go
+++ b/internal/terraform/node_resource_list_policy_test.go
@@ -164,6 +164,54 @@ func TestGenerateListResourcePolicyData_ProviderRPCPath(t *testing.T) {
 	}
 }
 
+func TestGenerateListResourcePolicyData_ConfigGenerationFailureIsUnknown(t *testing.T) {
+	p := &testing_provider.MockProvider{}
+	p.GenerateResourceConfigFn = func(_ providers.GenerateResourceConfigRequest) providers.GenerateResourceConfigResponse {
+		return providers.GenerateResourceConfigResponse{
+			Diagnostics: tfdiags.Diagnostics{
+				tfdiags.Sourceless(tfdiags.Error, "config generation failed", "provider could not generate config"),
+			},
+		}
+	}
+
+	n := listPolicyTestNode("test_resource", "mylist")
+	listBlockAddr := n.Addr
+	ctx := listPolicyTestContext(listBlockAddr, p, listPolicyTestProviderSchema(true))
+	data := cty.TupleVal([]cty.Value{listPolicyTestElement(
+		cty.ObjectVal(map[string]cty.Value{
+			"instance_type": cty.StringVal("t2.micro"),
+			"ami":           cty.StringVal("ami-12345"),
+		}),
+		cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("i-123")}),
+	)})
+
+	results, diags := n.generateListResourcePolicyData(ctx, listBlockAddr, data)
+
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].Unknown {
+		t.Fatal("expected config generation failure to produce an Unknown result")
+	}
+	if results[0].GeneratedConfig != cty.NilVal {
+		t.Fatalf("expected no generated config, got %#v", results[0].GeneratedConfig)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("expected one consolidated warning, got %d", len(diags))
+	}
+	diag := diags[0]
+	if diag.Severity() != tfdiags.Warning || diag.Description().Summary != "Policy evaluation skipped" {
+		t.Fatalf("unexpected diagnostic: %#v", diag.Description())
+	}
+	extra := tfdiags.ExtraInfo[*tfdiags.ListBlockAddrExtra](diag)
+	if extra == nil || extra.ListBlockAddr != listBlockAddr.String() {
+		t.Fatalf("unexpected list block diagnostic metadata: %#v", extra)
+	}
+}
+
 // TestGenerateListResourcePolicyData_LegacyFallbackPath verifies that when the
 // provider does not advertise GenerateResourceConfig, config is derived via
 // genconfig.ExtractLegacyConfigFromState without calling the RPC.

--- a/internal/terraform/node_resource_plan_instance_query.go
+++ b/internal/terraform/node_resource_plan_instance_query.go
@@ -168,9 +168,6 @@ func (n *NodePlannableResourceInstance) listResourceExecute(ctx EvalContext) (di
 	}
 	if ctx.PolicyGraph() != nil {
 		for _, input := range policyInputs {
-			if input.Unknown {
-				continue
-			}
 			ctx.PolicyGraph().AddQuery(&nodeQueryResourcePolicy{
 				ResourceAddr:    input.SyntheticAddr,
 				ProviderAddr:    n.ResolvedProvider,
@@ -178,6 +175,7 @@ func (n *NodePlannableResourceInstance) listResourceExecute(ctx EvalContext) (di
 				Identity:        input.Identity,
 				ResourceConfig:  input.ResourceConfig,
 				ListBlockAddr:   input.ListBlockAddr,
+				Unknown:         input.Unknown,
 			})
 		}
 	}


### PR DESCRIPTION
Fixes #

## Target Release

v1.17.0

## Description

Terraform query policy summaries could omit resources whose policy evaluation was unknown, and valid `n/a` results were rejected or rendered as Unknown. This fix preserves one result per discovered resource, retains evaluation diagnostics, accepts `n/a` in JSON summaries, and consistently renders Pass, Fail, Unknown, N/A, and Error outcomes.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.

## Smoke Testing

These tests require locally built `tfpolicy` binaries. The `tfpolicy` CLI and `tfpolicy-plugin` executable are separate binaries. Terraform uses `tfpolicy-plugin` through `TF_POLICY_PLUGIN`.

The `-policies` flag requires an experimental Terraform build.

Replace the example paths with the locations of the local checkouts.

### Build Binaries

```sh
cd /path/to/terraform

TFQUERY_DIR="$(mktemp -d)"
go build \
  -ldflags="-X 'main.experimentsAllowed=yes'" \
  -o "$TFQUERY_DIR/terraform-query-policy" .

export TFQUERY="$TFQUERY_DIR/terraform-query-policy"
```

Build the `tfpolicy` validation CLI:

```sh
cd /path/to/terraform-policy-cli

make bin
export TFPOLICY="$PWD/dist/$(go env GOOS)/$(go env GOARCH)/tfpolicy"
```

Build the Terraform policy plugin:

```sh
cd /path/to/terraform-policy-plugin

make bin
export TF_POLICY_PLUGIN="$PWD/dist/$(go env GOOS)/$(go env GOARCH)/tfpolicy-plugin"
```

Configure AWS credentials for an account containing at least one S3 bucket discoverable in `us-east-1`.

### Local Configuration

No remote backend configuration should be present.

```sh
SMOKE_DIR="$(mktemp -d)"
mkdir -p "$SMOKE_DIR/policies"/{pass,fail,na,error}
cd "$SMOKE_DIR"
```

Create `main.tf`:

```hcl
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 6.0"
    }
  }
}

provider "aws" {
  region = "us-east-1"
}
```

Initialize using the local backend:

```sh
"$TFQUERY" init -backend=false -no-color
```

Create `main.tfquery.hcl`:

```hcl
list "aws_s3_bucket" "all_east1_buckets" {
  provider         = aws
  include_resource = true
  config {}
}
```

### Policy Files

Create `policies/pass/region.policy.hcl`:

```hcl
resource_policy "aws_s3_bucket" "require_us_east_region" {
  enforce {
    condition     = core::try(attrs.region == "us-east-1", false)
    error_message = "S3 bucket must be in us-east-1."
  }
}
```

Create `policies/fail/always_fail.policy.hcl`:

```hcl
resource_policy "aws_s3_bucket" "intentional_failure" {
  enforce {
    condition     = false
    error_message = "Intentional smoke-test failure."
  }
}
```

Create `policies/na/unmatched.policy.hcl`:

```hcl
resource_policy "aws_instance" "unmatched_resource_type" {
  enforce {
    condition     = true
    error_message = "This policy should not match an S3 bucket."
  }
}
```

Create `policies/error/runtime_error.policy.hcl`:

```hcl
resource_policy "aws_s3_bucket" "runtime_error" {
  enforce {
    condition     = null
    error_message = "This policy intentionally produces an evaluation error."
  }
}
```

Validate the policy sets:

```sh
"$TFPOLICY" validate --policies policies/pass
"$TFPOLICY" validate --policies policies/fail
"$TFPOLICY" validate --policies policies/na
"$TFPOLICY" validate --policies policies/error
```

### JSON Summary Helper

Use this helper to verify the summary status:

```sh
check_summary() {
  expected="$1"
  output="$2"

  python3 - "$expected" "$output" <<'PY'
import json
import sys

expected, path = sys.argv[1:]
summaries = []

with open(path, encoding="utf-8") as stream:
    for line in stream:
        if not line.strip():
            continue
        record = json.loads(line)
        if record.get("type") == "policy_query_summary":
            summaries.append(record)

assert summaries, "no policy_query_summary record was emitted"

for summary in summaries:
    assert summary["overall_result"] == expected, summary
    assert summary["results"], "summary contained no discovered rows"
    for result in summary["results"]:
        assert result["result"] == expected, result

print(f"PASS: {path} contains {expected} policy result(s)")
PY
}
```

### Pass

```sh
"$TFQUERY" query -no-color \
  -policies=policies/pass \
  2>&1 | tee pass.txt

"$TFQUERY" query -no-color -json \
  -policies=policies/pass > pass.jsonl

check_summary pass pass.jsonl
```

Expected human output includes:

```text
Policy results for list.aws_s3_bucket.all_east1_buckets - Passed
```

Every discovered row should be `Passed`, and JSON `overall_result` should be `pass`.

### Fail

```sh
"$TFQUERY" query -no-color \
  -policies=policies/fail \
  2>&1 | tee fail.txt

"$TFQUERY" query -no-color -json \
  -policies=policies/fail > fail.jsonl

check_summary fail fail.jsonl
```

Expected human output includes:

```text
Policy results for list.aws_s3_bucket.all_east1_buckets - Failed
```

Every discovered row should be `Failed`, and the output should include the intentional policy diagnostic.

### Unknown

Change `main.tfquery.hcl` to set `include_resource = false`:

```hcl
list "aws_s3_bucket" "all_east1_buckets" {
  provider         = aws
  include_resource = false
  config {}
}
```

Run with the matching policy:

```sh
"$TFQUERY" query -no-color \
  -policies=policies/pass \
  2>&1 | tee unknown.txt

"$TFQUERY" query -no-color -json \
  -policies=policies/pass > unknown.jsonl

check_summary unknown unknown.jsonl
```

Expected output includes a `Policy evaluation skipped` warning and:

```text
Policy results for list.aws_s3_bucket.all_east1_buckets - Unknown
```

Each discovered row should be `Unknown`. The policy engine should not evaluate those rows because resource state was excluded.

### N/A

Restore `include_resource = true` in `main.tfquery.hcl`, then run with the policy that targets a different resource type:

```sh
"$TFQUERY" query -no-color \
  -policies=policies/na \
  2>&1 | tee na.txt

"$TFQUERY" query -no-color -json \
  -policies=policies/na > na.jsonl

check_summary n/a na.jsonl
```

Expected human output includes:

```text
Policy results for list.aws_s3_bucket.all_east1_buckets - N/A
```

Each JSON row should have `result: "n/a"` and an empty `policies` array. This verifies that a resource matching no policies is reported as N/A rather than Unknown.

### Error

Run with the policy containing the intentional runtime-invalid condition:

```sh
"$TFQUERY" query -no-color \
  -policies=policies/error \
  2>&1 | tee error.txt

"$TFQUERY" query -no-color -json \
  -policies=policies/error > error.jsonl

check_summary error error.jsonl
```

Expected human output includes:

```text
Policy results for list.aws_s3_bucket.all_east1_buckets - Error
```

The output should include an evaluation diagnostic for the invalid condition, and JSON `overall_result` should be `error`.

Do not use a missing plugin for this scenario. A missing or unusable plugin produces a setup diagnostic and does not exercise a row-level Error result.

An empty list result cannot validate row-level statuses, so confirm that the query discovers at least one S3 bucket.

## Verification

Focused tests completed successfully:

```text
go test ./internal/command/views -run 'Query|query'
go test ./internal/terraform -run 'Query|query|Policy'
go test ./internal/policy -run 'Client|Policy|Result|Evaluate'
go test ./internal/cloud -run 'Query|query|Policy'
go test -race ./internal/command/views ./internal/terraform ./internal/cloud
```
