### PR TITLE
fix(checks): add mutex to ObjectFailureMessages

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260825-171201.yaml
+++ b/.changes/v1.17/BUG FIXES-20260825-171201.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'checks: fix data race in ObjectFailureMessages by adding mutex protection'
+time: 2026-08-25T22:12:01.000000+00:00
+custom:
+    Issue: "39060"

--- a/internal/checks/state.go
+++ b/internal/checks/state.go
@@ -258,6 +258,9 @@ func (c *State) ObjectCheckStatus(addr addrs.Checkable) Status {
 // ObjectCheckStatus's result because errors are defined as "stronger"
 // than failures.
 func (c *State) ObjectFailureMessages(addr addrs.Checkable) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	var ret []string
 
 	configAddr := addr.ConfigCheckable()


### PR DESCRIPTION
Fixes data race in checks.State.

ObjectFailureMessages at internal/checks/state.go:260 reads shared state without holding c.mu, while all sibling accessors (RegisterModule, ConfigHasChecks, AllConfigAddrs, ObjectAddrs, AggregateCheckStatus, ObjectCheckStatus) correctly lock the mutex. Concurrent plan and apply operations can trigger a race on c.statuses and c.failureMsgs.

Fix adds c.mu.Lock and defer c.mu.Unlock as the first two lines of the method, matching the existing pattern.

Verification: go test ./internal/checks passes with and without -race. Tiny diff, single file.