### PR TITLE
state_migrate: Enable machine-readable output via -json flag, add first integration tests

### DIFF
--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -2114,3 +2114,68 @@ func TestStateMigrate_nonExistentLockFiles(t *testing.T) {
 		t.Fatalf("expected output %q, got %q", expectedMsg, out.All())
 	}
 }
+
+func TestStateMigrate_JSONOutput(t *testing.T) {
+	// All test scenarios use the same args to make assertions about JSON output
+	args := []string{"-input=false", "-json", "-force-copy"}
+
+	t.Run("backend to backend", func(t *testing.T) {
+		fixture := "state-migrate-backend-to-backend"
+		wd := tempWorkingDirFixture(t, fixture)
+		t.Chdir(wd.RootModuleDir())
+
+		ui := testUiWrapped(t)
+		view, done := testView(t)
+		c := &StateMigrateCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				WorkingDir:                wd,
+				AllowExperimentalFeatures: true,
+			},
+		}
+
+		code := c.Run(args)
+		out := done(t)
+		if code != 0 {
+			t.Fatalf("expected exit code 1, got %d:\n %q", code, out.All())
+		}
+
+		// Assert expected JSON output is made
+		checkGoldenReference(t, out, fixture)
+	})
+
+	t.Run("backend to state-store", func(t *testing.T) {
+		fixture := "state-migrate-backend-to-state-store"
+		wd := tempWorkingDirFixture(t, fixture)
+		t.Chdir(wd.RootModuleDir())
+
+		p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		p.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
+		providerSource := newMockProviderSource(t, map[string][]string{
+			"hashicorp/test": {"1.2.3"},
+		})
+
+		ui := testUiWrapped(t)
+		view, done := testView(t)
+		c := &StateMigrateCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				WorkingDir:                wd,
+				AllowExperimentalFeatures: true,
+				testingOverrides:          metaOverridesForProvider(p),
+				ProviderSource:            providerSource,
+			},
+		}
+
+		code := c.Run(args)
+		out := done(t)
+		if code != 0 {
+			t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
+		}
+
+		// Assert expected JSON output is made
+		checkGoldenReference(t, out, fixture)
+	})
+}

--- a/internal/command/testdata/state-migrate-backend-to-backend/output.jsonlog
+++ b/internal/command/testdata/state-migrate-backend-to-backend/output.jsonlog
@@ -1,0 +1,8 @@
+{"@level":"info","@message":"Terraform 1.17.0-dev","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","terraform":"1.17.0-dev","type":"version","ui":"1.3"}
+{"@level":"info","@message":"Initializing source...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_start"}
+{"@level":"info","@message":"Initialized source.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_complete"}
+{"@level":"info","@message":"Initializing destination...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_start"}
+{"@level":"info","@message":"Initialized destination.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_complete"}
+{"@level":"info","@message":"Migrating state from backend \"local\" to backend \"local\"...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_start"}
+{"@level":"info","@message":"The migration process has copied state from the backend \"local\" to the backend \"local\"","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_complete"}
+{"@level":"info","@message":"Finished migrating state from backend \"local\" to backend \"local\".","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_finalized"}

--- a/internal/command/testdata/state-migrate-backend-to-state-store/output.jsonlog
+++ b/internal/command/testdata/state-migrate-backend-to-state-store/output.jsonlog
@@ -1,0 +1,12 @@
+{"@level":"info","@message":"Terraform 1.17.0-dev","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","terraform":"1.17.0-dev","type":"version","ui":"1.3"}
+{"@level":"info","@message":"Initializing source...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_start"}
+{"@level":"info","@message":"Initialized source.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_complete"}
+{"@level":"info","@message":"Initializing destination...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_start"}
+{"@level":"info","@message":"Installing providers...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"provider_installation_start"}
+{"@level":"info","@message":"hashicorp/test: Reusing version 1.2.3 from the dependency lock file","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"provider_query_use_previous_version"}
+{"@level":"info","@message":"Installing provider version: hashicorp/test v1.2.3...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"provider_version_installation_start"}
+{"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (verified checksum)","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"provider_version_installation_complete"}
+{"@level":"info","@message":"Initialized destination.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_complete"}
+{"@level":"info","@message":"Migrating state from backend \"local\" to state store \"test_store\" (hashicorp/test 1.2.3)...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_start"}
+{"@level":"info","@message":"The migration process has copied state from the backend \"local\" to the state store \"test_store\" (hashicorp/test 1.2.3)","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_complete"}
+{"@level":"info","@message":"Finished migrating state from backend \"local\" to state store \"test_store\" (hashicorp/test 1.2.3).","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_finalized"}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -96,6 +96,10 @@ func NewStateMigrate(viewType arguments.ViewType, view *View) StateMigrate {
 	switch viewType {
 	case arguments.ViewHuman:
 		return &StateMigrateHuman{view: view}
+	case arguments.ViewJSON:
+		return &StateMigrateJSON{
+			view: NewJSONView(view),
+		}
 	default:
 		panic(fmt.Sprintf("unsupported view type: %s", viewType))
 	}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -103,7 +103,7 @@ func TestNewStateMigrate_LogInstallProviderVersionCompleteWithKeyID(t *testing.T
 func TestNewStateMigrate_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.Spacer()
 
@@ -121,7 +121,7 @@ func TestNewStateMigrate_Spacer_json(t *testing.T) {
 func TestNewStateMigrate_LogInteractiveApproval_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogInteractiveApproval()
 
@@ -143,7 +143,7 @@ func TestNewStateMigrate_LogInteractiveApproval_json(t *testing.T) {
 func TestNewStateMigrate_LogInteractiveRejection_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogInteractiveRejection()
 
@@ -165,7 +165,7 @@ func TestNewStateMigrate_LogInteractiveRejection_json(t *testing.T) {
 func TestNewStateMigrate_LogAutomaticApproval_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogAutomaticApproval()
 
@@ -187,7 +187,7 @@ func TestNewStateMigrate_LogAutomaticApproval_json(t *testing.T) {
 func TestNewStateMigrate_LogDependencyLockfileCreated_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogProviderLockfileCreated()
 
@@ -209,7 +209,7 @@ func TestNewStateMigrate_LogDependencyLockfileCreated_json(t *testing.T) {
 func TestNewStateMigrate_LogDependencyLockfileUpdated_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogProviderLockfileUpdated()
 
@@ -231,7 +231,7 @@ func TestNewStateMigrate_LogDependencyLockfileUpdated_json(t *testing.T) {
 func TestNewStateMigrate_LogInstallProvidersStart_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogInstallProvidersStart()
 
@@ -253,7 +253,7 @@ func TestNewStateMigrate_LogInstallProvidersStart_json(t *testing.T) {
 func TestNewStateMigrate_LogReusingPreviousProviderVersion_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	version := getproviders.MustParseVersion("1.0.0")
@@ -277,7 +277,7 @@ func TestNewStateMigrate_LogReusingPreviousProviderVersion_json(t *testing.T) {
 func TestNewStateMigrate_LogFindingMatchingVersion_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	constraint, _ := getproviders.ParseVersionConstraints("1.0.0")
@@ -301,7 +301,7 @@ func TestNewStateMigrate_LogFindingMatchingVersion_json(t *testing.T) {
 func TestNewStateMigrate_LogFindingLatestVersion_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	smView.LogFindingLatestVersion(p)
@@ -324,7 +324,7 @@ func TestNewStateMigrate_LogFindingLatestVersion_json(t *testing.T) {
 func TestNewStateMigrate_LogProviderVersionAlreadyInstalled_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	version := getproviders.MustParseVersion("1.0.0")
@@ -348,7 +348,7 @@ func TestNewStateMigrate_LogProviderVersionAlreadyInstalled_json(t *testing.T) {
 func TestNewStateMigrate_LogUsingProviderVersionFromCacheDir_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	version := getproviders.MustParseVersion("1.0.0")
@@ -372,7 +372,7 @@ func TestNewStateMigrate_LogUsingProviderVersionFromCacheDir_json(t *testing.T) 
 func TestNewStateMigrate_LogInstallProviderVersionComplete_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	v := versions.MustParseVersion("1.0.0")
@@ -398,7 +398,7 @@ func TestNewStateMigrate_LogInstallProviderVersionComplete_json(t *testing.T) {
 func TestNewStateMigrate_LogInstallProviderVersionCompleteWithKeyID_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	v := versions.MustParseVersion("1.0.0")
@@ -425,7 +425,7 @@ func TestNewStateMigrate_LogInstallProviderVersionCompleteWithKeyID_json(t *test
 func TestNewStateMigrate_LogBuiltInProviderAvailable_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	p := addrs.MustParseProviderSourceString("hashicorp/test")
 	smView.LogBuiltInProviderAvailable(p)
@@ -448,7 +448,7 @@ func TestNewStateMigrate_LogBuiltInProviderAvailable_json(t *testing.T) {
 func TestNewStateMigrate_LogPartnerAndCommunityProviders_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogPartnerAndCommunityProviders()
 
@@ -470,7 +470,7 @@ func TestNewStateMigrate_LogPartnerAndCommunityProviders_json(t *testing.T) {
 func TestNewStateMigrate_LogStateMigrationStart_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	source := "backend \"s3\""
 	destination := "state store \"test_store\""
@@ -494,7 +494,7 @@ func TestNewStateMigrate_LogStateMigrationStart_json(t *testing.T) {
 func TestNewStateMigrate_LogStateMigrationComplete_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	source := "backend \"s3\""
 	destination := "state store \"test_store\""
@@ -518,7 +518,7 @@ func TestNewStateMigrate_LogStateMigrationComplete_json(t *testing.T) {
 func TestNewStateMigrate_LogStateMigrationFinalized_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	source := "backend \"s3\""
 	destination := "state store \"test_store\""
@@ -543,7 +543,7 @@ func TestNewStateMigrate_LogStateMigrationErrored_json(t *testing.T) {
 	t.Run("migration itself fails", func(t *testing.T) {
 		streams, done := terminal.StreamsForTesting(t)
 		view := NewView(streams)
-		smView := StateMigrateJSON{view: NewJSONView(view)}
+		smView := NewStateMigrate(arguments.ViewJSON, view)
 
 		source := "backend \"s3\""
 		destination := "state store \"test_store\""
@@ -568,7 +568,7 @@ func TestNewStateMigrate_LogStateMigrationErrored_json(t *testing.T) {
 	t.Run("provider lockfile update fails", func(t *testing.T) {
 		streams, done := terminal.StreamsForTesting(t)
 		view := NewView(streams)
-		smView := StateMigrateJSON{view: NewJSONView(view)}
+		smView := NewStateMigrate(arguments.ViewJSON, view)
 
 		source := "backend \"s3\""
 		destination := "state store \"test_store\""
@@ -592,7 +592,7 @@ func TestNewStateMigrate_LogStateMigrationErrored_json(t *testing.T) {
 	t.Run("backend state file update fails", func(t *testing.T) {
 		streams, done := terminal.StreamsForTesting(t)
 		view := NewView(streams)
-		smView := StateMigrateJSON{view: NewJSONView(view)}
+		smView := NewStateMigrate(arguments.ViewJSON, view)
 
 		source := "backend \"s3\""
 		destination := "state store \"test_store\""
@@ -617,7 +617,7 @@ func TestNewStateMigrate_LogStateMigrationErrored_json(t *testing.T) {
 func TestNewStateMigrate_LogMigrationSourceInitializationStart_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogMigrationSourceInitializationStart()
 
@@ -639,7 +639,7 @@ func TestNewStateMigrate_LogMigrationSourceInitializationStart_json(t *testing.T
 func TestNewStateMigrate_LogMigrationSourceInitializationComplete_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogMigrationSourceInitializationComplete()
 
@@ -661,7 +661,7 @@ func TestNewStateMigrate_LogMigrationSourceInitializationComplete_json(t *testin
 func TestNewStateMigrate_LogMigrationDestinationInitializationStart_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogMigrationDestinationInitializationStart()
 
@@ -683,7 +683,7 @@ func TestNewStateMigrate_LogMigrationDestinationInitializationStart_json(t *test
 func TestNewStateMigrate_LogMigrationDestinationInitializationComplete_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)
-	smView := StateMigrateJSON{view: NewJSONView(view)}
+	smView := NewStateMigrate(arguments.ViewJSON, view)
 
 	smView.LogMigrationDestinationInitializationComplete()
 


### PR DESCRIPTION
Prior to this PR the `state migrate` command accepted a `-json` CLI flag but using it resulted in an error about an unknown view. Now the JSON view is fully implemented in the code base we can connect things up to enable JSON output to be used.

As part of this I've added minimal integration tests that make assertions about JSON output for a given `state migrate` scenario. I don't think we should add exhaustive tests like these as there are so many different variables to combine (e.g. is a provider locked or not, in a global cache or downloaded from a remote location, etc.).

Also I have done some repetitive refactoring to tests in the `views` package. When reviewing it may be helpful to go commit by commit.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
