### PR TITLE
checks: fix panic in RegisterModule when a module fails to load without error diagnostics

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260826-193225.yaml
+++ b/.changes/v1.17/BUG FIXES-20260826-193225.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fixed a crash during module installation when a module fails to load without producing any error diagnostics
+time: 2026-08-26T19:32:25.000000-00:00
+custom:
+    Issue: "1"

--- a/.changes/v1.17/BUG FIXES-20260826-193225.yaml
+++ b/.changes/v1.17/BUG FIXES-20260826-193225.yaml
@@ -2,4 +2,4 @@ kind: BUG FIXES
 body: Fixed a crash during module installation when a module fails to load without producing any error diagnostics
 time: 2026-08-26T19:32:25.000000-00:00
 custom:
-    Issue: "1"
+    Issue: "39067"

--- a/internal/checks/state_init.go
+++ b/internal/checks/state_init.go
@@ -23,6 +23,12 @@ func initialStatuses(cfg *configs.Config) addrs.Map[addrs.ConfigCheckable, *conf
 }
 
 func collectInitialStatuses(into addrs.Map[addrs.ConfigCheckable, *configCheckableState], cfg *configs.Config) {
+	if cfg == nil || cfg.Module == nil {
+		// Can happen if a module failed to load without producing any
+		// error diagnostics, in which case there's nothing to collect.
+		return
+	}
+
 	moduleAddr := cfg.Path
 
 	for _, rc := range cfg.Module.ManagedResources {

--- a/internal/checks/state_test.go
+++ b/internal/checks/state_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
+	"github.com/hashicorp/terraform/internal/configs"
 	tftesting "github.com/hashicorp/terraform/internal/terraform/testing"
 )
 
@@ -210,4 +211,20 @@ func TestChecksHappyPath(t *testing.T) {
 			}
 		}
 	}
+}
+
+// During module installation, Terraform Core registers each newly-loaded
+// module's config incrementally via RegisterModule. If a module fails to
+// load without producing any error diagnostics, the resulting *configs.Config
+// can have a nil Module field, and RegisterModule must not panic in that
+// case.
+func TestRegisterModuleWithNilModule(t *testing.T) {
+	state := checks.NewState(nil)
+
+	cfg := &configs.Config{
+		Path:   addrs.Module{"child"},
+		Module: nil,
+	}
+
+	state.RegisterModule(cfg)
 }


### PR DESCRIPTION
Fixes #38580.

`checks.State.RegisterModule()` panics with a nil pointer dereference when it's given a `*configs.Config` whose `Module` field is nil — this can happen during module installation (`internal/terraform/node_module_install.go`) if loading a child module fails without producing error diagnostics. The sibling function `initialStatuses()` already guards against a nil `*configs.Config`, but `RegisterModule` didn't, and neither guarded against a non-nil config with a nil `Module`.

This adds that guard to the shared `collectInitialStatuses()` helper and a regression test that reproduces the exact panic reported in #38580.

**AI disclosure:** Used Claude to help diagnose the crash and write the fix and regression test; I reviewed and verified all of it, including reproducing the panic locally before and confirming it's fixed after.

Verification:
- `go test ./internal/checks/...` — pass (new regression test fails on pre-fix code, passes after)
- `go test ./internal/terraform/... ./internal/initwd/...` — pass, no regressions
- `gofmt -l` — clean