### PR TITLE
[draft] schemas filtering prototype

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -228,6 +228,12 @@ func initCommands(
 			}, nil
 		},
 
+		"metadata schema": func() (cli.Command, error) {
+			return &command.MetadataSchemaCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"modules": func() (cli.Command, error) {
 			return &command.ModulesCommand{
 				Meta: meta,

--- a/internal/addrs/provider.go
+++ b/internal/addrs/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 	svchost "github.com/hashicorp/terraform-svchost"
+
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 

--- a/internal/command/arguments/metadata_schema.go
+++ b/internal/command/arguments/metadata_schema.go
@@ -1,0 +1,153 @@
+package arguments
+
+import (
+	"fmt"
+
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// MetadataSchema contains the command-line arguments for the metadata
+// schema command.
+type MetadataSchema struct {
+	JSON bool
+
+	// Var, State are the common extended flags
+	Vars  *Vars
+	State *State // probably should not handle this with extended flags - most state flags don't apply to this command (maybe????)
+
+	Filters SchemaFilters
+}
+
+type SchemaFilters struct {
+	ProviderFilter    *tfaddr.Provider
+	ProvisionerFilter string
+	RType             SchemaType // type as in "resource", "action", etc
+	TypeName          string     // "aws_instance", "local-exec"
+	Prune             bool
+	ConfigOnly        bool
+	StateOnly         bool
+}
+
+// inspired by addrs.ResourceMode, extended to include things that aren't strictly Resources
+type SchemaType int
+
+const (
+	NoType SchemaType = iota
+	DataSource
+	Resource
+	EphemeralResource
+	ListResource
+	Function
+	Action
+	Provider
+	Provisioner
+	StateStore
+	Invalid
+)
+
+func ParseMetadataSchemas(args []string) (*MetadataSchema, tfdiags.Diagnostics) {
+	schemas := &MetadataSchema{
+		Vars:    &Vars{},
+		State:   &State{},
+		Filters: SchemaFilters{},
+	}
+	var diags tfdiags.Diagnostics
+
+	// raw args to be parsed
+	var providerFilter, rType string
+
+	// flags directly assigned to the schemas struct
+	cmdFlags := extendedFlagSet("providers schema", schemas.State, nil, schemas.Vars)
+	cmdFlags.BoolVar(&schemas.JSON, "json", false, "produce JSON output")
+	cmdFlags.BoolVar(&schemas.Filters.ConfigOnly, "config-only", false, "only return providers in config")
+	cmdFlags.BoolVar(&schemas.Filters.StateOnly, "state-only", false, "only return providers in state")
+	cmdFlags.StringVar(&schemas.Filters.TypeName, "name", "", "type name")
+	cmdFlags.BoolVar(&schemas.Filters.Prune, "prune", false, "limit response to schemas used in the config and/or state")
+	cmdFlags.StringVar(&schemas.Filters.ProvisionerFilter, "provisioner", "", "return schemas from this provisioner")
+
+	// more parsing required
+	cmdFlags.StringVar(&rType, "type", "", "resource type") // needs better descriptor for resource++
+	cmdFlags.StringVar(&providerFilter, "provider", "", "return schemas from this provider")
+
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			err.Error(),
+		))
+	}
+
+	args = cmdFlags.Args()
+	if len(args) > 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Too many command line arguments",
+			"Expected no positional arguments.",
+		))
+	}
+
+	if !schemas.JSON {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"The -json flag is required",
+			"The `terraform metadata schema` command requires the `-json` flag.",
+		))
+	}
+
+	if schemas.Filters.ConfigOnly && schemas.Filters.StateOnly {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Conflicting flags",
+			"-config-only and -state-only are mutually exclusive flags.",
+		))
+	}
+
+	if providerFilter != "" {
+		switch providerFilter {
+		case "terraform", "builtin/terraform", "hashicorp/terraform": // i'm sure one of the parsers can actually handle this
+			tfp := tfaddr.Provider(addrs.NewBuiltInProvider("terraform"))
+			schemas.Filters.ProviderFilter = &tfp
+		default:
+			provider, pDiags := addrs.ParseProviderSourceString(providerFilter)
+			if diags.HasErrors() {
+				diags.Append(pDiags)
+			}
+			schemas.Filters.ProviderFilter = &provider
+		}
+	}
+
+	switch rType {
+	case "":
+		schemas.Filters.RType = NoType
+	case "datasource", "data-source":
+		schemas.Filters.RType = DataSource
+	case "resource":
+		schemas.Filters.RType = Resource
+	case "ephemeral", "ephemeral-resource":
+		schemas.Filters.RType = EphemeralResource
+	case "list", "list-resource":
+		schemas.Filters.RType = ListResource
+	case "action":
+		schemas.Filters.RType = Action
+	case "function":
+		schemas.Filters.RType = Function
+	case "provider", "provider-config":
+		schemas.Filters.RType = Provider
+	case "provisioner":
+		schemas.Filters.RType = Provisioner
+	case "state-store":
+		schemas.Filters.RType = StateStore
+	default:
+		schemas.Filters.RType = Invalid
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid arguments",
+			fmt.Sprintf("%q is not a valid resource type filter.", rType),
+		))
+	}
+
+	return schemas, diags
+}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/hashicorp/cli"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/disco"
@@ -89,7 +88,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// tempWorkingDir constructs a workdir.Dir object referring to a newly-created
 // tempWorkingDir constructs a workdir.Dir object referring to a newly-created
 // temporary directory. The temporary directory is automatically removed when
 // the test and all its subtests complete.
@@ -1433,5 +1431,83 @@ func checkGoldenReferenceStr(t *testing.T, output *terminal.TestOutput, want str
 		t.Errorf("wrong output lines\n%s\n"+
 			"NOTE: This failure may indicate a UI change affecting the behavior of structured run output on TFC.\n"+
 			"Please communicate with HCP Terraform team before resolving", diff)
+	}
+}
+
+// stealing from internal/terraform
+func simpleMockProvider() *testing_provider.MockProvider {
+	return &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{Body: simpleTestSchema()},
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": {Body: simpleTestSchema()},
+			},
+			DataSources: map[string]providers.Schema{
+				"test_object": {Body: simpleTestSchema()},
+			},
+			EphemeralResourceTypes: map[string]providers.Schema{
+				"test_object": {Body: simpleTestSchema()},
+			},
+			ListResourceTypes: map[string]providers.Schema{
+				"test_object": {Body: listTestSchema()},
+			},
+			Actions: map[string]providers.ActionSchema{
+				"test_action": {ConfigSchema: simpleTestSchema()},
+			},
+		},
+	}
+}
+
+func simpleTestSchema() *configschema.Block {
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"test_string": {
+				Type:     cty.String,
+				Optional: true,
+			},
+			"test_number": {
+				Type:     cty.Number,
+				Optional: true,
+			},
+			"test_bool": {
+				Type:     cty.Bool,
+				Optional: true,
+			},
+			"test_list": {
+				Type:     cty.List(cty.String),
+				Optional: true,
+			},
+			"test_map": {
+				Type:     cty.Map(cty.String),
+				Optional: true,
+			},
+		},
+	}
+}
+
+// list needs a config attr or we get panics in odd places
+func listTestSchema() *configschema.Block {
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"data": {
+				Type:     cty.DynamicPseudoType,
+				Computed: true,
+			},
+		},
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"config": {
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"foo": {
+							Type:     cty.String,
+							Optional: true,
+						},
+					},
+				},
+				Nesting:  configschema.NestingSingle,
+				MinItems: 1,
+				MaxItems: 1,
+			},
+		},
 	}
 }

--- a/internal/command/jsonprovider/provider.go
+++ b/internal/command/jsonprovider/provider.go
@@ -62,15 +62,28 @@ func Marshal(s *terraform.Schemas) ([]byte, error) {
 }
 
 func marshalProvider(tps providers.ProviderSchema) *Provider {
-	p := &Provider{
-		Provider:                 marshalSchema(tps.Provider),
-		ResourceSchemas:          marshalSchemas(tps.ResourceTypes),
-		DataSourceSchemas:        marshalSchemas(tps.DataSources),
-		EphemeralResourceSchemas: marshalSchemas(tps.EphemeralResourceTypes),
-		Functions:                jsonfunction.MarshalProviderFunctions(tps.Functions),
-		ResourceIdentitySchemas:  marshalIdentitySchemas(tps.ResourceTypes),
-		ActionSchemas:            marshalActionSchemas(tps.Actions),
-		StateStoreSchemas:        marshalSchemas(tps.StateStores),
+	p := &Provider{}
+	if tps.Provider.Body != nil { // provider config not included in schema
+		p.Provider = marshalSchema(tps.Provider)
+	}
+	if tps.ResourceTypes != nil {
+		p.ResourceSchemas = marshalSchemas(tps.ResourceTypes)
+		p.ResourceIdentitySchemas = marshalIdentitySchemas(tps.ResourceTypes)
+	}
+	if tps.DataSources != nil {
+		p.DataSourceSchemas = marshalSchemas(tps.DataSources)
+	}
+	if tps.EphemeralResourceTypes != nil {
+		p.EphemeralResourceSchemas = marshalSchemas(tps.EphemeralResourceTypes)
+	}
+	if tps.Functions != nil {
+		p.Functions = jsonfunction.MarshalProviderFunctions(tps.Functions)
+	}
+	if tps.Actions != nil {
+		p.ActionSchemas = marshalActionSchemas(tps.Actions)
+	}
+	if tps.StateStores != nil {
+		p.StateStoreSchemas = marshalSchemas(tps.StateStores)
 	}
 
 	// List resource schemas are nested under a "config" block, so we need to

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -20,8 +20,15 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
+	backendInit "github.com/hashicorp/terraform/internal/backend/init"
+	"github.com/hashicorp/terraform/internal/backend/local"
+	backendLocal "github.com/hashicorp/terraform/internal/backend/local"
+	"github.com/hashicorp/terraform/internal/backend/pluggable"
+	backendInmem "github.com/hashicorp/terraform/internal/backend/remote-state/inmem"
 	"github.com/hashicorp/terraform/internal/cloud"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/clistate"
@@ -39,14 +46,6 @@ import (
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
-
-	"github.com/zclconf/go-cty/cty"
-
-	backendInit "github.com/hashicorp/terraform/internal/backend/init"
-	"github.com/hashicorp/terraform/internal/backend/local"
-	backendLocal "github.com/hashicorp/terraform/internal/backend/local"
-	"github.com/hashicorp/terraform/internal/backend/pluggable"
-	backendInmem "github.com/hashicorp/terraform/internal/backend/remote-state/inmem"
 )
 
 // Test empty directory with no config/state creates a local state.

--- a/internal/command/metadata_schema.go
+++ b/internal/command/metadata_schema.go
@@ -1,0 +1,37 @@
+// the metadata_schema command is similar to providers schemas, in that it
+// returns schemas for providers found in state and configuration (defaults to
+// both, can use either),  but it also includes provisioner schemas, can get
+// schemas for providers or provisioners not in the local config (using any
+// configured installation methods), and can filter results.
+package command
+
+type MetadataSchemaCommand struct {
+	Meta
+}
+
+func (c *MetadataSchemaCommand) Help() string {
+	return metadataSchemaCommandHelp
+}
+
+func (c *MetadataSchemaCommand) Synopsis() string {
+	return "Show schemas for providers and provisioners"
+}
+
+func (c *MetadataSchemaCommand) Run(args []string) int {
+	// parse args
+	// get providers & provisioners from local config & state
+	// switch -
+	//   return all config and state
+	//   return only config or state
+	//   lookup specific provider by version (check if provider/version tuple already found)
+	//   lookup specific provisioner
+	// add filtering to results
+
+	return 0 // good job
+}
+
+const metadataSchemaCommandHelp = `
+Usage: terraform [global options] metadata schema -json
+
+  Prints out a json representation of provider and provisioner schemas.
+`

--- a/internal/command/metadata_schema.go
+++ b/internal/command/metadata_schema.go
@@ -5,6 +5,22 @@
 // configured installation methods), and can filter results.
 package command
 
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/backend/backendrun"
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/jsonprovider"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/terraform"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
 type MetadataSchemaCommand struct {
 	Meta
 }
@@ -18,16 +34,398 @@ func (c *MetadataSchemaCommand) Synopsis() string {
 }
 
 func (c *MetadataSchemaCommand) Run(args []string) int {
-	// parse args
-	// get providers & provisioners from local config & state
-	// switch -
-	//   return all config and state
-	//   return only config or state
-	//   lookup specific provider by version (check if provider/version tuple already found)
-	//   lookup specific provisioner
-	// add filtering to results
+	parsedArgs, diags := arguments.ParseMetadataSchemas(c.Meta.process(args))
+	if diags.HasErrors() {
+		// set up the view if possible?
+		c.showDiagnostics(diags) // TODO: this should return json if the view was set up
+		return 1
+	}
+	viewType := arguments.ViewJSON // JSON output is required; omitting -json results in a flag parsing error
+
+	// Check for user-supplied plugin path
+	var err error
+	if c.pluginPath, err = c.loadPluginPath(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
+		return 1
+	}
+
+	// Load the backend
+	b, backendDiags := c.backend(".", viewType)
+	diags = diags.Append(backendDiags)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	// We require a local backend
+	local, ok := b.(backendrun.Local)
+	if !ok {
+		c.showDiagnostics(diags) // in case of any warnings in here
+		c.Ui.Error(ErrUnsupportedLocalOp)
+		return 1
+	}
+
+	// This is a read-only command
+	c.ignoreRemoteVersionConflict(b)
+
+	// Get the config directory
+	cwd := c.WorkingDir.RootModuleDir()
+
+	// Build the operation
+	opReq := c.Operation(b, arguments.ViewJSON)
+	opReq.ConfigDir = cwd
+	opReq.ConfigLoader, err = c.initConfigLoader()
+	opReq.AllowUnsetVariables = true
+	if err != nil {
+		diags = diags.Append(err)
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	var varDiags tfdiags.Diagnostics
+	opReq.Variables, varDiags = parsedArgs.Vars.CollectValues(func(filename string, src []byte) {
+		opReq.ConfigLoader.Parser().ForceFileSource(filename, src)
+	})
+	diags = diags.Append(varDiags)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	// Get the context
+	lr, _, ctxDiags := local.LocalRun(context.Background(), opReq)
+	diags = diags.Append(ctxDiags)
+	if ctxDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	if parsedArgs.Filters.ConfigOnly && parsedArgs.Filters.StateOnly {
+		diags = diags.Append(tfdiags.Sourceless(tfdiags.Error,
+			"Failed to parse command-line flags",
+			"-config-only and -state-only are mutually exclusive. Both cannot be true",
+		))
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	if parsedArgs.Filters.ConfigOnly {
+		if lr.Config == nil {
+			// return error or maybe successful nothing
+			diags = diags.Append(tfdiags.Sourceless(tfdiags.Error,
+				"Invalid inputs",
+				"-config-only was true but no config was found",
+			))
+			c.showDiagnostics(diags)
+			return 1
+		} else {
+			lr.InputState = nil
+		}
+	}
+
+	if parsedArgs.Filters.StateOnly {
+		if lr.InputState == nil {
+			// return error or maybe successful nothing
+			diags = diags.Append(tfdiags.Sourceless(tfdiags.Error,
+				"Invalid inputs",
+				"-state-only was true but no state was found",
+			))
+			c.showDiagnostics(diags)
+			return 1
+		} else {
+			lr.Config = nil
+		}
+	}
+
+	allSchemas, schemaDiags := lr.Core.Schemas(lr.Config, lr.InputState)
+	diags = diags.Append(schemaDiags)
+	if schemaDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	filteredSchemas := &terraform.Schemas{
+		Providers:    map[addrs.Provider]providers.ProviderSchema{},
+		Provisioners: map[string]*configschema.Block{},
+	}
+
+	// the next two blocks could actually run before we pull all schemas if we
+	// "just" consult the installer (not implemented yet because I talked myself
+	// out of this command entirely)
+	if parsedArgs.Filters.ProviderFilter != nil {
+		// get provider locally, or download - no config/state needed
+		// but for now I'm going to do this the providers schema
+		p := parsedArgs.Filters.ProviderFilter
+		filteredSchemas := &terraform.Schemas{
+			Providers: map[addrs.Provider]providers.ProviderSchema{
+				addrs.Provider(*p): filterProvider(allSchemas.Providers[*p], parsedArgs.Filters),
+			},
+		}
+		outDiags := c.marshalAndOutputSchemas(filteredSchemas)
+		diags.Append(outDiags)
+		if diags.HasErrors() {
+			return 1
+		}
+		return 0
+	} else if parsedArgs.Filters.ProvisionerFilter != "" {
+		// get provisioner locally, or download - no config/state needed
+		// but for now I'm only to implement the used config/state path
+		p := parsedArgs.Filters.ProvisionerFilter
+		filteredSchemas := &terraform.Schemas{
+			Provisioners: map[string]*configschema.Block{
+				parsedArgs.Filters.ProvisionerFilter: allSchemas.Provisioners[p],
+			},
+		}
+		outDiags := c.marshalAndOutputSchemas(filteredSchemas)
+		diags.Append(outDiags)
+		if diags.HasErrors() {
+			return 1
+		}
+		return 0
+	} else {
+		// if we're not returning a single provider or provisioner, filter a copy of allSchemas
+		maps.Copy(filteredSchemas.Providers, allSchemas.Providers)
+		maps.Copy(filteredSchemas.Provisioners, allSchemas.Provisioners)
+	}
+
+	// apply (additional) filters here, so we only marshal what the user requested
+	var filterDiags tfdiags.Diagnostics
+	filteredSchemas, filterDiags = filterSchemas(filteredSchemas, parsedArgs.Filters)
+	diags = diags.Append(filterDiags)
+	if filterDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	var pruneDiags tfdiags.Diagnostics
+	if parsedArgs.Filters.Prune {
+		if lr.Config != nil {
+			filteredSchemas, pruneDiags = pruneSchemas(filteredSchemas, lr.Config)
+			diags = diags.Append(pruneDiags)
+			if schemaDiags.HasErrors() {
+				c.showDiagnostics(diags)
+				return 1
+			}
+		} else {
+			// if you run providers schemas with no config, you get terraform schemas
+			// but when -prune is used in a directory with no config, that should be an error
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"No terraform configuration found",
+				"-prune can only be used with config",
+			))
+		}
+	}
+
+	// provisioner marshalling TBD
+	if filteredSchemas != nil {
+		if len(filteredSchemas.Providers) > 0 {
+			jsonSchemas, err := jsonprovider.Marshal(filteredSchemas)
+			if err != nil {
+				diags = diags.Append(err)
+				c.showDiagnostics(diags)
+				return 1
+			}
+			c.Ui.Output(string(jsonSchemas))
+		}
+	}
 
 	return 0 // good job
+}
+
+func (c *MetadataSchemaCommand) marshalAndOutputSchemas(schemas *terraform.Schemas) (diags tfdiags.Diagnostics) {
+	if schemas != nil {
+		if len(schemas.Providers) > 0 {
+			jsonSchemas, err := jsonprovider.Marshal(schemas)
+			if err != nil {
+				diags = diags.Append(err)
+			}
+			c.Ui.Output(string(jsonSchemas))
+		}
+	}
+	return nil
+}
+
+func filterSchemas(schemas *terraform.Schemas, filters arguments.SchemaFilters) (*terraform.Schemas, tfdiags.Diagnostics) {
+	// easy case: only returning provisioners (typename filtering doesn't apply)
+	if filters.RType == arguments.Provisioner {
+		return &terraform.Schemas{Provisioners: schemas.Provisioners}, nil
+	}
+
+	filteredSchema := &terraform.Schemas{
+		Providers:    map[addrs.Provider]providers.ProviderSchema{},
+		Provisioners: map[string]*configschema.Block{},
+	}
+
+	// we've already apply single-provider filtering; now apply type and type name filters
+	for p, schema := range schemas.Providers {
+		providerSchema := filterProvider(schema, filters)
+		filteredSchema.Providers[p] = providerSchema
+	}
+
+	// we've already returned schemas if a specific provisioner was requested,
+	// now we're only including provisioner schemas if they weren't omitted.
+	// Note that this is ignoring type name in favor of the provisioner filter
+	// but both could be supported.
+	if filters.RType == arguments.NoType {
+		maps.Copy(filteredSchema.Provisioners, schemas.Provisioners)
+	}
+
+	return filteredSchema, nil
+}
+
+// filterProvider walks a single provider schema and removes types and types names as determined by the SchemaFilters.
+func filterProvider(schema providers.ProviderSchema, filters arguments.SchemaFilters) providers.ProviderSchema {
+	// nothing to do!
+	if filters.TypeName == "" && filters.RType == arguments.NoType {
+		return schema
+	}
+
+	filteredSchemas := providers.ProviderSchema{}
+	// single type return
+	if filters.RType != arguments.NoType {
+		switch filters.RType {
+		case arguments.Resource:
+			filteredSchemas.ResourceTypes = mapFilter(schema.ResourceTypes, filters.TypeName)
+		case arguments.DataSource:
+			filteredSchemas.DataSources = mapFilter(schema.DataSources, filters.TypeName)
+		case arguments.EphemeralResource:
+			filteredSchemas.EphemeralResourceTypes = mapFilter(schema.EphemeralResourceTypes, filters.TypeName)
+		case arguments.ListResource:
+			filteredSchemas.ListResourceTypes = mapFilter(schema.ListResourceTypes, filters.TypeName)
+		case arguments.Action:
+			filteredSchemas.Actions = mapFilter(schema.Actions, filters.TypeName)
+		case arguments.Function:
+			filteredSchemas.Functions = mapFilter(schema.Functions, filters.TypeName)
+		case arguments.Provider:
+			filteredSchemas.Provider = schema.Provider
+		case arguments.StateStore:
+			filteredSchemas.StateStores = mapFilter(schema.StateStores, filters.TypeName)
+		case arguments.Provisioner:
+			// not relevant here
+		default:
+			// should be impossible!
+			panic("unrecognized resource type filter!")
+		}
+		return filteredSchemas
+	}
+
+	// if we're not returning just one type, we're returning them all
+	filteredSchemas.ResourceTypes = mapFilter(schema.ResourceTypes, filters.TypeName)
+	filteredSchemas.DataSources = mapFilter(schema.DataSources, filters.TypeName)
+	filteredSchemas.EphemeralResourceTypes = mapFilter(schema.EphemeralResourceTypes, filters.TypeName)
+	filteredSchemas.ListResourceTypes = mapFilter(schema.ListResourceTypes, filters.TypeName)
+	filteredSchemas.Actions = mapFilter(schema.Actions, filters.TypeName)
+	filteredSchemas.Functions = mapFilter(schema.Functions, filters.TypeName)
+	filteredSchemas.Provider = schema.Provider
+
+	return filteredSchemas
+}
+
+func pruneSchemas(schemas *terraform.Schemas, config *configs.Config) (*terraform.Schemas, tfdiags.Diagnostics) {
+	// collect used types
+	tys := struct {
+		resourceTys    map[string]any
+		dataSourceTys  map[string]any
+		ephemeralTys   map[string]any
+		listTys        map[string]any
+		actionTys      map[string]any
+		functionTys    map[string]any
+		provisionerTys map[string]any
+		providerTys    map[string]any // not in love with this implementation - providerConfigTys?
+		stateStoreTys  map[string]any
+	}{
+		resourceTys:    map[string]any{},
+		dataSourceTys:  map[string]any{},
+		ephemeralTys:   map[string]any{},
+		listTys:        map[string]any{},
+		actionTys:      map[string]any{},
+		functionTys:    map[string]any{},
+		provisionerTys: map[string]any{},
+		providerTys:    map[string]any{},
+		stateStoreTys:  map[string]any{},
+	}
+
+	config.DeepEach(func(c *configs.Config) {
+		for _, resource := range c.Module.ManagedResources {
+			tys.resourceTys[resource.Type] = true
+			for _, p := range resource.Managed.Provisioners {
+				tys.provisionerTys[p.Type] = true
+			}
+		}
+		for _, datasource := range c.Module.DataResources {
+			tys.dataSourceTys[datasource.Type] = true
+		}
+		for _, ephemeral := range c.Module.EphemeralResources {
+			tys.ephemeralTys[ephemeral.Type] = true
+		}
+		for _, list := range c.Module.ListResources {
+			tys.listTys[list.Type] = true
+		}
+		for _, action := range c.Module.Actions {
+			tys.actionTys[action.Type] = true
+		}
+		if c.Module.StateStore != nil {
+			tys.stateStoreTys[c.Module.StateStore.Type] = true
+		}
+		for pc := range c.Module.ProviderConfigs {
+			tys.providerTys[pc] = true
+		}
+	})
+
+	for p, pSchema := range schemas.Providers {
+		for r := range pSchema.ResourceTypes {
+			if _, ok := tys.resourceTys[r]; !ok {
+				delete(schemas.Providers[p].ResourceTypes, r)
+			}
+		}
+		for d := range pSchema.DataSources {
+			if _, ok := tys.dataSourceTys[d]; !ok {
+				delete(pSchema.DataSources, d)
+			}
+		}
+		for e := range pSchema.EphemeralResourceTypes {
+			if _, ok := tys.ephemeralTys[e]; !ok {
+				delete(pSchema.EphemeralResourceTypes, e)
+			}
+		}
+		for l := range pSchema.ListResourceTypes {
+			if _, ok := tys.listTys[l]; !ok {
+				delete(pSchema.ListResourceTypes, l)
+			}
+		}
+		for a := range pSchema.Actions {
+			if _, ok := tys.actionTys[a]; !ok {
+				delete(pSchema.Actions, a)
+			}
+		}
+		for s := range pSchema.StateStores {
+			if _, ok := tys.stateStoreTys[s]; !ok {
+				delete(pSchema.StateStores, s)
+			}
+		}
+	}
+
+	for p := range schemas.Provisioners {
+		if _, ok := tys.provisionerTys[p]; !ok {
+			delete(schemas.Provisioners, p)
+		}
+	}
+
+	return schemas, nil
+}
+
+// exact matches only
+func mapFilter[V any](schema map[string]V, name string) map[string]V {
+	if name == "" {
+		return schema
+	}
+
+	ret := make(map[string]V)
+	if gotSchema, ok := schema[name]; ok {
+		ret[name] = gotSchema
+	}
+	return ret
 }
 
 const metadataSchemaCommandHelp = `

--- a/internal/command/metadata_schema_test.go
+++ b/internal/command/metadata_schema_test.go
@@ -1,0 +1,172 @@
+package command
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/providers"
+)
+
+func TestMetadataSchema_error(t *testing.T) {
+	t.Parallel()
+	ui := testUiWrapped(t)
+	c := &MetadataSchemaCommand{
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	// This test will always error because it's missing the -json flag
+	if code := c.Run(nil); code != 1 {
+		t.Fatalf("expected error, got:\n%s", ui.OutputWriter.String())
+	}
+}
+
+func TestMetadataSchemas_output(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("metadata-schema"), td)
+	t.Chdir(td)
+	p := simpleMockProvider()
+	pf := &testingOverrides{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"):                        providers.FactoryFixed(p),
+			addrs.MustParseProviderSourceString("austinvalle/bufo"): providers.FactoryFixed(p),
+			addrs.NewDefaultProvider("example"):                     providers.FactoryFixed(p),
+		},
+	}
+
+	t.Run("full output", func(t *testing.T) {
+		ui := testUiWrapped(t)
+		c := &MetadataSchemaCommand{
+			Meta: Meta{
+				Ui:               ui,
+				testingOverrides: pf,
+			},
+		}
+
+		if code := c.Run([]string{"-json"}); code != 0 {
+			t.Fatalf("wrong exit status %d; want 0\nstderr: %s", code, ui.ErrorWriter.String())
+		}
+		output := ui.OutputWriter.String()
+		var got metadataSchemas
+		json.Unmarshal([]byte(output), &got)
+		if len(got.Schemas) != 3 {
+			t.Fatalf("wrong number of provider schemas returned. Got %d, expected 3", len(got.Schemas))
+		}
+	})
+
+	t.Run("filtered by name", func(t *testing.T) {
+		ui := testUiWrapped(t)
+		c := &MetadataSchemaCommand{
+			Meta: Meta{
+				Ui:               ui,
+				testingOverrides: pf,
+			},
+		}
+		if code := c.Run([]string{"-json", "-name=test_action"}); code != 0 {
+			t.Fatalf("wrong exit status %d; want 0\nstderr: %s", code, ui.ErrorWriter.String())
+		}
+		output := ui.OutputWriter.String()
+		var got metadataSchemas
+		json.Unmarshal([]byte(output), &got)
+
+		// every test provider has one test_action
+		if len(got.Schemas) != 3 {
+			t.Fatalf("wrong number of provider schemas returned. Got %d, expected 3", len(got.Schemas))
+		}
+		// every provider has the same schema
+		for _, s := range got.Schemas {
+			if len(s.DataSourceSchemas) > 0 {
+				t.Errorf("unexpected ds schemas found in results")
+			}
+			if len(s.ResourceSchemas) > 0 {
+				t.Errorf("unexpected rs schemas found in results")
+			}
+			if len(s.ActionSchemas) != 1 {
+				t.Errorf("wrong number of action schemas. Got %d, expected 1", len(s.ActionSchemas))
+			}
+			if len(s.ListSchemas) != 0 {
+				t.Errorf("unexpected list resource schemas found in results")
+			}
+			if len(s.Functions) > 0 {
+				t.Errorf("unexpected functions found in results")
+			}
+		}
+	})
+
+	t.Run("filtered by provider", func(t *testing.T) {
+		ui := testUiWrapped(t)
+		c := &MetadataSchemaCommand{
+			Meta: Meta{
+				Ui:               ui,
+				testingOverrides: pf,
+			},
+		}
+		if code := c.Run([]string{"-json", "-provider=austinvalle/bufo"}); code != 0 {
+			t.Fatalf("wrong exit status %d; want 0\nstderr: %s", code, ui.ErrorWriter.String())
+		}
+		output := ui.OutputWriter.String()
+		var got providerSchemas
+		json.Unmarshal([]byte(output), &got)
+		if len(got.Schemas) > 1 {
+			t.Fatalf("too many provider schemas returned")
+		}
+		// todo:  check that the return is populated
+	})
+
+	t.Run("pruned output", func(t *testing.T) {
+		ui := testUiWrapped(t)
+		c := &MetadataSchemaCommand{
+			Meta: Meta{
+				Ui:               ui,
+				testingOverrides: pf,
+			},
+		}
+		if code := c.Run([]string{"-json", "-prune=true"}); code != 0 {
+			t.Fatalf("wrong exit status %d; want 0\nstderr: %s", code, ui.ErrorWriter.String())
+		}
+		output := ui.OutputWriter.String()
+		var got metadataSchemas
+		json.Unmarshal([]byte(output), &got)
+
+		// since all providers have the same schema, the results are a bit weird and not what you'd expect to see in reality
+		if len(got.Schemas) != 3 {
+			t.Fatalf("wrong number of provider schemas returned. Got %d, expected 3", len(got.Schemas))
+		}
+		// still should only be one resource schema returned (from each)
+		for _, s := range got.Schemas {
+			if len(s.DataSourceSchemas) > 0 {
+				t.Errorf("unexpected ds schemas found in results")
+			}
+			if len(s.ActionSchemas) > 0 {
+				t.Errorf("unexpected action schemas found in results")
+			}
+			if len(s.ResourceSchemas) != 1 {
+				t.Errorf("wrong number of resource schemas. Got %d, expected 1", len(s.ResourceSchemas))
+			}
+			if len(s.ListSchemas) != 0 {
+				t.Errorf("unexpected list resource schemas found in results")
+			}
+			if len(s.Functions) > 0 {
+				t.Errorf("unexpected functions found in results")
+			}
+		}
+	})
+}
+
+// if this command gets implemented, this will be refactored to be a subset of the overall return
+type metadataSchemas struct {
+	FormatVersion string                            `json:"format_version"`
+	Schemas       map[string]metadataProviderSchema `json:"provider_schemas"`
+}
+
+type metadataProviderSchema struct {
+	Provider          any            `json:"provider,omitempty"`
+	ResourceSchemas   map[string]any `json:"resource_schemas,omitempty"`
+	DataSourceSchemas map[string]any `json:"data_source_schemas,omitempty"`
+	StateStoreSchemas map[string]any `json:"state_store_schemas,omitempty"`
+	ActionSchemas     map[string]any `json:"action_schemas,omitempty"`
+	ListSchemas       map[string]any `json:"list_schemas,omitempty"`
+	Functions         map[string]any `json:"functions,omitempty"`
+}

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -21,7 +21,6 @@ import (
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	backendCloud "github.com/hashicorp/terraform/internal/cloud"
 	"github.com/hashicorp/terraform/internal/command/workdir"
-
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"

--- a/internal/command/testdata/metadata-schema/main.tf
+++ b/internal/command/testdata/metadata-schema/main.tf
@@ -1,0 +1,9 @@
+terraform {
+    required_providers {
+        test = {source = "hashicorp/test" }
+        bufo = { source = "austinvalle/bufo" } 
+        anotherone = { source = "hashicorp/example" }
+    }
+}
+
+resource "test_object" "test" {}

--- a/internal/provisioners/provisioner.go
+++ b/internal/provisioners/provisioner.go
@@ -4,9 +4,10 @@
 package provisioners
 
 import (
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Interface is the set of methods required for a resource provisioner plugin.
@@ -39,6 +40,10 @@ type Interface interface {
 	// Close shuts down the plugin process if applicable.
 	Close() error
 }
+
+// ProvisionerSchema is an overall container for all of the schemas defined
+// within a particular provisioner.
+type ProvisionerSchema GetSchemaResponse
 
 type GetSchemaResponse struct {
 	// Provisioner contains the schema for this provisioner.


### PR DESCRIPTION
Halfway through implementing this, I decided that this wasn't what metadata schemas should be, but I wanted to at least finish (most of) the prototype - so here's a new command, which actually works just like `providers schema` with some extra filtering options. I stopped before adding the provisioner schema marshaling since it wouldn't be relevant for providers schema (unless...). 

I would like to see these options added to providers schema instead of made into a new command, but that does leave some gaps - provisioners! Adding provisioner schemas to the providers schema output would require a change to the output (though we could add a flag to include provisioners and document that using that flag results in a different providers schemas return object, but that feels sloppy - at that point I'd rather add a provisioner schemas command).

Here's my proposal: 
1. Add the following filters to providers schema (BIKESHED HERE):
`-prune` (-precise? -config-resources? -config?)
`-type` (resource, list, etc) (I've seen others suggest `kind`, which i dislike, because we use kind no where in terraform docs.  we do need a word that refers to resources++, so feel free to fight me on this)
`-name` (aws_instance)
`-provider` (parsable source address incl. shortnames)

2. Make a new metadata schemas command (either now, or later when we have better ideas about vague projects that may or may not be happening)(i'm not vaguespeaking to be coy, I have no idea) that handles specific (single or multiple) provider/provisioner requests with filters, including specific provider versions (provisioners don't have versions)(as far as terraform is concerned, at least).

I can easily cleanup these filters and add them to providers schema but figured I'd get this cleaned up enough that some folks (@bbasata , @ansgarm 👋🏻) could play with the implementation if they wanted to see how it felt/worked with the other cool tools they are working on.  


-----
little sidenote on the thought process here: somewhere between proposal feedback (thanks everyone!) and the inner workings of init & provider installation it was clear that I was trying to solve too many requests which, I believe, benefit from separate solutions. `providers schema` is a command for getting schemas from  providers in config and state, and we could add the proposed filters to that command, while _also_ designing a new command for getting schemas for specific provider versions. (we can decide what default behaviors exist - maybe if called with no flags, we just return the providers and provisioners from config&state, or maybe the command always requires either provider&version.)