### PR TITLE
command/views: Align const names for state migrate msg types

### DIFF
--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -90,10 +90,10 @@ const (
 	ProviderAutomaticApproval    MessageType = "provider_automatic_approval"
 
 	// State migration-related messages
-	LogStateMigrationStart                        MessageType = "migration_start"
-	LogStateMigrationComplete                     MessageType = "migration_complete"
-	LogStateMigrationErrored                      MessageType = "migration_errored"
-	LogStateMigrationFinalized                    MessageType = "migration_finalized"
+	LogMigrationStart                             MessageType = "migration_start"
+	LogMigrationComplete                          MessageType = "migration_complete"
+	LogMigrationErrored                           MessageType = "migration_errored"
+	LogMigrationFinalized                         MessageType = "migration_finalized"
 	LogMigrationSourceInitializationStart         MessageType = "migration_source_initialization_start"
 	LogMigrationSourceInitializationComplete      MessageType = "migration_source_initialization_complete"
 	LogMigrationDestinationInitializationStart    MessageType = "migration_destination_initialization_start"

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -338,7 +338,7 @@ func (s *StateMigrateJSON) LogStateMigrationStart(source string, destination str
 	msg := fmt.Sprintf(logStateMigrationStartJSON, source, destination)
 	s.view.log.Info(
 		msg,
-		"type", json.LogStateMigrationStart,
+		"type", json.LogMigrationStart,
 	)
 }
 
@@ -347,7 +347,7 @@ func (s *StateMigrateJSON) LogStateMigrationComplete(source string, destination 
 	msg := fmt.Sprintf(logStateMigrationCompleteJSON, source, destination)
 	s.view.log.Info(
 		msg,
-		"type", json.LogStateMigrationComplete,
+		"type", json.LogMigrationComplete,
 	)
 }
 
@@ -356,7 +356,7 @@ func (s *StateMigrateJSON) LogStateMigrationFinalized(source string, destination
 	msg := fmt.Sprintf(logStateMigrationFinalizedJSON, source, destination)
 	s.view.log.Info(
 		msg,
-		"type", json.LogStateMigrationFinalized,
+		"type", json.LogMigrationFinalized,
 	)
 }
 
@@ -378,7 +378,7 @@ func (s *StateMigrateJSON) LogStateMigrationErrored(failMode stateMigrationFailu
 
 	s.view.log.Info(
 		msg,
-		"type", json.LogStateMigrationErrored,
+		"type", json.LogMigrationErrored,
 		"failure_mode", failMode,
 	)
 }


### PR DESCRIPTION
This has no end-user impact as the message types are not being changed, just the internally used constant names. Here we align them with the raw names and remaining half of the constant names, for consistency.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
