### PR TITLE
command/views: Align remaining state migration related msg types

### DIFF
--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -330,7 +330,7 @@ func (v *InitJSON) LogInstallStateStoreProviderStart(pAddr tfaddr.Provider, cons
 
 	v.view.log.Info(
 		msg,
-		"type", json.InstallStateStoreProviderStart,
+		"type", json.LogStateStoreProviderInstallationStart,
 	)
 }
 
@@ -338,7 +338,7 @@ func (v *InitJSON) LogInstallStateStoreProviderStart(pAddr tfaddr.Provider, cons
 func (v *InitJSON) LogInteractiveApproval() {
 	v.view.log.Info(
 		logInteractiveApprovalMessageJSON,
-		"type", json.ProviderInteractiveApproval,
+		"type", json.LogProviderInteractiveApproval,
 	)
 }
 
@@ -346,7 +346,7 @@ func (v *InitJSON) LogInteractiveApproval() {
 func (v *InitJSON) LogInteractiveRejection() {
 	v.view.log.Info(
 		logInteractiveRejectionMessageJSON,
-		"type", json.ProviderInteractiveRejection,
+		"type", json.LogProviderInteractiveRejection,
 	)
 }
 
@@ -354,7 +354,7 @@ func (v *InitJSON) LogInteractiveRejection() {
 func (v *InitJSON) LogAutomaticApproval() {
 	v.view.log.Info(
 		logInteractiveAutomaticApprovalMessageJSON,
-		"type", json.ProviderAutomaticApproval,
+		"type", json.LogProviderAutomaticApproval,
 	)
 }
 

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -67,27 +67,27 @@ const (
 	MessagePolicyQuerySummary     MessageType = "policy_query_summary"
 
 	// Provider installation messages
-	InstallProvidersStart               MessageType = "provider_installation_start"
-	InstallStateStoreProviderStart      MessageType = "state_store_provider_installation_start"
-	LogReusingPreviousProviderVersion   MessageType = "provider_query_use_previous_version"
-	LogFindingMatchingVersion           MessageType = "provider_query_use_constraints"
-	LogFindingLatestVersion             MessageType = "provider_query_use_latest"
-	LogProviderVersionAlreadyInstalled  MessageType = "provider_version_already_installed"
-	LogUsingProviderVersionFromCacheDir MessageType = "provider_version_found_in_cache_dir"
-	LogInstallProviderVersionStart      MessageType = "provider_version_installation_start"
-	LogInstallProviderVersionComplete   MessageType = "provider_version_installation_complete"
-	BuiltInProviderAvailable            MessageType = "built_in_provider_available"
-	LogPartnerAndCommunityProviders     MessageType = "third_party_providers_installed"
+	LogProviderInstallationStart           MessageType = "provider_installation_start"
+	LogStateStoreProviderInstallationStart MessageType = "state_store_provider_installation_start"
+	LogProviderQueryUsePreviousVersion     MessageType = "provider_query_use_previous_version"
+	LogProviderQueryUseConstraints         MessageType = "provider_query_use_constraints"
+	LogProviderQueryUseLatest              MessageType = "provider_query_use_latest"
+	LogProviderVersionAlreadyInstalled     MessageType = "provider_version_already_installed"
+	LogProviderVersionFoundInCacheDir      MessageType = "provider_version_found_in_cache_dir"
+	LogProviderVersionInstallationStart    MessageType = "provider_version_installation_start"
+	LogProviderVersionInstallationComplete MessageType = "provider_version_installation_complete"
+	LogBuiltInProviderAvailable            MessageType = "built_in_provider_available"
+	LogThirdPartyProvidersInstalled        MessageType = "third_party_providers_installed"
 
 	// Dependency lock file messages
 	// Uses provider-oriented language in case we add a module lock file in future.
-	ProviderLockfileCreated MessageType = "provider_lockfile_created"
-	ProviderLockfileUpdated MessageType = "provider_lockfile_updated"
+	LogProviderLockfileCreated MessageType = "provider_lockfile_created"
+	LogProviderLockfileUpdated MessageType = "provider_lockfile_updated"
 
 	// Provider trust-related message (currently used only in PSS context)
-	ProviderInteractiveApproval  MessageType = "provider_interactive_approval"
-	ProviderInteractiveRejection MessageType = "provider_interactive_rejection"
-	ProviderAutomaticApproval    MessageType = "provider_automatic_approval"
+	LogProviderInteractiveApproval  MessageType = "provider_interactive_approval"
+	LogProviderInteractiveRejection MessageType = "provider_interactive_rejection"
+	LogProviderAutomaticApproval    MessageType = "provider_automatic_approval"
 
 	// State migration-related messages
 	LogMigrationStart                             MessageType = "migration_start"

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -391,7 +391,7 @@ func (s *StateMigrateJSON) LogStateMigrationErrored(failMode stateMigrationFailu
 func (s *StateMigrateJSON) LogInteractiveApproval() {
 	s.view.log.Info(
 		logInteractiveApprovalMessageJSON,
-		"type", json.ProviderInteractiveApproval,
+		"type", json.LogProviderInteractiveApproval,
 	)
 }
 
@@ -399,7 +399,7 @@ func (s *StateMigrateJSON) LogInteractiveApproval() {
 func (s *StateMigrateJSON) LogInteractiveRejection() {
 	s.view.log.Info(
 		logInteractiveRejectionMessageJSON,
-		"type", json.ProviderInteractiveRejection,
+		"type", json.LogProviderInteractiveRejection,
 	)
 }
 
@@ -407,7 +407,7 @@ func (s *StateMigrateJSON) LogInteractiveRejection() {
 func (s *StateMigrateJSON) LogAutomaticApproval() {
 	s.view.log.Info(
 		logInteractiveAutomaticApprovalMessageJSON,
-		"type", json.ProviderAutomaticApproval,
+		"type", json.LogProviderAutomaticApproval,
 	)
 }
 
@@ -416,7 +416,7 @@ func (s *StateMigrateJSON) LogProviderLockfileCreated() {
 	msg := strings.TrimSpace(previousLockInfoJSON)
 	s.view.log.Info(
 		msg,
-		"type", json.ProviderLockfileCreated,
+		"type", json.LogProviderLockfileCreated,
 	)
 }
 
@@ -425,7 +425,7 @@ func (s *StateMigrateJSON) LogProviderLockfileUpdated() {
 	msg := strings.TrimSpace(dependenciesLockChangesInfo)
 	s.view.log.Info(
 		msg,
-		"type", json.ProviderLockfileUpdated,
+		"type", json.LogProviderLockfileUpdated,
 	)
 }
 
@@ -433,7 +433,7 @@ func (s *StateMigrateJSON) LogProviderLockfileUpdated() {
 func (s *StateMigrateJSON) LogInstallProvidersStart() {
 	s.view.log.Info(
 		logInstallProvidersStartMessageJSON,
-		"type", json.InstallProvidersStart,
+		"type", json.LogProviderInstallationStart,
 	)
 }
 
@@ -442,7 +442,7 @@ func (s *StateMigrateJSON) LogBuiltInProviderAvailable(providerAddr addrs.Provid
 	msg := fmt.Sprintf(logBuiltInProviderAvailableJSON, providerAddr.ForDisplay())
 	s.view.log.Info(
 		msg,
-		"type", json.BuiltInProviderAvailable,
+		"type", json.LogBuiltInProviderAvailable,
 	)
 }
 
@@ -451,7 +451,7 @@ func (s *StateMigrateJSON) LogReusingPreviousProviderVersion(providerAddr addrs.
 	msg := fmt.Sprintf(logReusingPreviousProviderVersionJSON, providerAddr.ForDisplay(), version)
 	s.view.log.Info(
 		msg,
-		"type", json.LogReusingPreviousProviderVersion,
+		"type", json.LogProviderQueryUsePreviousVersion,
 	)
 }
 
@@ -460,7 +460,7 @@ func (s *StateMigrateJSON) LogFindingLatestVersion(providerAddr addrs.Provider) 
 	msg := fmt.Sprintf(logFindingLatestVersionJSON, providerAddr.ForDisplay())
 	s.view.log.Info(
 		msg,
-		"type", json.LogFindingLatestVersion,
+		"type", json.LogProviderQueryUseLatest,
 	)
 }
 
@@ -469,7 +469,7 @@ func (s *StateMigrateJSON) LogFindingMatchingVersion(providerAddr addrs.Provider
 	msg := fmt.Sprintf(logFindingMatchingVersionJSON, providerAddr.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
 	s.view.log.Info(
 		msg,
-		"type", json.LogFindingMatchingVersion,
+		"type", json.LogProviderQueryUseConstraints,
 	)
 }
 
@@ -487,7 +487,7 @@ func (s *StateMigrateJSON) LogUsingProviderVersionFromCacheDir(providerAddr addr
 	msg := fmt.Sprintf(logUsingProviderVersionFromCacheDirJSON, providerAddr.ForDisplay(), version)
 	s.view.log.Info(
 		msg,
-		"type", json.LogUsingProviderVersionFromCacheDir,
+		"type", json.LogProviderVersionFoundInCacheDir,
 	)
 }
 
@@ -496,7 +496,7 @@ func (s *StateMigrateJSON) LogInstallProviderVersionStart(providerAddr addrs.Pro
 	msg := fmt.Sprintf(logInstallProviderVersionStartJSON, providerAddr.ForDisplay(), version)
 	s.view.log.Info(
 		msg,
-		"type", json.LogInstallProviderVersionStart,
+		"type", json.LogProviderVersionInstallationStart,
 	)
 }
 
@@ -506,7 +506,7 @@ func (s *StateMigrateJSON) LogInstallProviderVersionComplete(providerAddr addrs.
 	msg := fmt.Sprintf(logInstallProviderVersionCompleteJSON, providerAddr.ForDisplay(), version, auth, keyDetails)
 	s.view.log.Info(
 		msg,
-		"type", json.LogInstallProviderVersionComplete,
+		"type", json.LogProviderVersionInstallationComplete,
 	)
 }
 
@@ -516,7 +516,7 @@ func (s *StateMigrateJSON) LogInstallProviderVersionCompleteWithKeyID(providerAd
 	msg := fmt.Sprintf(logInstallProviderVersionCompleteJSON, providerAddr.ForDisplay(), version, auth, keyDetails)
 	s.view.log.Info(
 		msg,
-		"type", json.LogInstallProviderVersionComplete,
+		"type", json.LogProviderVersionInstallationComplete,
 	)
 }
 
@@ -524,7 +524,7 @@ func (s *StateMigrateJSON) LogInstallProviderVersionCompleteWithKeyID(providerAd
 func (s *StateMigrateJSON) LogPartnerAndCommunityProviders() {
 	s.view.log.Info(
 		logPartnerAndCommunityProviders,
-		"type", json.LogPartnerAndCommunityProviders,
+		"type", json.LogThirdPartyProvidersInstalled,
 	)
 }
 


### PR DESCRIPTION
I don't have strong opinions about the `Log` prefixes and I note they are also missing in some other constant names. I also see we use `Message` suffix in many other cases. I'm fine aligning it either way and this should not be a breaking change anyway.

What is the main aim of this PR however is aligning the rest of the names with the underlying raw (underscored) name.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
