### PR TITLE
state_migrate: Update JSON log's human-readable description to specify whether backend/state store is being initialised. Refactor control flow.

### DIFF
--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -118,7 +118,8 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	view.LogMigrationSourceInitializationStart(sourceStorageMethod)
 	var source string
 	var sourceLock *depsfile.Locks // This should only contain a single lock, if non nil. Used to avoid re-download if destination provider is the same.
-	if sourceStorageMethod == Backend {
+	switch sourceStorageMethod {
+	case Backend:
 		source = fmt.Sprintf("backend %q", smi.Backend.Type)
 
 		srcB, _, srcDiags := c.Meta.backendInitFromConfig(smi.Backend)
@@ -127,8 +128,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			migrateOpts.SourceType = smi.Backend.Type
 			migrateOpts.Source = srcB
 		}
-	} else if sourceStorageMethod == StateStore {
-		// Load any pre-existing source provider lock file.
+	case StateStore:
 		var lockfilePath string
 		if args.SourceLockFilePath != "" {
 			lockfilePath = args.SourceLockFilePath
@@ -176,6 +176,12 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			migrateOpts.SourceType = smi.StateStore.Type
 			migrateOpts.Source = srcB
 		}
+	default:
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Unknown migration source",
+			"No configuration was provided for where to migrate the state from. Please ensure that a file with a .tfmigrate.hcl extension is present and contains valid state_store or backend configuration inside the from block.",
+		))
 	}
 	view.LogMigrationSourceInitializationComplete(sourceStorageMethod)
 
@@ -184,7 +190,8 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	var destination string
 	var destinationLock *depsfile.Locks                               // This should only contain a single lock, if non nil. Used to update the dependency lock file on disk.
 	var bsf *workdir.BackendStateFile = workdir.NewBackendStateFile() // Collect data below for updating the backend state file.
-	if destinationStorageMethod == Backend {
+	switch destinationStorageMethod {
+	case Backend:
 		destination = fmt.Sprintf("backend %q", rootMod.Backend.Type)
 
 		dstB, dstConfig, dstDiags := c.Meta.backendInitFromConfig(rootMod.Backend)
@@ -214,7 +221,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 				return 1
 			}
 		}
-	} else if destinationStorageMethod == StateStore {
+	case StateStore:
 		// Get single required_providers entry for state store provider.
 		dstReq, dstReqDiags := c.getDestinationStateStoreProviderRequirements(rootMod.StateStore.ProviderAddr, rootMod.ProviderRequirements)
 		diags = diags.Append(dstReqDiags)
@@ -331,15 +338,13 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			view.Diagnostics(diags)
 			return 1
 		}
-
-	} else {
+	default:
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Unknown migration destination",
 			"No configuration was provided for where to migrate the state to. Please ensure that a file with a .tf extension is present and contains valid state_store or backend configuration inside the terraform block.",
 		))
 	}
-
 	// present all errors from above together so user can fix them all at once
 	if diags.HasErrors() {
 		view.Diagnostics(diags)

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -98,11 +98,27 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	}
 	c.Meta.forceInitCopy = args.ForceCopy // backendMigrateOpts.force is overwritten with this value, so we also need to set it.
 
+	// Get info about the state storage methods used in the source and destination
+	// This is used as an argument to the view and to control which logic is used for initialization.
+	var sourceStorageMethod string
+	var destinationStorageMethod string
+	if smi.Backend != nil {
+		sourceStorageMethod = Backend
+	} else if smi.StateStore != nil {
+		sourceStorageMethod = StateStore
+	}
+	rootMod := cfg.Module
+	if rootMod.Backend != nil {
+		destinationStorageMethod = Backend
+	} else if rootMod.StateStore != nil {
+		destinationStorageMethod = StateStore
+	}
+
 	// Load the source backend
-	view.LogMigrationSourceInitializationStart()
+	view.LogMigrationSourceInitializationStart(sourceStorageMethod)
 	var source string
 	var sourceLock *depsfile.Locks // This should only contain a single lock, if non nil. Used to avoid re-download if destination provider is the same.
-	if smi.Backend != nil {
+	if sourceStorageMethod == Backend {
 		source = fmt.Sprintf("backend %q", smi.Backend.Type)
 
 		srcB, _, srcDiags := c.Meta.backendInitFromConfig(smi.Backend)
@@ -111,7 +127,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			migrateOpts.SourceType = smi.Backend.Type
 			migrateOpts.Source = srcB
 		}
-	} else if smi.StateStore != nil {
+	} else if sourceStorageMethod == StateStore {
 		// Load any pre-existing source provider lock file.
 		var lockfilePath string
 		if args.SourceLockFilePath != "" {
@@ -161,15 +177,14 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			migrateOpts.Source = srcB
 		}
 	}
-	view.LogMigrationSourceInitializationComplete()
+	view.LogMigrationSourceInitializationComplete(sourceStorageMethod)
 
 	// Load the destination backend
-	view.LogMigrationDestinationInitializationStart()
-	rootMod := cfg.Module
+	view.LogMigrationDestinationInitializationStart(destinationStorageMethod)
 	var destination string
 	var destinationLock *depsfile.Locks                               // This should only contain a single lock, if non nil. Used to update the dependency lock file on disk.
 	var bsf *workdir.BackendStateFile = workdir.NewBackendStateFile() // Collect data below for updating the backend state file.
-	if rootMod.Backend != nil {
+	if destinationStorageMethod == Backend {
 		destination = fmt.Sprintf("backend %q", rootMod.Backend.Type)
 
 		dstB, dstConfig, dstDiags := c.Meta.backendInitFromConfig(rootMod.Backend)
@@ -199,7 +214,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 				return 1
 			}
 		}
-	} else if rootMod.StateStore != nil {
+	} else if destinationStorageMethod == StateStore {
 		// Get single required_providers entry for state store provider.
 		dstReq, dstReqDiags := c.getDestinationStateStoreProviderRequirements(rootMod.StateStore.ProviderAddr, rootMod.ProviderRequirements)
 		diags = diags.Append(dstReqDiags)
@@ -330,7 +345,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		view.Diagnostics(diags)
 		return 1
 	}
-	view.LogMigrationDestinationInitializationComplete()
+	view.LogMigrationDestinationInitializationComplete(destinationStorageMethod)
 
 	view.LogStateMigrationStart(source, destination)
 
@@ -347,7 +362,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 
 	// After a successful migration to a state store, we must make sure the dependency lock file contains the
 	// details of the destination state store provider.
-	if rootMod.StateStore != nil {
+	if destinationStorageMethod == StateStore {
 		originalLocks, originalLockDiags := c.lockedDependencies()
 		diags = diags.Append(originalLockDiags)
 		if originalLockDiags.HasErrors() {
@@ -422,6 +437,8 @@ func (c *StateMigrateCommand) Synopsis() string {
 }
 
 const (
+	Backend              = "backend"
+	StateStore           = "state store"
 	MigrationSource      = "source"
 	MigrationDestination = "destination"
 )

--- a/internal/command/testdata/state-migrate-backend-to-backend/output.jsonlog
+++ b/internal/command/testdata/state-migrate-backend-to-backend/output.jsonlog
@@ -1,8 +1,8 @@
 {"@level":"info","@message":"Terraform 1.17.0-dev","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","terraform":"1.17.0-dev","type":"version","ui":"1.3"}
-{"@level":"info","@message":"Initializing source...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_start"}
-{"@level":"info","@message":"Initialized source.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_complete"}
-{"@level":"info","@message":"Initializing destination...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_start"}
-{"@level":"info","@message":"Initialized destination.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_complete"}
+{"@level":"info","@message":"Initializing source backend...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_start"}
+{"@level":"info","@message":"Initialized source backend.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_complete"}
+{"@level":"info","@message":"Initializing destination backend...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_start"}
+{"@level":"info","@message":"Initialized destination backend.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_complete"}
 {"@level":"info","@message":"Migrating state from backend \"local\" to backend \"local\"...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_start"}
 {"@level":"info","@message":"The migration process has copied state from the backend \"local\" to the backend \"local\"","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_complete"}
 {"@level":"info","@message":"Finished migrating state from backend \"local\" to backend \"local\".","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_finalized"}

--- a/internal/command/testdata/state-migrate-backend-to-state-store/output.jsonlog
+++ b/internal/command/testdata/state-migrate-backend-to-state-store/output.jsonlog
@@ -1,12 +1,12 @@
 {"@level":"info","@message":"Terraform 1.17.0-dev","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","terraform":"1.17.0-dev","type":"version","ui":"1.3"}
-{"@level":"info","@message":"Initializing source...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_start"}
-{"@level":"info","@message":"Initialized source.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_complete"}
-{"@level":"info","@message":"Initializing destination...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_start"}
+{"@level":"info","@message":"Initializing source backend...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_start"}
+{"@level":"info","@message":"Initialized source backend.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_source_initialization_complete"}
+{"@level":"info","@message":"Initializing destination state store...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_start"}
 {"@level":"info","@message":"Installing providers...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"provider_installation_start"}
 {"@level":"info","@message":"hashicorp/test: Reusing version 1.2.3 from the dependency lock file","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"provider_query_use_previous_version"}
 {"@level":"info","@message":"Installing provider version: hashicorp/test v1.2.3...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"provider_version_installation_start"}
 {"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (verified checksum)","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"provider_version_installation_complete"}
-{"@level":"info","@message":"Initialized destination.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_complete"}
+{"@level":"info","@message":"Initialized destination state store.","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_destination_initialization_complete"}
 {"@level":"info","@message":"Migrating state from backend \"local\" to state store \"test_store\" (hashicorp/test 1.2.3)...","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_start"}
 {"@level":"info","@message":"The migration process has copied state from the backend \"local\" to the state store \"test_store\" (hashicorp/test 1.2.3)","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_complete"}
 {"@level":"info","@message":"Finished migrating state from backend \"local\" to state store \"test_store\" (hashicorp/test 1.2.3).","@module":"terraform.ui","@timestamp":"2026-08-26T16:20:04.692816+01:00","type":"migration_finalized"}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -19,10 +19,10 @@ import (
 const (
 
 	// JSON only - log the start and end of initializing the source and destination for the migration
-	logMigrationSourceInitializationStartJSON         = "Initializing source..."
-	logMigrationSourceInitializationCompleteJSON      = "Initialized source."
-	logMigrationDestinationInitializationStartJSON    = "Initializing destination..."
-	logMigrationDestinationInitializationCompleteJSON = "Initialized destination."
+	logMigrationSourceInitializationStartJSON         = "Initializing source %s..."
+	logMigrationSourceInitializationCompleteJSON      = "Initialized source %s."
+	logMigrationDestinationInitializationStartJSON    = "Initializing destination %s..."
+	logMigrationDestinationInitializationCompleteJSON = "Initialized destination %s."
 
 	// Notify the user that any preparation steps are over and the migration is starting.
 	logStateMigrationStartHuman = "[reset][bold]Migrating state from %s to %s...[reset]"
@@ -79,10 +79,10 @@ type StateMigrate interface {
 	LogStateMigrationErrored(failMode stateMigrationFailureMode, source, destination string)
 	LogStateMigrationFinalized(source, destination string)
 
-	LogMigrationSourceInitializationStart()
-	LogMigrationSourceInitializationComplete()
-	LogMigrationDestinationInitializationStart()
-	LogMigrationDestinationInitializationComplete()
+	LogMigrationSourceInitializationStart(storageMethod string)
+	LogMigrationSourceInitializationComplete(storageMethod string)
+	LogMigrationDestinationInitializationStart(storageMethod string)
+	LogMigrationDestinationInitializationComplete(storageMethod string)
 
 	ProviderInstallationLogger
 	ProviderLockingLogger
@@ -148,19 +148,19 @@ func (s *StateMigrateHuman) LogStateMigrationErrored(failMode stateMigrationFail
 	s.log(msg)
 }
 
-func (s *StateMigrateHuman) LogMigrationSourceInitializationStart() {
+func (s *StateMigrateHuman) LogMigrationSourceInitializationStart(_ string) {
 	// no-op in human view
 }
 
-func (s *StateMigrateHuman) LogMigrationSourceInitializationComplete() {
+func (s *StateMigrateHuman) LogMigrationSourceInitializationComplete(_ string) {
 	// no-op in human view
 }
 
-func (s *StateMigrateHuman) LogMigrationDestinationInitializationStart() {
+func (s *StateMigrateHuman) LogMigrationDestinationInitializationStart(_ string) {
 	// no-op in human view
 }
 
-func (s *StateMigrateHuman) LogMigrationDestinationInitializationComplete() {
+func (s *StateMigrateHuman) LogMigrationDestinationInitializationComplete(_ string) {
 	// no-op in human view
 }
 
@@ -528,30 +528,34 @@ func (s *StateMigrateJSON) LogPartnerAndCommunityProviders() {
 	)
 }
 
-func (s *StateMigrateJSON) LogMigrationSourceInitializationStart() {
+func (s *StateMigrateJSON) LogMigrationSourceInitializationStart(storageMethod string) {
+	msg := fmt.Sprintf(logMigrationSourceInitializationStartJSON, storageMethod)
 	s.view.log.Info(
-		logMigrationSourceInitializationStartJSON,
+		msg,
 		"type", json.LogMigrationSourceInitializationStart,
 	)
 }
 
-func (s *StateMigrateJSON) LogMigrationSourceInitializationComplete() {
+func (s *StateMigrateJSON) LogMigrationSourceInitializationComplete(storageMethod string) {
+	msg := fmt.Sprintf(logMigrationSourceInitializationCompleteJSON, storageMethod)
 	s.view.log.Info(
-		logMigrationSourceInitializationCompleteJSON,
+		msg,
 		"type", json.LogMigrationSourceInitializationComplete,
 	)
 }
 
-func (s *StateMigrateJSON) LogMigrationDestinationInitializationStart() {
+func (s *StateMigrateJSON) LogMigrationDestinationInitializationStart(storageMethod string) {
+	msg := fmt.Sprintf(logMigrationDestinationInitializationStartJSON, storageMethod)
 	s.view.log.Info(
-		logMigrationDestinationInitializationStartJSON,
+		msg,
 		"type", json.LogMigrationDestinationInitializationStart,
 	)
 }
 
-func (s *StateMigrateJSON) LogMigrationDestinationInitializationComplete() {
+func (s *StateMigrateJSON) LogMigrationDestinationInitializationComplete(storageMethod string) {
+	msg := fmt.Sprintf(logMigrationDestinationInitializationCompleteJSON, storageMethod)
 	s.view.log.Info(
-		logMigrationDestinationInitializationCompleteJSON,
+		msg,
 		"type", json.LogMigrationDestinationInitializationComplete,
 	)
 }

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -619,13 +619,13 @@ func TestNewStateMigrate_LogMigrationSourceInitializationStart_json(t *testing.T
 	view := NewView(streams)
 	smView := NewStateMigrate(arguments.ViewJSON, view)
 
-	smView.LogMigrationSourceInitializationStart()
+	smView.LogMigrationSourceInitializationStart("backend")
 
 	// Assert output
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`"@message":"Initializing source..."`,
+		`"@message":"Initializing source backend..."`,
 		`"@module":"terraform.ui"`,
 		`"type":"migration_source_initialization_start"`,
 	}
@@ -641,13 +641,13 @@ func TestNewStateMigrate_LogMigrationSourceInitializationComplete_json(t *testin
 	view := NewView(streams)
 	smView := NewStateMigrate(arguments.ViewJSON, view)
 
-	smView.LogMigrationSourceInitializationComplete()
+	smView.LogMigrationSourceInitializationComplete("state store")
 
 	// Assert output
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`"@message":"Initialized source."`,
+		`"@message":"Initialized source state store."`,
 		`"@module":"terraform.ui"`,
 		`"type":"migration_source_initialization_complete"`,
 	}
@@ -663,13 +663,13 @@ func TestNewStateMigrate_LogMigrationDestinationInitializationStart_json(t *test
 	view := NewView(streams)
 	smView := NewStateMigrate(arguments.ViewJSON, view)
 
-	smView.LogMigrationDestinationInitializationStart()
+	smView.LogMigrationDestinationInitializationStart("state store")
 
 	// Assert output
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`"@message":"Initializing destination..."`,
+		`"@message":"Initializing destination state store..."`,
 		`"@module":"terraform.ui"`,
 		`"type":"migration_destination_initialization_start"`,
 	}
@@ -685,13 +685,13 @@ func TestNewStateMigrate_LogMigrationDestinationInitializationComplete_json(t *t
 	view := NewView(streams)
 	smView := NewStateMigrate(arguments.ViewJSON, view)
 
-	smView.LogMigrationDestinationInitializationComplete()
+	smView.LogMigrationDestinationInitializationComplete("backend")
 
 	// Assert output
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`"@message":"Initialized destination."`,
+		`"@message":"Initialized destination backend."`,
 		`"@module":"terraform.ui"`,
 		`"type":"migration_destination_initialization_complete"`,
 	}


### PR DESCRIPTION
Addresses feedback here: https://github.com/hashicorp/terraform/pull/39064#discussion_r3871855961

This PR makes the JSON logs marking when a backend/state store initialisation starts or completes includes that backend/state store distinction.

To enable this I've updated the code to determine whether the source and destination are backends or state stores, and that data is used:
- to allow more specific log messages mentioning "backend" or "state store"
- to control which initialisation logic is run

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
