### PR TITLE
command/views: delimit provider signing key IDs in JSON messages

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260828-221428.yaml
+++ b/.changes/v1.17/BUG FIXES-20260828-221428.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'provider installation: Correctly delimit signing key ID details in JSON log messages'
+time: 2026-08-28T22:14:28.941581+08:00
+custom:
+    Issue: "39078"

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -8943,7 +8943,7 @@ func Test_fetchPackageSuccessCallback(t *testing.T) {
 		}
 		// Assert output - json
 		output = doneJ(t)
-		expectedOutput = `{"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (signed by a HashiCorp partnerkey_id: key-id-123)","@module":"terraform.ui","@timestamp":` // Stop comparison before timestamp
+		expectedOutput = `{"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (signed by a HashiCorp partner, key_id: key-id-123)","@module":"terraform.ui","@timestamp":` // Stop comparison before timestamp
 		if !strings.Contains(output.Stdout(), expectedOutput) {
 			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", expectedOutput, output.Stdout())
 		}

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -423,7 +423,7 @@ func (v *InitJSON) LogInstallProviderVersionComplete(providerAddr addrs.Provider
 }
 
 func (v *InitJSON) LogInstallProviderVersionCompleteWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
-	keyDetails := fmt.Sprintf("key_id: %s", keyID) // key id needs to be formatted for JSON output
+	keyDetails := fmt.Sprintf(", key_id: %s", keyID) // key id needs to be formatted for JSON output
 	params := []any{providerAddr.ForDisplay(), version, auth, keyDetails}
 
 	// This was previously logged via LogInitMessage, so we need to match implementation of that method

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -628,7 +628,7 @@ func TestNewInit_LogInstallProviderVersionCompleteWithKeyID(t *testing.T) {
 
 		// Assert output - human
 		output := done(t)
-		expectedOutput := `{"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (signed by a HashiCorp partnerkey_id: key-id-123)","@module":"terraform.ui","@timestamp":` // Stop comparison before timestamp
+		expectedOutput := `{"@level":"info","@message":"Installed provider version: hashicorp/test v1.2.3 (signed by a HashiCorp partner, key_id: key-id-123)","@module":"terraform.ui","@timestamp":` // Stop comparison before timestamp
 		if !strings.Contains(output.Stdout(), expectedOutput) {
 			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", expectedOutput, output.Stdout())
 		}
@@ -705,7 +705,7 @@ func TestNewInit_LogInstallProviderVersionCompleteWithKeyID_json(t *testing.T) {
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`"@message":"Installed provider version: hashicorp/test v1.0.0 (signed by a HashiCorp partnerkey_id: key-id-123)"`,
+		`"@message":"Installed provider version: hashicorp/test v1.0.0 (signed by a HashiCorp partner, key_id: key-id-123)"`,
 		`"@module":"terraform.ui"`,
 		`"type":"log"`,
 	}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -512,7 +512,7 @@ func (s *StateMigrateJSON) LogInstallProviderVersionComplete(providerAddr addrs.
 
 // Implements ProviderInstallationLogger interface.
 func (s *StateMigrateJSON) LogInstallProviderVersionCompleteWithKeyID(providerAddr addrs.Provider, version getproviders.Version, auth *getproviders.PackageAuthenticationResult, keyID string) {
-	keyDetails := fmt.Sprintf("key_id: %s", keyID) // key id needs to be formatted for JSON output
+	keyDetails := fmt.Sprintf(", key_id: %s", keyID) // key id needs to be formatted for JSON output
 	msg := fmt.Sprintf(logInstallProviderVersionCompleteJSON, providerAddr.ForDisplay(), version, auth, keyDetails)
 	s.view.log.Info(
 		msg,

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -411,7 +411,7 @@ func TestNewStateMigrate_LogInstallProviderVersionCompleteWithKeyID_json(t *test
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`"@message":"Installed provider version: hashicorp/test v1.0.0 (signed by a HashiCorp partnerkey_id: key-id-123)"`,
+		`"@message":"Installed provider version: hashicorp/test v1.0.0 (signed by a HashiCorp partner, key_id: key-id-123)"`,
 		`"@module":"terraform.ui"`,
 		`"type":"provider_version_installation_complete"`,
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Provider installation JSON messages concatenate the authentication description and signing key ID without a delimiter, producing output such as:

`(signed by a HashiCorp partnerkey_id: ABC123)`

Prefix the JSON key details with `, ` so both init and state migration produce:

`(signed by a HashiCorp partner, key_id: ABC123)`

Update the view-level and command-level regression tests that previously asserted the malformed output.



Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No security control changes.


## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
