### PR TITLE
refactor: Move user-facing `init` message codes into centralised location, stop using them to access message strings - Part 1

### DIFF
--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -200,10 +200,8 @@ func (v *InitHuman) LogModuleInstallation(message string) {
 
 // Implements ModuleInstallationLogger
 func (v *InitHuman) LogModuleUpgrade() {
-	// This was previously logged via Output, so we need to match implementation of that method
-	// to ensure the same JSON log is produced.
-	params := []any{}
-	v.print(v.prepareMessage(UpgradingModulesMessage, params...))
+	msg := "[reset][bold]Upgrading modules..."
+	v.print(msg)
 }
 
 // Implements ModuleInstallationLogger
@@ -477,10 +475,8 @@ func (v *InitJSON) LogModuleInstallation(message string) {
 
 // Implements ModuleInstallationLogger
 func (v *InitJSON) LogModuleUpgrade() {
-	// This was previously logged via Output, so we need to match implementation of that method
-	// to ensure the same JSON log is produced.
-	params := []any{}
-	v.Output(UpgradingModulesMessage, params...)
+	msg := "Upgrading modules..."
+	v.initOutputLog(msg, json.UpgradingModulesMessage)
 }
 
 // Implements ModuleInstallationLogger
@@ -535,10 +531,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 	"output_init_success_cli_cloud_message": {
 		HumanValue: outputInitSuccessCLICloud,
 		JSONValue:  outputInitSuccessCLICloudJSON,
-	},
-	"upgrading_modules_message": {
-		HumanValue: "[reset][bold]Upgrading modules...",
-		JSONValue:  "Upgrading modules...",
 	},
 	"initializing_modules_message": {
 		HumanValue: "[reset][bold]Initializing modules...",
@@ -661,7 +653,6 @@ const (
 	OutputInitSuccessCloudMessage     InitMessageCode = "output_init_success_cloud_message"
 	OutputInitSuccessCLIMessage       InitMessageCode = "output_init_success_cli_message"
 	OutputInitSuccessCLICloudMessage  InitMessageCode = "output_init_success_cli_cloud_message"
-	UpgradingModulesMessage           InitMessageCode = "upgrading_modules_message"
 	InitializingTerraformCloudMessage InitMessageCode = "initializing_terraform_cloud_message"
 	InitializingModulesMessage        InitMessageCode = "initializing_modules_message"
 	InitializingBackendMessage        InitMessageCode = "initializing_backend_message"

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -94,7 +94,8 @@ func (v *InitHuman) LogConfigurationCopyingStart(moduleSource string) {
 }
 
 func (v *InitHuman) LogInstallProvidersStart() {
-	v.print(v.prepareMessage(InitializingProviderPluginMessage))
+	msg := "\n[reset][bold]Initializing provider plugins..."
+	v.print(msg)
 }
 
 func (v *InitHuman) LogInstallStateStoreProviderStart(pAddr tfaddr.Provider, cons getproviders.VersionConstraints, storeType string) {
@@ -318,10 +319,8 @@ func (v *InitJSON) logInitMessage(messageCode InitMessageCode, params ...any) {
 }
 
 func (v *InitJSON) LogInstallProvidersStart() {
-	// This was previously logged via Output, so we need to match implementation of that method
-	// to ensure the same JSON log is produced.
-	params := []any{}
-	v.Output(InitializingProviderPluginMessage, params...)
+	msg := "Initializing provider plugins..."
+	v.initOutputLog(msg, json.InitializingProviderPluginMessage)
 }
 
 func (v *InitJSON) LogInstallStateStoreProviderStart(pAddr tfaddr.Provider, cons getproviders.VersionConstraints, storeType string) {
@@ -536,10 +535,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]Initializing the backend...",
 		JSONValue:  "Initializing the backend...",
 	},
-	"initializing_provider_plugin_message": {
-		HumanValue: "\n[reset][bold]Initializing provider plugins...",
-		JSONValue:  "Initializing provider plugins...",
-	},
 	"initializing_state_store_message": {
 		HumanValue: "\n[reset][bold]Initializing the state store %q...",
 		JSONValue:  "Initializing the state store %q...",
@@ -648,7 +643,6 @@ const (
 	InitializingTerraformCloudMessage InitMessageCode = "initializing_terraform_cloud_message"
 	InitializingBackendMessage        InitMessageCode = "initializing_backend_message"
 	InitializingStateStoreMessage     InitMessageCode = "initializing_state_store_message"
-	InitializingProviderPluginMessage InitMessageCode = "initializing_provider_plugin_message"
 	LockInfo                          InitMessageCode = "lock_info"
 	DependenciesLockChangesInfo       InitMessageCode = "dependencies_lock_changes_info"
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -89,7 +89,8 @@ func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
 }
 
 func (v *InitHuman) LogConfigurationCopyingStart(moduleSource string) {
-	v.print(v.prepareMessage(CopyingConfigurationMessage, moduleSource))
+	template := "[reset][bold]Copying configuration[reset] from %q..."
+	v.print(fmt.Sprintf(template, moduleSource))
 }
 
 func (v *InitHuman) LogInstallProvidersStart() {
@@ -296,11 +297,8 @@ func (v *InitJSON) initOutputLog(preppedMessage string, messageCode any) {
 }
 
 func (v *InitJSON) LogConfigurationCopyingStart(moduleSource string) {
-	params := []any{moduleSource}
-
-	// This was previously logged via Output, so we need to match implementation of that method
-	// to ensure the same JSON log is produced.
-	v.Output(CopyingConfigurationMessage, params...)
+	template := "Copying configuration from %q..."
+	v.initOutputLog(fmt.Sprintf(template, moduleSource), json.CopyingConfigurationMessage)
 }
 
 // logInitMessage is an internalised version of an old method `LogInitMessage`.
@@ -518,10 +516,6 @@ type InitMessage struct {
 }
 
 var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMessage{
-	"copying_configuration_message": {
-		HumanValue: "[reset][bold]Copying configuration[reset] from %q...",
-		JSONValue:  "Copying configuration from %q...",
-	},
 	"output_init_empty_message": {
 		HumanValue: outputInitEmpty,
 		JSONValue:  outputInitEmptyJSON,
@@ -662,7 +656,6 @@ const (
 	// Following message codes are used and documented EXTERNALLY
 	// Keep docs/internals/machine-readable-ui.mdx up to date with
 	// this list when making changes here.
-	CopyingConfigurationMessage       InitMessageCode = "copying_configuration_message"
 	OutputInitEmptyMessage            InitMessageCode = "output_init_empty_message"
 	OutputInitSuccessMessage          InitMessageCode = "output_init_success_message"
 	OutputInitSuccessCloudMessage     InitMessageCode = "output_init_success_cloud_message"

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -206,10 +206,8 @@ func (v *InitHuman) LogModuleUpgrade() {
 
 // Implements ModuleInstallationLogger
 func (v *InitHuman) LogModuleInitialization() {
-	// This was previously logged via Output, so we need to match implementation of that method
-	// to ensure the same JSON log is produced.
-	params := []any{}
-	v.print(v.prepareMessage(InitializingModulesMessage, params...))
+	msg := "[reset][bold]Initializing modules..."
+	v.print(msg)
 }
 
 // print formats (trims whitespace & applies colour) and
@@ -481,10 +479,8 @@ func (v *InitJSON) LogModuleUpgrade() {
 
 // Implements ModuleInstallationLogger
 func (v *InitJSON) LogModuleInitialization() {
-	// This was previously logged via Output, so we need to match implementation of that method
-	// to ensure the same JSON log is produced.
-	params := []any{}
-	v.Output(InitializingModulesMessage, params...)
+	msg := "Initializing modules..."
+	v.initOutputLog(msg, json.InitializingModulesMessage)
 }
 
 // prepareMessage retrieves a message template matching the InitMessageCode and
@@ -531,10 +527,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 	"output_init_success_cli_cloud_message": {
 		HumanValue: outputInitSuccessCLICloud,
 		JSONValue:  outputInitSuccessCLICloudJSON,
-	},
-	"initializing_modules_message": {
-		HumanValue: "[reset][bold]Initializing modules...",
-		JSONValue:  "Initializing modules...",
 	},
 	"initializing_terraform_cloud_message": {
 		HumanValue: "\n[reset][bold]Initializing HCP Terraform...",
@@ -654,7 +646,6 @@ const (
 	OutputInitSuccessCLIMessage       InitMessageCode = "output_init_success_cli_message"
 	OutputInitSuccessCLICloudMessage  InitMessageCode = "output_init_success_cli_cloud_message"
 	InitializingTerraformCloudMessage InitMessageCode = "initializing_terraform_cloud_message"
-	InitializingModulesMessage        InitMessageCode = "initializing_modules_message"
 	InitializingBackendMessage        InitMessageCode = "initializing_backend_message"
 	InitializingStateStoreMessage     InitMessageCode = "initializing_state_store_message"
 	InitializingProviderPluginMessage InitMessageCode = "initializing_provider_plugin_message"

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -267,6 +267,16 @@ func (v *InitJSON) PolicyResult(addr string, resp policy.EvaluationResponse) {
 
 func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
 	preppedMessage := v.prepareMessage(messageCode, params...)
+	v.initOutputLog(preppedMessage, messageCode)
+}
+
+func (v *InitJSON) initOutputLog(preppedMessage string, messageCode any) {
+	switch messageCode.(type) {
+	case InitMessageCode, json.MessageType:
+		// ok, tolerated custom string types
+	default:
+		panic(fmt.Sprintf("initOutputLog: unexpected argument type %T", messageCode))
+	}
 
 	// Logged data includes by default:
 	// @level as "info"
@@ -281,7 +291,7 @@ func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
 	v.view.log.Info(
 		preppedMessage,
 		"type", "init_output",
-		"message_code", string(messageCode),
+		"message_code", messageCode,
 	)
 }
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -175,8 +175,7 @@ func (v *InitHuman) LogPartnerAndCommunityProviders() {
 
 // Implements ProviderLockingLogger
 func (v *InitHuman) LogProviderLockfileCreated() {
-	params := []any{}
-	v.print(v.prepareMessage(LockInfo, params...))
+	v.print(createdLockInfoHuman)
 }
 
 // Implements ProviderLockingLogger
@@ -442,10 +441,8 @@ func (v *InitJSON) LogPartnerAndCommunityProviders() {
 
 // Implements ProviderLockingLogger
 func (v *InitJSON) LogProviderLockfileCreated() {
-	// This was previously logged via Output, so we need to match implementation of that method
-	// to ensure the same JSON log is produced.
-	params := []any{}
-	v.Output(LockInfo, params...)
+	msg := strings.TrimSpace(createdLockInfoJSON)
+	v.initOutputLog(msg, json.LockInfo)
 }
 
 // Implements ProviderLockingLogger
@@ -543,10 +540,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: dependenciesLockChangesInfo,
 		JSONValue:  dependenciesLockChangesInfo,
 	},
-	"lock_info": {
-		HumanValue: previousLockInfoHuman,
-		JSONValue:  previousLockInfoJSON,
-	},
 	"provider_already_installed_message": {
 		HumanValue: logProviderVersionAlreadyInstalledHuman,
 		JSONValue:  logProviderVersionAlreadyInstalledJSON,
@@ -643,7 +636,6 @@ const (
 	InitializingTerraformCloudMessage InitMessageCode = "initializing_terraform_cloud_message"
 	InitializingBackendMessage        InitMessageCode = "initializing_backend_message"
 	InitializingStateStoreMessage     InitMessageCode = "initializing_state_store_message"
-	LockInfo                          InitMessageCode = "lock_info"
 	DependenciesLockChangesInfo       InitMessageCode = "dependencies_lock_changes_info"
 
 	//// Message codes below are ONLY used INTERNALLY (for now)

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -180,8 +180,8 @@ func (v *InitHuman) LogProviderLockfileCreated() {
 
 // Implements ProviderLockingLogger
 func (v *InitHuman) LogProviderLockfileUpdated() {
-	params := []any{}
-	v.print(v.prepareMessage(DependenciesLockChangesInfo, params...))
+	msg := strings.TrimSpace(dependenciesLockChangesInfo)
+	v.print(msg)
 }
 
 // Implements ModuleInstallationLogger
@@ -447,10 +447,8 @@ func (v *InitJSON) LogProviderLockfileCreated() {
 
 // Implements ProviderLockingLogger
 func (v *InitJSON) LogProviderLockfileUpdated() {
-	// This was previously logged via Output, so we need to match implementation of that method
-	// to ensure the same JSON log is produced.
-	params := []any{}
-	v.Output(DependenciesLockChangesInfo, params...)
+	msg := strings.TrimSpace(dependenciesLockChangesInfo)
+	v.initOutputLog(msg, json.DependenciesLockChangesInfo)
 }
 
 // Implements ModuleInstallationLogger
@@ -535,10 +533,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 	"initializing_state_store_message": {
 		HumanValue: "\n[reset][bold]Initializing the state store %q...",
 		JSONValue:  "Initializing the state store %q...",
-	},
-	"dependencies_lock_changes_info": {
-		HumanValue: dependenciesLockChangesInfo,
-		JSONValue:  dependenciesLockChangesInfo,
 	},
 	"provider_already_installed_message": {
 		HumanValue: logProviderVersionAlreadyInstalledHuman,
@@ -636,7 +630,6 @@ const (
 	InitializingTerraformCloudMessage InitMessageCode = "initializing_terraform_cloud_message"
 	InitializingBackendMessage        InitMessageCode = "initializing_backend_message"
 	InitializingStateStoreMessage     InitMessageCode = "initializing_state_store_message"
-	DependenciesLockChangesInfo       InitMessageCode = "dependencies_lock_changes_info"
 
 	//// Message codes below are ONLY used INTERNALLY (for now)
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -294,7 +294,7 @@ func (v *InitJSON) initOutputLog(preppedMessage string, messageCode any) {
 
 func (v *InitJSON) LogConfigurationCopyingStart(moduleSource string) {
 	template := "Copying configuration from %q..."
-	v.initOutputLog(fmt.Sprintf(template, moduleSource), json.CopyingConfigurationMessage)
+	v.initOutputLog(fmt.Sprintf(template, moduleSource), json.MessageCopyingConfigurationMessage)
 }
 
 // logInitMessage is an internalised version of an old method `LogInitMessage`.
@@ -319,7 +319,7 @@ func (v *InitJSON) logInitMessage(messageCode InitMessageCode, params ...any) {
 
 func (v *InitJSON) LogInstallProvidersStart() {
 	msg := "Initializing provider plugins..."
-	v.initOutputLog(msg, json.InitializingProviderPluginMessage)
+	v.initOutputLog(msg, json.MessageInitializingProviderPluginMessage)
 }
 
 func (v *InitJSON) LogInstallStateStoreProviderStart(pAddr tfaddr.Provider, cons getproviders.VersionConstraints, storeType string) {
@@ -442,13 +442,13 @@ func (v *InitJSON) LogPartnerAndCommunityProviders() {
 // Implements ProviderLockingLogger
 func (v *InitJSON) LogProviderLockfileCreated() {
 	msg := strings.TrimSpace(createdLockInfoJSON)
-	v.initOutputLog(msg, json.LockInfo)
+	v.initOutputLog(msg, json.MessageLockInfo)
 }
 
 // Implements ProviderLockingLogger
 func (v *InitJSON) LogProviderLockfileUpdated() {
 	msg := strings.TrimSpace(dependenciesLockChangesInfo)
-	v.initOutputLog(msg, json.DependenciesLockChangesInfo)
+	v.initOutputLog(msg, json.MessageDependenciesLockChangesInfo)
 }
 
 // Implements ModuleInstallationLogger
@@ -468,13 +468,13 @@ func (v *InitJSON) LogModuleInstallation(message string) {
 // Implements ModuleInstallationLogger
 func (v *InitJSON) LogModuleUpgrade() {
 	msg := "Upgrading modules..."
-	v.initOutputLog(msg, json.UpgradingModulesMessage)
+	v.initOutputLog(msg, json.MessageUpgradingModulesMessage)
 }
 
 // Implements ModuleInstallationLogger
 func (v *InitJSON) LogModuleInitialization() {
 	msg := "Initializing modules..."
-	v.initOutputLog(msg, json.InitializingModulesMessage)
+	v.initOutputLog(msg, json.MessageInitializingModulesMessage)
 }
 
 // prepareMessage retrieves a message template matching the InitMessageCode and

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -112,4 +112,5 @@ const (
 	InitializingModulesMessage        MessageType = "initializing_modules_message"
 	InitializingProviderPluginMessage MessageType = "initializing_provider_plugin_message"
 	LockInfo                          MessageType = "lock_info"
+	DependenciesLockChangesInfo       MessageType = "dependencies_lock_changes_info"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -111,4 +111,5 @@ const (
 	UpgradingModulesMessage           MessageType = "upgrading_modules_message"
 	InitializingModulesMessage        MessageType = "initializing_modules_message"
 	InitializingProviderPluginMessage MessageType = "initializing_provider_plugin_message"
+	LockInfo                          MessageType = "lock_info"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -107,10 +107,10 @@ const (
 	// In a future major version we should make init's JSON output align with the conventions used
 	// elsewhere in the CLI. For now these consts are here to demonstrate that they're public-facing
 	// and changes are potentially breaking.
-	CopyingConfigurationMessage       MessageType = "copying_configuration_message"
-	UpgradingModulesMessage           MessageType = "upgrading_modules_message"
-	InitializingModulesMessage        MessageType = "initializing_modules_message"
-	InitializingProviderPluginMessage MessageType = "initializing_provider_plugin_message"
-	LockInfo                          MessageType = "lock_info"
-	DependenciesLockChangesInfo       MessageType = "dependencies_lock_changes_info"
+	MessageCopyingConfigurationMessage       MessageType = "copying_configuration_message"
+	MessageUpgradingModulesMessage           MessageType = "upgrading_modules_message"
+	MessageInitializingModulesMessage        MessageType = "initializing_modules_message"
+	MessageInitializingProviderPluginMessage MessageType = "initializing_provider_plugin_message"
+	MessageLockInfo                          MessageType = "lock_info"
+	MessageDependenciesLockChangesInfo       MessageType = "dependencies_lock_changes_info"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -109,4 +109,5 @@ const (
 	// and changes are potentially breaking.
 	CopyingConfigurationMessage MessageType = "copying_configuration_message"
 	UpgradingModulesMessage     MessageType = "upgrading_modules_message"
+	InitializingModulesMessage  MessageType = "initializing_modules_message"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -108,4 +108,5 @@ const (
 	// elsewhere in the CLI. For now these consts are here to demonstrate that they're public-facing
 	// and changes are potentially breaking.
 	CopyingConfigurationMessage MessageType = "copying_configuration_message"
+	UpgradingModulesMessage     MessageType = "upgrading_modules_message"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -98,4 +98,14 @@ const (
 	MessageMigrationSourceInitializationComplete      MessageType = "migration_source_initialization_complete"
 	MessageMigrationDestinationInitializationStart    MessageType = "migration_destination_initialization_start"
 	MessageMigrationDestinationInitializationComplete MessageType = "migration_destination_initialization_complete"
+
+	// Init-specific messages
+	//
+	// NOTE: These are not used to set the `type` field in the JSON output from the init command.
+	// Instead, the init command's JSON output was implemented so that some messages are logged with
+	// `"type": "init_output"` and a `message_code` field that takes the const values below.
+	// In a future major version we should make init's JSON output align with the conventions used
+	// elsewhere in the CLI. For now these consts are here to demonstrate that they're public-facing
+	// and changes are potentially breaking.
+	CopyingConfigurationMessage MessageType = "copying_configuration_message"
 )

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -107,7 +107,8 @@ const (
 	// In a future major version we should make init's JSON output align with the conventions used
 	// elsewhere in the CLI. For now these consts are here to demonstrate that they're public-facing
 	// and changes are potentially breaking.
-	CopyingConfigurationMessage MessageType = "copying_configuration_message"
-	UpgradingModulesMessage     MessageType = "upgrading_modules_message"
-	InitializingModulesMessage  MessageType = "initializing_modules_message"
+	CopyingConfigurationMessage       MessageType = "copying_configuration_message"
+	UpgradingModulesMessage           MessageType = "upgrading_modules_message"
+	InitializingModulesMessage        MessageType = "initializing_modules_message"
+	InitializingProviderPluginMessage MessageType = "initializing_provider_plugin_message"
 )

--- a/internal/command/views/provider_locking_logger.go
+++ b/internal/command/views/provider_locking_logger.go
@@ -8,13 +8,13 @@ type ProviderLockingLogger interface {
 	LogProviderLockfileUpdated()
 }
 
-const previousLockInfoHuman = `
+const createdLockInfoHuman = `
 Terraform has created a lock file [bold].terraform.lock.hcl[reset] to record the provider
 selections it made above. Include this file in your version control repository
 so that Terraform can guarantee to make the same selections by default when
 you run "terraform init" in the future.`
 
-const previousLockInfoJSON = `
+const createdLockInfoJSON = `
 Terraform has created a lock file .terraform.lock.hcl to record the provider
 selections it made above. Include this file in your version control repository
 so that Terraform can guarantee to make the same selections by default when

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -292,7 +292,7 @@ func (s *StateMigrateHuman) LogPartnerAndCommunityProviders() {
 
 // Implements DependencyLockLogger interface.
 func (s *StateMigrateHuman) LogProviderLockfileCreated() {
-	s.log(previousLockInfoHuman)
+	s.log(createdLockInfoHuman)
 }
 
 // Implements DependencyLockLogger interface.
@@ -413,7 +413,7 @@ func (s *StateMigrateJSON) LogAutomaticApproval() {
 
 // Implements ProviderLockingLogger interface.
 func (s *StateMigrateJSON) LogProviderLockfileCreated() {
-	msg := strings.TrimSpace(previousLockInfoJSON)
+	msg := strings.TrimSpace(createdLockInfoJSON)
 	s.view.log.Info(
 		msg,
 		"type", json.MessageProviderLockfileCreated,


### PR DESCRIPTION
This PR is part of removing the use of `prepareMessage` and the message registry map when producing output for the `init` command.

For each commit (this may be worth reviewing commit-by-commit) I remove an entry from the map and remove the const used to access values from the map. Instead, methods implemented on the human and JSON views have the template for the message declared inside the method.

Previously this wasn't possible because there were 2 methods used to produce logs from `init`, but now there is a method per event to be logged.

There is no user-facing change in the JSON output, this is just a refactor.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
