### PR TITLE
refactor: Move user-facing `init` message codes into centralised location, stop using them to access message strings - Part 2

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -176,7 +176,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ini
 	defer span.End()
 
 	if root.StateStore != nil {
-		view.Output(views.InitializingStateStoreMessage, root.StateStore.Type)
+		view.LogInitializingStateStoreStart(root.StateStore.Type)
 	} else {
 		view.Output(views.InitializingBackendMessage)
 	}

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -178,7 +178,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ini
 	if root.StateStore != nil {
 		view.LogInitializingStateStoreStart(root.StateStore.Type)
 	} else {
-		view.Output(views.InitializingBackendMessage)
+		view.LogInitializingBackendStart()
 	}
 
 	earlyBdiags := c.earlyValidateBackend(root, initArgs)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -146,7 +146,7 @@ func (c *InitCommand) initCloud(ctx context.Context, root *configs.Module, extra
 	_ = ctx // prevent staticcheck from complaining to avoid a maintenance hazard of having the wrong ctx in scope here
 	defer span.End()
 
-	view.Output(views.InitializingTerraformCloudMessage)
+	view.LogInitializingHCPTerraformStart()
 
 	if len(extraConfig.AllItems()) != 0 {
 		diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -30,6 +30,9 @@ type Init interface {
 	// This is signposted as distinct from general provider download, which may happen later in init.
 	LogInstallStateStoreProviderStart(providerAddr addrs.Provider, cons getproviders.VersionConstraints, storeType string)
 
+	// LogInitializingStateStoreStart indicates progress initializing a state store.
+	LogInitializingStateStoreStart(storeType string)
+
 	ModuleInstallationLogger
 	ProviderInstallationLogger
 	ProviderLockingLogger
@@ -91,6 +94,11 @@ func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
 func (v *InitHuman) LogConfigurationCopyingStart(moduleSource string) {
 	template := "[reset][bold]Copying configuration[reset] from %q..."
 	v.print(fmt.Sprintf(template, moduleSource))
+}
+
+func (v *InitHuman) LogInitializingStateStoreStart(storeType string) {
+	template := "\n[reset][bold]Initializing the state store %q..."
+	v.print(fmt.Sprintf(template, storeType))
 }
 
 func (v *InitHuman) LogInstallProvidersStart() {
@@ -295,6 +303,11 @@ func (v *InitJSON) initOutputLog(preppedMessage string, messageCode any) {
 func (v *InitJSON) LogConfigurationCopyingStart(moduleSource string) {
 	template := "Copying configuration from %q..."
 	v.initOutputLog(fmt.Sprintf(template, moduleSource), json.MessageCopyingConfigurationMessage)
+}
+
+func (v *InitJSON) LogInitializingStateStoreStart(storeType string) {
+	template := "Initializing the state store %q..."
+	v.initOutputLog(fmt.Sprintf(template, storeType), json.MessageInitializingStateStoreMessage)
 }
 
 // logInitMessage is an internalised version of an old method `LogInitMessage`.
@@ -530,10 +543,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]Initializing the backend...",
 		JSONValue:  "Initializing the backend...",
 	},
-	"initializing_state_store_message": {
-		HumanValue: "\n[reset][bold]Initializing the state store %q...",
-		JSONValue:  "Initializing the state store %q...",
-	},
 	"provider_already_installed_message": {
 		HumanValue: logProviderVersionAlreadyInstalledHuman,
 		JSONValue:  logProviderVersionAlreadyInstalledJSON,
@@ -629,7 +638,6 @@ const (
 	OutputInitSuccessCLICloudMessage  InitMessageCode = "output_init_success_cli_cloud_message"
 	InitializingTerraformCloudMessage InitMessageCode = "initializing_terraform_cloud_message"
 	InitializingBackendMessage        InitMessageCode = "initializing_backend_message"
-	InitializingStateStoreMessage     InitMessageCode = "initializing_state_store_message"
 
 	//// Message codes below are ONLY used INTERNALLY (for now)
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -33,6 +33,9 @@ type Init interface {
 	// LogInitializingStateStoreStart indicates progress initializing a state store.
 	LogInitializingStateStoreStart(storeType string)
 
+	// LogInitializingBackendStart indicates progress initializing a backend.
+	LogInitializingBackendStart()
+
 	ModuleInstallationLogger
 	ProviderInstallationLogger
 	ProviderLockingLogger
@@ -99,6 +102,11 @@ func (v *InitHuman) LogConfigurationCopyingStart(moduleSource string) {
 func (v *InitHuman) LogInitializingStateStoreStart(storeType string) {
 	template := "\n[reset][bold]Initializing the state store %q..."
 	v.print(fmt.Sprintf(template, storeType))
+}
+
+func (v *InitHuman) LogInitializingBackendStart() {
+	msg := "\n[reset][bold]Initializing the backend..."
+	v.print(msg)
 }
 
 func (v *InitHuman) LogInstallProvidersStart() {
@@ -308,6 +316,11 @@ func (v *InitJSON) LogConfigurationCopyingStart(moduleSource string) {
 func (v *InitJSON) LogInitializingStateStoreStart(storeType string) {
 	template := "Initializing the state store %q..."
 	v.initOutputLog(fmt.Sprintf(template, storeType), json.MessageInitializingStateStoreMessage)
+}
+
+func (v *InitJSON) LogInitializingBackendStart() {
+	msg := "Initializing the backend..."
+	v.initOutputLog(msg, json.MessageInitializingBackendMessage)
 }
 
 // logInitMessage is an internalised version of an old method `LogInitMessage`.
@@ -539,10 +552,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]Initializing HCP Terraform...",
 		JSONValue:  "Initializing HCP Terraform...",
 	},
-	"initializing_backend_message": {
-		HumanValue: "\n[reset][bold]Initializing the backend...",
-		JSONValue:  "Initializing the backend...",
-	},
 	"provider_already_installed_message": {
 		HumanValue: logProviderVersionAlreadyInstalledHuman,
 		JSONValue:  logProviderVersionAlreadyInstalledJSON,
@@ -637,7 +646,6 @@ const (
 	OutputInitSuccessCLIMessage       InitMessageCode = "output_init_success_cli_message"
 	OutputInitSuccessCLICloudMessage  InitMessageCode = "output_init_success_cli_cloud_message"
 	InitializingTerraformCloudMessage InitMessageCode = "initializing_terraform_cloud_message"
-	InitializingBackendMessage        InitMessageCode = "initializing_backend_message"
 
 	//// Message codes below are ONLY used INTERNALLY (for now)
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -36,6 +36,9 @@ type Init interface {
 	// LogInitializingBackendStart indicates progress initializing a backend.
 	LogInitializingBackendStart()
 
+	// LogInitializingHCPTerraformStart indicates progress initializing the `cloud` backend.
+	LogInitializingHCPTerraformStart()
+
 	ModuleInstallationLogger
 	ProviderInstallationLogger
 	ProviderLockingLogger
@@ -106,6 +109,11 @@ func (v *InitHuman) LogInitializingStateStoreStart(storeType string) {
 
 func (v *InitHuman) LogInitializingBackendStart() {
 	msg := "\n[reset][bold]Initializing the backend..."
+	v.print(msg)
+}
+
+func (v *InitHuman) LogInitializingHCPTerraformStart() {
+	msg := "\n[reset][bold]Initializing HCP Terraform..."
 	v.print(msg)
 }
 
@@ -321,6 +329,11 @@ func (v *InitJSON) LogInitializingStateStoreStart(storeType string) {
 func (v *InitJSON) LogInitializingBackendStart() {
 	msg := "Initializing the backend..."
 	v.initOutputLog(msg, json.MessageInitializingBackendMessage)
+}
+
+func (v *InitJSON) LogInitializingHCPTerraformStart() {
+	msg := "Initializing HCP Terraform..."
+	v.initOutputLog(msg, json.MessageInitializingTerraformCloudMessage)
 }
 
 // logInitMessage is an internalised version of an old method `LogInitMessage`.
@@ -548,10 +561,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: outputInitSuccessCLICloud,
 		JSONValue:  outputInitSuccessCLICloudJSON,
 	},
-	"initializing_terraform_cloud_message": {
-		HumanValue: "\n[reset][bold]Initializing HCP Terraform...",
-		JSONValue:  "Initializing HCP Terraform...",
-	},
 	"provider_already_installed_message": {
 		HumanValue: logProviderVersionAlreadyInstalledHuman,
 		JSONValue:  logProviderVersionAlreadyInstalledJSON,
@@ -640,12 +649,11 @@ const (
 	// Following message codes are used and documented EXTERNALLY
 	// Keep docs/internals/machine-readable-ui.mdx up to date with
 	// this list when making changes here.
-	OutputInitEmptyMessage            InitMessageCode = "output_init_empty_message"
-	OutputInitSuccessMessage          InitMessageCode = "output_init_success_message"
-	OutputInitSuccessCloudMessage     InitMessageCode = "output_init_success_cloud_message"
-	OutputInitSuccessCLIMessage       InitMessageCode = "output_init_success_cli_message"
-	OutputInitSuccessCLICloudMessage  InitMessageCode = "output_init_success_cli_cloud_message"
-	InitializingTerraformCloudMessage InitMessageCode = "initializing_terraform_cloud_message"
+	OutputInitEmptyMessage           InitMessageCode = "output_init_empty_message"
+	OutputInitSuccessMessage         InitMessageCode = "output_init_success_message"
+	OutputInitSuccessCloudMessage    InitMessageCode = "output_init_success_cloud_message"
+	OutputInitSuccessCLIMessage      InitMessageCode = "output_init_success_cli_message"
+	OutputInitSuccessCLICloudMessage InitMessageCode = "output_init_success_cli_cloud_message"
 
 	//// Message codes below are ONLY used INTERNALLY (for now)
 

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -935,6 +935,29 @@ func TestNewInit_LogInitializingBackendStart_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogInitializingHCPTerraformStart_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogInitializingHCPTerraformStart()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Initializing HCP Terraform..."`,
+		`"@module":"terraform.ui"`,
+		`"message_code":"initializing_terraform_cloud_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -888,6 +888,30 @@ func TestNewInit_LogConfigurationCopyingStart_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogInitializingStateStoreStart_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	storeType := "aws_s3"
+	initView.LogInitializingStateStoreStart(storeType)
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Initializing the state store \"aws_s3\"..."`,
+		`"@module":"terraform.ui"`,
+		`"message_code":"initializing_state_store_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -912,6 +912,29 @@ func TestNewInit_LogInitializingStateStoreStart_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogInitializingBackendStart_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogInitializingBackendStart()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Initializing the backend..."`,
+		`"@module":"terraform.ui"`,
+		`"message_code":"initializing_backend_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -110,6 +110,7 @@ const (
 	MessageCopyingConfigurationMessage       MessageType = "copying_configuration_message"
 	MessageUpgradingModulesMessage           MessageType = "upgrading_modules_message"
 	MessageInitializingModulesMessage        MessageType = "initializing_modules_message"
+	MessageInitializingStateStoreMessage     MessageType = "initializing_state_store_message"
 	MessageInitializingProviderPluginMessage MessageType = "initializing_provider_plugin_message"
 	MessageLockInfo                          MessageType = "lock_info"
 	MessageDependenciesLockChangesInfo       MessageType = "dependencies_lock_changes_info"

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -111,6 +111,7 @@ const (
 	MessageUpgradingModulesMessage           MessageType = "upgrading_modules_message"
 	MessageInitializingModulesMessage        MessageType = "initializing_modules_message"
 	MessageInitializingStateStoreMessage     MessageType = "initializing_state_store_message"
+	MessageInitializingBackendMessage        MessageType = "initializing_backend_message"
 	MessageInitializingProviderPluginMessage MessageType = "initializing_provider_plugin_message"
 	MessageLockInfo                          MessageType = "lock_info"
 	MessageDependenciesLockChangesInfo       MessageType = "dependencies_lock_changes_info"

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -109,6 +109,7 @@ const (
 	// and changes are potentially breaking.
 	MessageCopyingConfigurationMessage       MessageType = "copying_configuration_message"
 	MessageUpgradingModulesMessage           MessageType = "upgrading_modules_message"
+	MessageInitializingTerraformCloudMessage MessageType = "initializing_terraform_cloud_message"
 	MessageInitializingModulesMessage        MessageType = "initializing_modules_message"
 	MessageInitializingStateStoreMessage     MessageType = "initializing_state_store_message"
 	MessageInitializingBackendMessage        MessageType = "initializing_backend_message"


### PR DESCRIPTION
This PR is part of removing the use of `prepareMessage` and the message registry map when producing output for the `init` command.

For each commit (this may be worth reviewing commit-by-commit) I remove an entry from the map and remove the const used to access values from the map. Instead, methods implemented on the human and JSON views have the template for the message declared inside the method.

Previously this wasn't possible because there were 2 methods used to produce logs from init, but now there is a method per event to be logged.

There is no user-facing change in the JSON output, this is just a refactor.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
