### PR TITLE
deferred: Update apply expansion to ensure partial expansions are registered as unknown

### DIFF
--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -3646,6 +3646,194 @@ import {
 			},
 		},
 	}
+	unknownCountOutputEvaluation = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+resource "test" "a" {
+	name = "1"
+}
+
+resource "test" "b" {
+	count = tonumber(test.a.output)
+	name = "test-b-${count.index}"
+}
+
+output "test" {
+	value = test.b[0].output
+	type = string
+}
+`,
+		},
+		stages: []deferredActionsTestStage{
+			{
+				buildOpts: func(opts *PlanOpts) {
+					opts.Mode = plans.NormalMode
+				},
+				wantActions: map[string]plans.Action{
+					"test.a": plans.Create,
+				},
+				wantPlanned: map[string]cty.Value{
+					"1": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("1"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+					"<unknown>": cty.ObjectVal(map[string]cty.Value{
+						"name": cty.UnknownVal(cty.String).Refine().
+							StringPrefixFull("test-b-").
+							NotNull().
+							NewValue(),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+				},
+				wantApplied: map[string]cty.Value{
+					"1": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("1"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("1"),
+					}),
+				},
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.b[*]": ExpectedDeferred{
+						Action: plans.Create,
+						Reason: providers.DeferredReasonInstanceCountUnknown,
+					},
+				},
+				wantOutputs: map[string]cty.Value{
+					"test": cty.NullVal(cty.String),
+				},
+				complete: false,
+			},
+			{
+				buildOpts: func(opts *PlanOpts) {
+					opts.Mode = plans.NormalMode
+				},
+				wantActions: map[string]plans.Action{
+					"test.a":    plans.NoOp,
+					"test.b[0]": plans.Create,
+				},
+				wantPlanned: map[string]cty.Value{
+					"1": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("1"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("1"),
+					}),
+					"test-b-0": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("test-b-0"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+				},
+				wantApplied: map[string]cty.Value{
+					"test-b-0": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("test-b-0"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("test-b-0"),
+					}),
+				},
+				wantDeferred: map[string]ExpectedDeferred{},
+				wantOutputs: map[string]cty.Value{
+					"test": cty.StringVal("test-b-0"),
+				},
+				complete: true,
+			},
+		},
+	}
+	unknownForEachOutputEvaluation = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+resource "test" "a" {
+	name = "1"
+}
+
+resource "test" "b" {
+	for_each = toset(["key${test.a.output}"])
+	name = "test-b-${test.a.output}"
+}
+
+output "test" {
+	value = test.b["key1"].output
+	type = string
+}
+`,
+		},
+		stages: []deferredActionsTestStage{
+			{
+				buildOpts: func(opts *PlanOpts) {
+					opts.Mode = plans.NormalMode
+				},
+				wantActions: map[string]plans.Action{
+					"test.a": plans.Create,
+				},
+				wantPlanned: map[string]cty.Value{
+					"1": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("1"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+					"<unknown>": cty.ObjectVal(map[string]cty.Value{
+						"name": cty.UnknownVal(cty.String).Refine().
+							StringPrefixFull("test-b-").
+							NotNull().
+							NewValue(),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+				},
+				wantApplied: map[string]cty.Value{
+					"1": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("1"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("1"),
+					}),
+				},
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.b[*]": ExpectedDeferred{
+						Action: plans.Create,
+						Reason: providers.DeferredReasonInstanceCountUnknown,
+					},
+				},
+				wantOutputs: map[string]cty.Value{
+					"test": cty.NullVal(cty.String),
+				},
+				complete: false,
+			},
+			{
+				buildOpts: func(opts *PlanOpts) {
+					opts.Mode = plans.NormalMode
+				},
+				wantActions: map[string]plans.Action{
+					"test.a":           plans.NoOp,
+					"test.b[\"key1\"]": plans.Create,
+				},
+				wantPlanned: map[string]cty.Value{
+					"1": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("1"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("1"),
+					}),
+					"test-b-1": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("test-b-1"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+				},
+				wantApplied: map[string]cty.Value{
+					"test-b-1": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("test-b-1"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("test-b-1"),
+					}),
+				},
+				wantDeferred: map[string]ExpectedDeferred{},
+				wantOutputs: map[string]cty.Value{
+					"test": cty.StringVal("test-b-1"),
+				},
+				complete: true,
+			},
+		},
+	}
 )
 
 func TestContextApply_deferredActions(t *testing.T) {
@@ -3704,6 +3892,8 @@ func TestContextApply_deferredActions(t *testing.T) {
 		"unknown_foreach_during_destroy":                          unknownForEachDuringDestroy,
 		"unknown_foreach_during_refresh_with_import":              unknownForEachDuringRefreshWithImport,
 		"unknown_foreach_during_destroy_with_import":              unknownForEachDuringDestroyWithImport,
+		"unknown_count_output_evaluation":                         unknownCountOutputEvaluation,
+		"unknown_foreach_output_evaluation":                       unknownForEachOutputEvaluation,
 	}
 
 	for name, test := range tests {

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -82,7 +82,7 @@ func (n *nodeExpandApplyableResource) checkForPartialExpansion(ctx EvalContext, 
 			case n.Config != nil && n.Config.Count != nil:
 				expander.SetResourceCountUnknown(addr.Module, n.Addr.Resource)
 			case n.Config != nil && n.Config.ForEach != nil:
-				expander.SetResourceCountUnknown(addr.Module, n.Addr.Resource)
+				expander.SetResourceForEachUnknown(addr.Module, n.Addr.Resource)
 			default:
 				continue
 			}

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -55,11 +55,43 @@ func (n *nodeExpandApplyableResource) DynamicExpand(ctx EvalContext) (*Graph, tf
 	expander := ctx.InstanceExpander()
 	moduleInstances := expander.ExpandModule(n.Addr.Module, false)
 	for _, module := range moduleInstances {
+		absAddr := n.Addr.Resource.Absolute(module)
+		// If the resource in this module instance is part of a partial expansion, we will expand it with an unknown count/for_each
+		if n.checkForPartialExpansion(ctx, absAddr) {
+			continue
+		}
+
 		moduleCtx := evalContextForModuleInstance(ctx, module)
-		diags = diags.Append(n.recordResourceData(moduleCtx, n.Addr.Resource.Absolute(module)))
+		diags = diags.Append(n.recordResourceData(moduleCtx, absAddr))
 	}
 
 	return nil, diags
+}
+
+func (n *nodeExpandApplyableResource) checkForPartialExpansion(ctx EvalContext, addr addrs.AbsResource) bool {
+	if len(n.PartialExpansions) == 0 {
+		return false
+	}
+
+	expander := ctx.InstanceExpander()
+	for _, per := range n.PartialExpansions {
+		if per.MatchesResource(addr) {
+			// Resources that are partially expanded shouldn't evaluate count or for_each expressions
+			// as we have already deferred them, so any resulting evaluations were not part of the plan.
+			switch {
+			case n.Config != nil && n.Config.Count != nil:
+				expander.SetResourceCountUnknown(addr.Module, n.Addr.Resource)
+			case n.Config != nil && n.Config.ForEach != nil:
+				expander.SetResourceCountUnknown(addr.Module, n.Addr.Resource)
+			default:
+				continue
+			}
+
+			return true
+		}
+	}
+
+	return false
 }
 
 // We need to expand the ephemeral resources mostly the same as we do during


### PR DESCRIPTION
This PR fixes an issue where deferred resource expansions were being registered incorrectly during apply, which can result in an evaluation error. For example, given the config below:

```terraform
resource "random_integer" "test" {
  min = 1
  max = 3
}

resource "random_pet" "pets" {
  count = random_integer.test.result
}

output "test" {
  value = random_pet.pets[0].id # This will definitely exist, but not on the first apply
}
```

Running `terraform apply -auto-approve -allow-deferral` will produce an error when `output.test` is evaluated:
```bash
│ Error: Invalid index
│ 
│   on main.tf line 11, in output "test":
│   11:   value = random_pet.pets[0].id # This will definitely exist, but not on the first apply
│     ├────────────────
│     │ random_pet.pets is empty tuple
│ 
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
```

-------

The root cause of this error is because `nodeExpandApplyableResource` for `random_pet.pets` is evaluated after `random_integer.test` was already applied. This means that the `count` evaluation will then successfully resolve and [set an expansion count](https://github.com/hashicorp/terraform/blob/d052145462e9b513211f335509bff31b86507127/internal/terraform/node_resource_abstract.go#L515) for `random_pet.pets`, however, there won't be any data as that resource was already deferred and a placeholder node was created  (see [`transform_deferred`](https://github.com/hashicorp/terraform/blob/d052145462e9b513211f335509bff31b86507127/internal/terraform/transform_deferred.go#L49-L89)). An empty collection is returned for `random_pet.pets` when evaluated in the output (or any reference, output is just being used as an example), then you get the invalid index error.

Since `random_pet.pets` was already deferred due to an unknown `count` during plan, we must set the expansion to unknown regardless of whether `count` or `for_each` evaluates to a known value during apply. This was actually in-place originally, then removed in https://github.com/hashicorp/terraform/pull/35182/changes#diff-a88c8d4a2649b110ff5056785e9a2d89ef634d24262c8e07c9a210026d1516fe (although I don't believe that piece of code would even work as-is 😅 ).

Once the unknown expansion for `count` or `for_each` is registered, all further evaluation will receive a `cty.DynamicVal` via this existing logic in the evaluator: https://github.com/hashicorp/terraform/blob/d052145462e9b513211f335509bff31b86507127/internal/terraform/evaluate.go#L689-L705

-------

 With these changes applied, you can successfully run the example config above through two rounds of `terraform apply -auto-approve -allow-deferral`:
```bash
$ terraform apply -auto-approve -allow-deferral

Note: This is a partial plan, parts can only be known in the next plan / apply cycle.


  # random_pet.pets[*] was deferred
  # (because the number of resource instances is unknown)
  + resource "random_pet" "pets" {
      + id        = (known after apply)
      + length    = 2
      + separator = "-"
    }

─────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # random_integer.test will be created
  + resource "random_integer" "test" {
      + id     = (known after apply)
      + max    = 3
      + min    = 1
      + result = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + test = (known after apply)
random_integer.test: Creating...
random_integer.test: Creation complete after 0s [id=2]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

test = null

------------------------

$ terraform apply -auto-approve -allow-deferral


random_integer.test: Refreshing state... [id=2]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # random_pet.pets[0] will be created
  + resource "random_pet" "pets" {
      + id        = (known after apply)
      + length    = 2
      + separator = "-"
    }

  # random_pet.pets[1] will be created
  + resource "random_pet" "pets" {
      + id        = (known after apply)
      + length    = 2
      + separator = "-"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + test = (known after apply)
random_pet.pets[1]: Creating...
random_pet.pets[1]: Creation complete after 0s [id=frank-polliwog]
random_pet.pets[0]: Creating...
random_pet.pets[0]: Creation complete after 0s [id=rested-python]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

test = "rested-python"
```

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [X] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
