### PR TITLE
fix apply graph build order for CBD nodes

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260831-100833.yaml
+++ b/.changes/v1.16/BUG FIXES-20260831-100833.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix create_before_destroy ordering in some combinations of changes
+time: 2026-08-31T10:08:33.916401-04:00
+custom:
+    Issue: "39091"

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -5285,3 +5285,121 @@ resource "test_object" "forget_too" {
 		t.Fatal("unexpected resources in state")
 	}
 }
+
+// the addition of the CBD resource should not interfere with the existing resource replacement
+func TestContext2Apply_replaceWithAddedCBD(t *testing.T) {
+	t.Run("example1", func(t *testing.T) {
+		state := states.BuildState(func(s *states.SyncState) {
+			s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.r3"), &states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"test_string":"old_r3"}`),
+				Status:    states.ObjectTainted,
+			}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+		})
+
+		m := testModuleInline(t, map[string]string{
+			"main.tf": `
+resource "test_object" "r1" {}
+
+resource "test_object" "r2" {
+  lifecycle { create_before_destroy = true }
+  depends_on = [test_object.r1]
+}
+
+resource "test_object" "r3" {
+  test_string = test_object.r1.test_string
+}
+`})
+
+		p := simpleMockProvider()
+		oldR3destroyed := false
+
+		p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+			// we need to check for the destroy request for the old r3 instance
+			if !req.PriorState.IsNull() {
+				if arg := req.PriorState.GetAttr("test_string"); !arg.IsNull() && arg.AsString() == "old_r3" && req.PlannedState.IsNull() {
+					oldR3destroyed = true
+				}
+
+			}
+			resp.NewState = req.PlannedState
+			return resp
+		}
+
+		hook := new(MockHook)
+		ctx := testContext2(t, &ContextOpts{
+			Hooks: []Hook{hook},
+			Providers: map[addrs.Provider]providers.Factory{
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+			},
+		})
+
+		plan, diags := ctx.Plan(m, state, &PlanOpts{Mode: plans.NormalMode})
+		if assertNoDiagnostics(t, diags) {
+			t.Fatal(diags.ErrWithWarnings())
+		}
+
+		for _, ch := range plan.Changes.Resources {
+			if ch.Addr.Equal(mustResourceInstanceAddr("test_object.r3")) && ch.Action != plans.DeleteThenCreate {
+				t.Fatal("wrong change for r3:", ch.Action, ch.ActionReason)
+			}
+		}
+
+		_, applyDiags := ctx.Apply(plan, m, nil)
+		assertNoDiagnostics(t, applyDiags)
+
+		if !oldR3destroyed {
+			t.Fatal("the original r3 was not destroyed")
+		}
+	})
+
+	t.Run("example2", func(t *testing.T) {
+		state := states.BuildState(func(s *states.SyncState) {
+			s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.r2"), &states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"test_string":"r2"}`),
+				Status:    states.ObjectTainted,
+			}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+			s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.r3"), &states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"test_string":"r3"}`),
+				Status:    states.ObjectTainted,
+			}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+		})
+
+		m := testModuleInline(t, map[string]string{
+			"main.tf": `
+resource "test_object" "r1" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "test_object" "r2" {
+  lifecycle {
+    replace_triggered_by = [test_object.r3]
+  }
+  depends_on = [test_object.r1]
+}
+
+resource "test_object" "r3" {
+  test_string = null
+}
+`})
+
+		p := simpleMockProvider()
+
+		hook := new(MockHook)
+		ctx := testContext2(t, &ContextOpts{
+			Hooks: []Hook{hook},
+			Providers: map[addrs.Provider]providers.Factory{
+				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+			},
+		})
+
+		plan, diags := ctx.Plan(m, state, &PlanOpts{Mode: plans.NormalMode})
+		if assertNoDiagnostics(t, diags) {
+			t.Fatal(diags.ErrWithWarnings())
+		}
+
+		_, applyDiags := ctx.Apply(plan, m, nil)
+		assertNoDiagnostics(t, applyDiags)
+	})
+}

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -223,12 +223,6 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// done its thing.
 		&checkStartTransformer{Config: b.Config, Operation: b.Operation},
 
-		// Destruction ordering
-		&DestroyEdgeTransformer{
-			Changes:   b.Changes,
-			Operation: b.Operation,
-		},
-
 		// Detect when create_before_destroy must be forced on for a particular
 		// node due to dependency edges, to avoid graph cycles during apply.
 		//
@@ -237,6 +231,12 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// information is lost for newly created instances because it contains
 		// no state value, and we end up recalculating CBD for all nodes.
 		&ForcedCBDTransformer{},
+
+		// Destruction ordering
+		&DestroyEdgeTransformer{
+			Changes:   b.Changes,
+			Operation: b.Operation,
+		},
 
 		&CBDEdgeTransformer{
 			Config: b.Config,


### PR DESCRIPTION
Apply graph ordering was incorrect when there were resource changes in combination with CBD nodes added to the graph. This was due to the ForcedCBDTransformer needing to run before the normal destroy edge transformer, or else the DestroyEdgeTransformer will disrupt the method the DestroyEdgeTransformer uses to walk the correct nodes.

The reason for moving the DestroyEdgeTransformer in the first place was taken care of by another change, and no existing tests need to be fixed when moving it back. Optimally, the FIXME associated with the ForcedCBDTransformer should be taken care of, because in theory we don't need to check for ForcedCBD status during apply since we should have planned everything already.

Fixes #39076
Fixes #39089