### PR TITLE
Delete changefile as part of backporting change

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260818-111835.yaml
+++ b/.changes/v1.17/BUG FIXES-20260818-111835.yaml
@@ -1,5 +1,0 @@
-kind: BUG FIXES
-body: Fix panic when import identity references sensitive value
-time: 2026-08-18T11:18:35.405953+02:00
-custom:
-    Issue: "39013"


### PR DESCRIPTION
This change on main branch is a counterpart to the backport in https://github.com/hashicorp/terraform/pull/39097; moving the change file to the v1.16 folder is needed for the backport, so we don't want it duplicated in the v1.17 release notes.

Do not merge until after https://github.com/hashicorp/terraform/pull/39097

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
