### PR TITLE
Reduce json message length lockfile msgs

### DIFF
--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -561,8 +561,8 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  dependenciesLockChangesInfoJSON,
 	},
 	"lock_info": {
-		HumanValue: previousLockInfoHuman,
-		JSONValue:  previousLockInfoJSON,
+		HumanValue: createdLockInfoHuman,
+		JSONValue:  createdLockInfoJSON,
 	},
 	"provider_already_installed_message": {
 		HumanValue: logProviderVersionAlreadyInstalledHuman,

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -557,8 +557,8 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  "Initializing the state store %q...",
 	},
 	"dependencies_lock_changes_info": {
-		HumanValue: dependenciesLockChangesInfo,
-		JSONValue:  dependenciesLockChangesInfo,
+		HumanValue: dependenciesLockChangesInfoHuman,
+		JSONValue:  dependenciesLockChangesInfoJSON,
 	},
 	"lock_info": {
 		HumanValue: previousLockInfoHuman,

--- a/internal/command/views/provider_locking_logger.go
+++ b/internal/command/views/provider_locking_logger.go
@@ -8,17 +8,13 @@ type ProviderLockingLogger interface {
 	LogProviderLockfileUpdated()
 }
 
-const previousLockInfoHuman = `
+const createdLockInfoHuman = `
 Terraform has created a lock file [bold].terraform.lock.hcl[reset] to record the provider
 selections it made above. Include this file in your version control repository
 so that Terraform can guarantee to make the same selections by default when
 you run "terraform init" in the future.`
 
-const previousLockInfoJSON = `
-Terraform has created a lock file .terraform.lock.hcl to record the provider
-selections it made above. Include this file in your version control repository
-so that Terraform can guarantee to make the same selections by default when
-you run "terraform init" in the future.`
+const createdLockInfoJSON = `Terraform has created a lock file .terraform.lock.hcl to record the provider selections made during this command.`
 
 const dependenciesLockChangesInfoHuman = `
 Terraform has made some changes to the provider dependency selections recorded

--- a/internal/command/views/provider_locking_logger.go
+++ b/internal/command/views/provider_locking_logger.go
@@ -20,7 +20,9 @@ selections it made above. Include this file in your version control repository
 so that Terraform can guarantee to make the same selections by default when
 you run "terraform init" in the future.`
 
-const dependenciesLockChangesInfo = `
+const dependenciesLockChangesInfoHuman = `
 Terraform has made some changes to the provider dependency selections recorded
 in the .terraform.lock.hcl file. Review those changes and commit them to your
 version control system if they represent changes you intended to make.`
+
+const dependenciesLockChangesInfoJSON = `Terraform has made some changes to the provider dependency selections recorded in the .terraform.lock.hcl file.`

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -292,7 +292,7 @@ func (s *StateMigrateHuman) LogPartnerAndCommunityProviders() {
 
 // Implements DependencyLockLogger interface.
 func (s *StateMigrateHuman) LogProviderLockfileCreated() {
-	s.log(previousLockInfoHuman)
+	s.log(createdLockInfoHuman)
 }
 
 // Implements DependencyLockLogger interface.
@@ -413,7 +413,7 @@ func (s *StateMigrateJSON) LogAutomaticApproval() {
 
 // Implements ProviderLockingLogger interface.
 func (s *StateMigrateJSON) LogProviderLockfileCreated() {
-	msg := strings.TrimSpace(previousLockInfoJSON)
+	msg := strings.TrimSpace(createdLockInfoJSON)
 	s.view.log.Info(
 		msg,
 		"type", json.LogProviderLockfileCreated,

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -297,7 +297,7 @@ func (s *StateMigrateHuman) LogProviderLockfileCreated() {
 
 // Implements DependencyLockLogger interface.
 func (s *StateMigrateHuman) LogProviderLockfileUpdated() {
-	s.log(dependenciesLockChangesInfo)
+	s.log(dependenciesLockChangesInfoHuman)
 }
 
 // Implements ProviderInstallationLogger interface.
@@ -422,7 +422,7 @@ func (s *StateMigrateJSON) LogProviderLockfileCreated() {
 
 // Implements ProviderLockingLogger interface.
 func (s *StateMigrateJSON) LogProviderLockfileUpdated() {
-	msg := strings.TrimSpace(dependenciesLockChangesInfo)
+	msg := strings.TrimSpace(dependenciesLockChangesInfoJSON)
 	s.view.log.Info(
 		msg,
 		"type", json.LogProviderLockfileUpdated,

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -217,7 +217,7 @@ func TestNewStateMigrate_LogDependencyLockfileUpdated_json(t *testing.T) {
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`Terraform has made some changes to the provider dependency selections`, // @message - incomplete but sufficient
+		`"@message":"Terraform has made some changes to the provider dependency selections recorded in the .terraform.lock.hcl file."`,
 		`"@module":"terraform.ui"`,
 		`"type":"provider_lockfile_updated"`,
 	}

--- a/internal/command/views/state_migrate_test.go
+++ b/internal/command/views/state_migrate_test.go
@@ -195,7 +195,7 @@ func TestNewStateMigrate_LogDependencyLockfileCreated_json(t *testing.T) {
 	output := done(t)
 	expectedOutputFields := []string{
 		`"@level":"info"`,
-		`Terraform has created a lock file .terraform.lock.hcl`, // @message - incomplete but sufficient
+		`"@message":"Terraform has created a lock file .terraform.lock.hcl to record the provider selections made during this command."`, // @message - incomplete but sufficient
 		`"@module":"terraform.ui"`,
 		`"type":"provider_lockfile_created"`,
 	}


### PR DESCRIPTION
This change makes the JSON logs describing creation and updates to dependency lock files, in both the `init` and `state migrate` commands, no longer include the full human-readable output as the `@message` field's value.

The @message field is [the human-readable summary of the contents of a JSON log message](https://developer.hashicorp.com/terraform/internals/machine-readable-ui#message), and this doesn't necessarily mean a complete reproduction of the human-readable version of the same log.

Some nuance that I need to clarify is whether we consider JSON output as inherently tied to use in automation or not. In the codebase there are messages that we purposefully exclude because they contain calls to action, and we suppress those if we know there is no audience to read them because Terraform is being run in automation ([example](https://github.com/hashicorp/terraform/blob/d4db61992b36ab92f92c86a9f2ca64cc14bff16e/internal/command/init_run.go#L457)). It feels _off_ to include calls to action in the human summary of a JSON log because 1) calls to action are additional information and not summaries, 2) use of JSON implies consumption by a machine not a human reader.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
