### PR TITLE
plan: Update `-minimal-refresh` to force refresh when an identity schema is upgraded

### DIFF
--- a/internal/terraform/context_plan_minimal_refresh_test.go
+++ b/internal/terraform/context_plan_minimal_refresh_test.go
@@ -643,7 +643,7 @@ resource "test_object" "a" {
 `,
 	})
 
-	// Provider schema is at version 1, but the stored state is at version 0, so
+	// Resource schema is at version 1, but the stored state is at version 0, so
 	// reading the state performs a schema version upgrade, which will prompt a refresh
 	p := minimalRefreshPlanTestProvider(1)
 	state := minimalRefreshPlanTestState(t, `{"id":"a","arg":"foo","computed":"boop"}`, 0, false)
@@ -662,6 +662,86 @@ resource "test_object" "a" {
 
 	if !p.UpgradeResourceStateCalled {
 		t.Fatal(`Expected a call to UpgradeResourceState but received none.`)
+	}
+	if !p.ReadResourceCalled {
+		t.Fatal(`Expected a call to ReadResource but received none. The resource in this test should be refreshed with ` +
+			`the -minimal-refresh flag as the provider schema version was upgraded.`)
+	}
+
+	change := plan.Changes.ResourceInstance(mustResourceInstanceAddr("test_object.a"))
+	if got, want := change.Action, plans.NoOp; got != want {
+		t.Fatalf("wrong plan action - got: %s, want: %s", got, want)
+	}
+}
+
+func TestContext2Plan_minimal_refresh_identity_upgrade_will_refresh(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "a" {
+  arg = "foo"
+}
+`,
+	})
+
+	// Resource identity schema is at version 1, but the stored identity is at version 0, so
+	// reading the state performs an identity upgrade, which will prompt a refresh
+	p := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": {
+					IdentityVersion: 1,
+					Identity: &configschema.Object{
+						Attributes: map[string]*configschema.Attribute{
+							"id":       {Type: cty.String, Required: true},
+							"newfield": {Type: cty.String, Optional: true},
+						},
+						Nesting: configschema.NestingSingle,
+					},
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"id":       {Type: cty.String, Computed: true},
+							"arg":      {Type: cty.String, Optional: true},
+							"computed": {Type: cty.String, Computed: true},
+						},
+					},
+				},
+			},
+		},
+		PlanResourceChangeFn: func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+			return providers.PlanResourceChangeResponse{PlannedState: req.ProposedNewState}
+		},
+		ApplyResourceChangeFn: func(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+			return providers.ApplyResourceChangeResponse{NewState: req.PlannedState}
+		},
+	}
+
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_object.a"),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON:             []byte(`{"id":"a","arg":"foo","computed":"boop"}`),
+				IdentityJSON:          []byte(`{"id":"a"}`),
+				IdentitySchemaVersion: 0,
+				Status:                states.ObjectReady,
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(m, state, &PlanOpts{
+		Mode:           plans.NormalMode,
+		MinimalRefresh: true,
+	})
+	tfdiags.AssertNoErrors(t, diags)
+
+	if !p.UpgradeResourceIdentityCalled {
+		t.Fatal(`Expected a call to UpgradeResourceIdentityCalled but received none.`)
 	}
 	if !p.ReadResourceCalled {
 		t.Fatal(`Expected a call to ReadResource but received none. The resource in this test should be refreshed with ` +

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -572,7 +572,7 @@ func (n *NodeAbstractResource) readResourceInstanceState(ctx EvalContext, addr a
 		// Shouldn't happen since we should've failed long ago if no schema is present
 		return nil, false, diags.Append(fmt.Errorf("no schema available for %s while reading state; this is a bug in Terraform and should be reported", addr))
 	}
-	src, schemaVersionUpgraded, upgradeDiags := upgradeResourceState(addr, provider, src, schema)
+	src, stateSchemaUpgraded, upgradeDiags := upgradeResourceState(addr, provider, src, schema)
 	if n.Config != nil {
 		upgradeDiags = upgradeDiags.InConfigBody(n.Config.Config, addr.String())
 	}
@@ -581,7 +581,7 @@ func (n *NodeAbstractResource) readResourceInstanceState(ctx EvalContext, addr a
 		return nil, false, diags
 	}
 
-	src, upgradeDiags = upgradeResourceIdentity(addr, provider, src, schema)
+	src, identityUpgraded, upgradeDiags := upgradeResourceIdentity(addr, provider, src, schema)
 	diags = diags.Append(upgradeDiags)
 	if diags.HasErrors() {
 		return nil, false, diags
@@ -592,7 +592,7 @@ func (n *NodeAbstractResource) readResourceInstanceState(ctx EvalContext, addr a
 		diags = diags.Append(err)
 	}
 
-	return obj, schemaVersionUpgraded, diags
+	return obj, stateSchemaUpgraded || identityUpgraded, diags
 }
 
 // readResourceInstanceStateDeposed reads the deposed object for a specific
@@ -638,7 +638,7 @@ func (n *NodeAbstractResource) readResourceInstanceStateDeposed(ctx EvalContext,
 		return nil, diags
 	}
 
-	src, upgradeDiags = upgradeResourceIdentity(addr, provider, src, schema)
+	src, _, upgradeDiags = upgradeResourceIdentity(addr, provider, src, schema)
 	diags = diags.Append(upgradeDiags)
 	if diags.HasErrors() {
 		return nil, diags

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -218,7 +218,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	// If the resource is to be imported, we now ask the provider for an Import
 	// and a Refresh, and save the resulting state to instanceRefreshState.
 
-	schemaVersionUpgraded := false
+	resourceDataUpgraded := false
 	if importing {
 		if n.importTarget.target.IsWhollyKnown() {
 			var importDiags tfdiags.Diagnostics
@@ -265,7 +265,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		}
 	} else {
 		var readDiags tfdiags.Diagnostics
-		instanceRefreshState, schemaVersionUpgraded, readDiags = n.readResourceInstanceState(ctx, addr)
+		instanceRefreshState, resourceDataUpgraded, readDiags = n.readResourceInstanceState(ctx, addr)
 		diags = diags.Append(readDiags)
 		if diags.HasErrors() {
 			// Pre-Diff error hook
@@ -343,7 +343,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	// The practitioner indicated that they don't want to refresh the instance if the configuration
 	// provided doesn't produce a change on it's own, which we will confirm by running an initial plan.
 	// If that plan is a no-op we report the changes and return without refreshing the state.
-	if n.minimalRefresh && !schemaVersionUpgraded && !importing && instanceRefreshState != nil {
+	if n.minimalRefresh && !resourceDataUpgraded && !importing && instanceRefreshState != nil {
 		// We'll keep all the diagnostics separated in this block until we return
 		var initialPlanDiags tfdiags.Diagnostics
 
@@ -415,8 +415,8 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		}
 	}
 
-	if n.minimalRefresh && schemaVersionUpgraded {
-		log.Printf("[DEBUG] Minimal refresh mode: refreshing resource as the schema version has been updated for %s", addr)
+	if n.minimalRefresh && resourceDataUpgraded {
+		log.Printf("[DEBUG] Minimal refresh mode: refreshing resource as the schema version for either the state or identity has been updated for %s", addr)
 	}
 
 	// Refresh, maybe

--- a/internal/terraform/upgrade_resource_state.go
+++ b/internal/terraform/upgrade_resource_state.go
@@ -157,7 +157,7 @@ func upgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Int
 	return new, schemaVersionUpgraded, diags
 }
 
-func upgradeResourceIdentity(addr addrs.AbsResourceInstance, provider providers.Interface, src *states.ResourceInstanceObjectSrc, currentSchema providers.Schema) (*states.ResourceInstanceObjectSrc, tfdiags.Diagnostics) {
+func upgradeResourceIdentity(addr addrs.AbsResourceInstance, provider providers.Interface, src *states.ResourceInstanceObjectSrc, currentSchema providers.Schema) (*states.ResourceInstanceObjectSrc, bool, tfdiags.Diagnostics) {
 	// TODO: This should eventually use a proper FQN.
 	providerType := addr.Resource.Resource.ImpliedProvider()
 	if src.IdentitySchemaVersion > uint64(currentSchema.IdentityVersion) {
@@ -171,13 +171,15 @@ func upgradeResourceIdentity(addr addrs.AbsResourceInstance, provider providers.
 			// version might be required here. :(
 			fmt.Sprintf("The current state of %s was created by a newer provider version than is currently selected. Upgrade the %s provider to work with this state.", addr, providerType),
 		))
-		return nil, diags
+		return nil, false, diags
 	}
 
 	// We don't need to do anything if the identity schema version is already up-to-date.
 	if src.IdentitySchemaVersion == uint64(currentSchema.IdentityVersion) {
-		return src, nil
+		return src, false, nil
 	}
+
+	log.Printf("[TRACE] upgradeResourceIdentity: upgrading identity for %s from version %d to %d using provider %q", addr, src.IdentitySchemaVersion, currentSchema.IdentityVersion, providerType)
 
 	req := providers.UpgradeResourceIdentityRequest{
 		TypeName: addr.Resource.Resource.Type,
@@ -194,7 +196,7 @@ func upgradeResourceIdentity(addr addrs.AbsResourceInstance, provider providers.
 	resp := provider.UpgradeResourceIdentity(req)
 	diags := resp.Diagnostics
 	if diags.HasErrors() {
-		return nil, diags
+		return nil, false, diags
 	}
 
 	if !resp.UpgradedIdentity.IsWhollyKnown() {
@@ -203,7 +205,7 @@ func upgradeResourceIdentity(addr addrs.AbsResourceInstance, provider providers.
 			"Invalid resource identity upgrade",
 			fmt.Sprintf("The %s provider upgraded the identity for %s from a previous version, but produced an invalid result: The returned state contains unknown values.", providerType, addr),
 		))
-		return nil, diags
+		return nil, false, diags
 	}
 
 	newIdentity := resp.UpgradedIdentity
@@ -217,7 +219,7 @@ func upgradeResourceIdentity(addr addrs.AbsResourceInstance, provider providers.
 				fmt.Sprintf("The %s provider upgraded the identity for %s from a previous version, but produced an invalid result: %s.", providerType, addr, tfdiags.FormatError(err)),
 			))
 		}
-		return nil, diags
+		return nil, false, diags
 	}
 
 	new, err := src.CompleteIdentityUpgrade(newIdentity, currentSchema)
@@ -231,7 +233,7 @@ func upgradeResourceIdentity(addr addrs.AbsResourceInstance, provider providers.
 		))
 	}
 
-	return new, diags
+	return new, true, diags
 }
 
 // stripRemovedStateAttributes deletes any attributes no longer present in the


### PR DESCRIPTION
Follow up to #38953

This PR adds logic to detect if an identity is upgraded when reading the resource state (similar to the existing state schema version check), and if detected a refresh will be performed for the resource when using `-minimal-refresh`.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing but the functionality hasn't been released yet 😅  ~and I added a changelog entry.~
- [ ] This change is not user-facing.
