### PR TITLE
addrs: Fix ConfigAction.TargetContains to return true for itself

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260903-032045.yaml
+++ b/.changes/v1.17/BUG FIXES-20260903-032045.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'addrs: Fix ConfigAction.TargetContains to return true for itself- #39120'
+time: 2026-09-03T03:20:45.686821+05:30
+custom:
+    Issue: "39120"

--- a/internal/addrs/action.go
+++ b/internal/addrs/action.go
@@ -360,6 +360,8 @@ func (a ConfigAction) Equal(o ConfigAction) bool {
 
 func (a ConfigAction) TargetContains(other Targetable) bool {
 	switch other := other.(type) {
+	case ConfigAction:
+		return a.Equal(other)
 	case AbsAction:
 		return other.ConfigAction().Equal(a)
 	case AbsActionInstance:

--- a/internal/addrs/action_test.go
+++ b/internal/addrs/action_test.go
@@ -413,3 +413,23 @@ func TestParseAbsActionInstance(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigActionTargetContains(t *testing.T) {
+	addr := ConfigAction{
+		Module: RootModule,
+		Action: Action{Type: "mock", Name: "example"},
+	}
+
+	if !addr.TargetContains(addr) {
+		t.Fatalf("expected ConfigAction to contain itself")
+	}
+
+	// Test it if it does not contain a completely different action
+	otherAddr := ConfigAction{
+		Module: RootModule,
+		Action: Action{Type: "mock", Name: "different"},
+	}
+	if addr.TargetContains(otherAddr) {
+		t.Fatalf("expected ConfigAction not to contain a different action")
+	}
+}


### PR DESCRIPTION
This PR fixes a critical logic flaw in the `addrs` package where `ConfigAction.TargetContains(ConfigAction)` evaluated to `false` when comparing an address against itself.

By definition in the Terraform graph builder, a targetable address must contain itself. Without this missing `case` in the type switch, targeting an action block directly via the CLI (e.g., `terraform plan -target=action.mock.example`) would cause the graph walker to silently bypass the target.

**Changes:**

* Added `case ConfigAction` to the type switch in `ConfigAction.TargetContains` to ensure self-containment.
* Added `TestConfigActionTargetContains` to `action_test.go` to explicitly prevent regressions on self-containment and false-positive matches.

**Evidence:**

* **Before:** The test fails because the address fails to contain itself.
  
<img width="937" height="180" alt="Screenshot from 2026-09-03 02-30-10" src="https://github.com/user-attachments/assets/5eb4f4b1-a713-4573-8d04-72e163f9a075" />


* **After:** The test passes the self-containment check and successfully rejects a different action block.
  
<img width="957" height="156" alt="Screenshot from 2026-09-03 02-32-59" src="https://github.com/user-attachments/assets/d4c34aab-50c6-4744-ba1e-067b0ab4300b" />


**AI Disclosure:**

I utilized an AI assistant to help identify the specific internal DAG graph-walker constraint (that nodes must contain themselves for the `-target` flag to function) and to assist in formatting the table-driven regression tests. All logic and tests were reviewed, compiled, and executed locally by me.

Fixes #39119

## Target Release

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.
## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
