### PR TITLE
Fix mutex leak in newHandleWithDependency

### DIFF
--- a/internal/rpcapi/handles.go
+++ b/internal/rpcapi/handles.go
@@ -219,6 +219,7 @@ func newHandle[ObjT any](t *handleTable, obj ObjT) handle[ObjT] {
 // returned error will be [newHandleErrorNoParent].
 func newHandleWithDependency[ObjT, DepT any](t *handleTable, obj ObjT, dep handle[DepT]) (handle[ObjT], error) {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	if depObjectI, exists := t.handleObjs[int64(dep)]; !exists {
 		return handle[ObjT](0), newHandleErrorNoParent
 	} else if depObject, ok := depObjectI.(DepT); !ok {
@@ -233,7 +234,6 @@ func newHandleWithDependency[ObjT, DepT any](t *handleTable, obj ObjT, dep handl
 		t.handleDeps[int64(dep)] = make(map[int64]struct{})
 	}
 	t.handleDeps[int64(dep)][hnd] = struct{}{}
-	t.mu.Unlock()
 	return handle[ObjT](hnd), nil
 }
 

--- a/internal/rpcapi/handles_test.go
+++ b/internal/rpcapi/handles_test.go
@@ -1,0 +1,49 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package rpcapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-slug/sourcebundle"
+
+	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
+)
+
+func TestNewHandleWithDependency_ParentNotExists(t *testing.T) {
+	// This test verifies that when newHandleWithDependency returns
+	// newHandleErrorNoParent, the mutex is properly unlocked and does
+	// not leak. This was a bug where the mutex was not unlocked on
+	// the error path, causing a potential deadlock.
+	//
+	// See: https://github.com/hashicorp/terraform/issues/39053
+
+	tbl := newHandleTable()
+
+	// Create a handle that depends on a non-existent parent handle (id 999)
+	nonExistentParent := handle[*sourcebundle.Bundle](999)
+	_, err := newHandleWithDependency(tbl, &stackconfig.Config{}, nonExistentParent)
+
+	if err != newHandleErrorNoParent {
+		t.Fatalf("expected newHandleErrorNoParent, got %v", err)
+	}
+
+	// Now verify the mutex is not leaked by attempting to acquire it.
+	// If the mutex was leaked, this would block forever (or timeout).
+	// We use a goroutine with a timeout to detect the leak.
+	done := make(chan struct{})
+	go func() {
+		tbl.mu.Lock()
+		tbl.mu.Unlock()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Mutex was properly unlocked - test passes
+	case <-time.After(time.Second):
+		t.Fatal("mutex appears to be leaked: could not acquire lock within timeout")
+	}
+}


### PR DESCRIPTION
Fixes a potential deadlock bug where the handleTable's mutex was not unlocked when newHandleErrorNoParent was returned. The mutex is now properly unlocked using defer.

Add test case to verify mutex is properly unlocked when parent handle does not exist.

Fixes #39053