### PR TITLE
PSS: Update partial configuration errors to reflect when PSS is in use.

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -242,7 +242,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ini
 
 			// Handle any overrides supplied via -backend-config CLI flags
 			var overrideDiags tfdiags.Diagnostics
-			configOverride, overrideDiags = c.backendConfigOverrideBody(initArgs.BackendConfig, stateStoreSchema.Body)
+			configOverride, overrideDiags = c.backendConfigOverrideBody(initArgs.BackendConfig, stateStoreSchema.Body, StateStore)
 			diags = diags.Append(overrideDiags)
 			if overrideDiags.HasErrors() {
 				return nil, true, diags
@@ -269,7 +269,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ini
 		var configOverride hcl.Body
 		if !initArgs.BackendConfig.Empty() {
 			var overrideDiags tfdiags.Diagnostics
-			configOverride, overrideDiags = c.backendConfigOverrideBody(initArgs.BackendConfig, backendSchema)
+			configOverride, overrideDiags = c.backendConfigOverrideBody(initArgs.BackendConfig, backendSchema, Backend)
 			diags = diags.Append(overrideDiags)
 			if overrideDiags.HasErrors() {
 				return nil, true, diags
@@ -694,7 +694,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 //
 // If the returned diagnostics contains errors then the returned body may be
 // incomplete or invalid.
-func (c *InitCommand) backendConfigOverrideBody(flags arguments.FlagNameValueSlice, schema *configschema.Block) (hcl.Body, tfdiags.Diagnostics) {
+func (c *InitCommand) backendConfigOverrideBody(flags arguments.FlagNameValueSlice, schema *configschema.Block, stateStorageMode string) (hcl.Body, tfdiags.Diagnostics) {
 	items := flags.AllItems()
 	if len(items) == 0 {
 		return nil, nil
@@ -772,12 +772,12 @@ func (c *InitCommand) backendConfigOverrideBody(flags arguments.FlagNameValueSli
 			if attrS == nil {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
-					"Invalid backend configuration argument",
-					fmt.Sprintf("The backend configuration argument %q given on the command line is not expected for the selected backend type.", name),
+					fmt.Sprintf("Invalid %s configuration argument", stateStorageMode),
+					fmt.Sprintf("The %s configuration argument %q given on the command line is not expected for the selected %s type.", stateStorageMode, name, stateStorageMode),
 				))
 				continue
 			}
-			value, valueDiags := configValueFromCLI(item.String(), rawValue, attrS.Type)
+			value, valueDiags := configValueFromCLI(item.String(), rawValue, attrS.Type, stateStorageMode)
 			diags = diags.Append(valueDiags)
 			if valueDiags.HasErrors() {
 				continue

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -731,6 +731,8 @@ func (c *InitCommand) backendConfigOverrideBody(flags arguments.FlagNameValueSli
 
 		if eq == -1 {
 			// The value is interpreted as a filename.
+			//
+			// Overrides via file support overriding Attributes and Blocks.
 			newBody, fileDiags := c.loadHCLFile(item.Value)
 			diags = diags.Append(fileDiags)
 			if fileDiags.HasErrors() {
@@ -776,6 +778,9 @@ func (c *InitCommand) backendConfigOverrideBody(flags arguments.FlagNameValueSli
 			flushVals() // deal with any accumulated individual values first
 			mergeBody(newBody)
 		} else {
+			// The value is interpreted as a key-value pair.
+			//
+			// Overrides via key-value pair only support overriding Attributes.
 			name := item.Value[:eq]
 			rawValue := item.Value[eq+1:]
 			attrS := schema.Attributes[name]

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -757,6 +757,16 @@ func (c *InitCommand) backendConfigOverrideBody(flags arguments.FlagNameValueSli
 					LabelNames: labelNames,
 				})
 			}
+
+			if stateStorageMode == StateStore {
+				// Raise an error if the user is attempting to override a provider block in a state_store block.
+				diags = diags.Append(checkIfConfigOverrideIncludesProviderBlock(newBody))
+
+				// Allow to fall through to next check, which will also raise an "Unsupported block type" error
+				// related to the unexpected "provider" block, too. This is alongside any other errors the user
+				// should be notified about.
+			}
+
 			// Verify that the file body matches the expected backend schema.
 			_, schemaDiags := newBody.Content(&bodySchema)
 			diags = diags.Append(schemaDiags)
@@ -789,6 +799,30 @@ func (c *InitCommand) backendConfigOverrideBody(flags arguments.FlagNameValueSli
 	flushVals()
 
 	return ret, diags
+}
+
+// checkIfConfigOverrideIncludesProviderBlock checks if the HCL body created from a file
+// used to supply override configuration for a state store is attempting to override the provider block.
+// We do this by seeing if the HCL body contains any "provider" blocks.
+func checkIfConfigOverrideIncludesProviderBlock(newBody hcl.Body) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	var s hcl.BodySchema
+	s.Blocks = append(s.Blocks, hcl.BlockHeaderSchema{
+		Type:       "provider",
+		LabelNames: []string{"name"},
+	})
+	bc, _, _ := newBody.PartialContent(&s)
+	for _, b := range bc.Blocks {
+		if b.Type == "provider" {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Cannot partially override provider configuration in a state store block.",
+				"The configuration arguments supplied by the override file attempts to override provider configuration, which is not allowed when using a state store.",
+			))
+			break
+		}
+	}
+	return diags
 }
 
 func (c *InitCommand) AutocompleteArgs() complete.Predictor {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -762,7 +762,7 @@ func (c *InitCommand) backendConfigOverrideBody(flags arguments.FlagNameValueSli
 
 			if stateStorageMode == StateStore {
 				// Raise an error if the user is attempting to override a provider block in a state_store block.
-				diags = diags.Append(checkIfConfigOverrideIncludesProviderBlock(newBody))
+				diags = diags.Append(checkIfConfigOverrideIncludesProviderBlock(newBody, item.Value))
 
 				// Allow to fall through to next check, which will also raise an "Unsupported block type" error
 				// related to the unexpected "provider" block, too. This is alongside any other errors the user
@@ -809,7 +809,7 @@ func (c *InitCommand) backendConfigOverrideBody(flags arguments.FlagNameValueSli
 // checkIfConfigOverrideIncludesProviderBlock checks if the HCL body created from a file
 // used to supply override configuration for a state store is attempting to override the provider block.
 // We do this by seeing if the HCL body contains any "provider" blocks.
-func checkIfConfigOverrideIncludesProviderBlock(newBody hcl.Body) tfdiags.Diagnostics {
+func checkIfConfigOverrideIncludesProviderBlock(newBody hcl.Body, filename string) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	var s hcl.BodySchema
 	s.Blocks = append(s.Blocks, hcl.BlockHeaderSchema{
@@ -819,11 +819,16 @@ func checkIfConfigOverrideIncludesProviderBlock(newBody hcl.Body) tfdiags.Diagno
 	bc, _, _ := newBody.PartialContent(&s)
 	for _, b := range bc.Blocks {
 		if b.Type == "provider" {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Cannot partially override provider configuration in a state store block.",
-				"The configuration arguments supplied by the override file attempts to override provider configuration, which is not allowed when using a state store.",
-			))
+			diags = diags.Append(
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Cannot partially override provider configuration in a state store block.",
+					Detail:   "The configuration arguments supplied by the override file attempts to override provider configuration, which is not allowed when using a state store.",
+					Subject: &hcl.Range{
+						Filename: filename,
+					},
+				},
+			)
 			break
 		}
 	}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4772,7 +4772,7 @@ func TestInit_stateStore_newWorkingDir_partialConfiguration(t *testing.T) {
 
 		// Create file with partial configuration
 		partialConfigPath := filepath.Join(td, "overrides.test_store.tfbackend")
-		cfg := `provider {
+		cfg := `provider "test" {
   value = "OVERRIDDEN"
 }`
 		if err := os.WriteFile(partialConfigPath, []byte(cfg), 0644); err != nil {
@@ -4789,8 +4789,17 @@ func TestInit_stateStore_newWorkingDir_partialConfiguration(t *testing.T) {
 			t.Fatalf("expected code 1 exit code, got %d, output: \n%s", code, testOutput.All())
 		}
 
-		if !strings.Contains(testOutput.Stderr(), "Error: Unsupported block type") {
-			t.Fatalf("expected error output to report the config argument was invalid, got:\n %s", testOutput.All())
+		expectedErrorMsgs := []string{
+			// We've detected that the user is attempting to override the provider block in a state_store block.
+			"Error: Cannot partially override provider configuration in a state store block.",
+
+			// More generic error due to the state store's schema not including the provider block in it's schema.
+			"Error: Unsupported block type",
+		}
+		for _, expected := range expectedErrorMsgs {
+			if !strings.Contains(testOutput.Stderr(), expected) {
+				t.Fatalf("expected error output to include %q, got:\n %s", expected, testOutput.All())
+			}
 		}
 	})
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -949,7 +949,7 @@ func TestInit_backendConfigFile(t *testing.T) {
 		}
 		flagConfigExtra := arguments.NewFlagNameValueSlice("-backend-config")
 		flagConfigExtra.Set("input.config")
-		_, diags := c.backendConfigOverrideBody(flagConfigExtra, schema)
+		_, diags := c.backendConfigOverrideBody(flagConfigExtra, schema, Backend)
 		if len(diags) != 0 {
 			t.Errorf("expected no diags, got: %s", diags.Err())
 		}
@@ -4733,7 +4733,7 @@ func TestInit_stateStore_newWorkingDir_partialConfiguration(t *testing.T) {
 			t.Fatalf("expected code 1 exit code, got %d, output: \n%s", code, testOutput.All())
 		}
 
-		if !strings.Contains(testOutput.Stderr(), "Invalid backend configuration argument") {
+		if !strings.Contains(testOutput.Stderr(), "Invalid state store configuration argument") {
 			t.Fatalf("expected error output to report the config argument was invalid, got:\n %s", testOutput.All())
 		}
 	})

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -495,7 +495,7 @@ func (m *Meta) getProviderSupplyModeForStateStore(config *configs.Module) getpro
 // context in the CLI where only strings can be provided, such as on the
 // command line or in an environment variable, and returns the resulting
 // value.
-func configValueFromCLI(synthFilename, rawValue string, wantType cty.Type) (cty.Value, tfdiags.Diagnostics) {
+func configValueFromCLI(synthFilename, rawValue string, wantType cty.Type, stateStorageMode string) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	switch {
@@ -507,8 +507,8 @@ func configValueFromCLI(synthFilename, rawValue string, wantType cty.Type) (cty.
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
-				"Invalid backend configuration value",
-				fmt.Sprintf("Invalid backend configuration argument %s: %s", synthFilename, err),
+				fmt.Sprintf("Invalid %s configuration value", stateStorageMode),
+				fmt.Sprintf("Invalid %s configuration argument %s: %s", stateStorageMode, synthFilename, err),
 			))
 			val = cty.DynamicVal // just so we return something valid-ish
 		}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/pull/39027

This PR updates error messages raised by partial configuration of backends/state stores:
1. Diagnostics now can refer to either "backend configuration" or "state store configuration" when appropriate.
2. Terraform raises a more explicit error when it detects that a user is trying to override a provider block via an override file.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
