### PR TITLE
PSS: Fix provider schema caching issue so `state migrate` can handle two versions of the same provider with schema differences.

### DIFF
--- a/internal/command/e2etest/pluggable_state_store_test.go
+++ b/internal/command/e2etest/pluggable_state_store_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/command"
+	"github.com/hashicorp/terraform/internal/command/clistate"
 	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/e2e"
 	"github.com/hashicorp/terraform/internal/getproviders"
@@ -409,6 +411,158 @@ func TestPrimary_stateStore_stateMigrateCmd_upgrade(t *testing.T) {
 	givenVersion := pLock.Version()
 	if expectedVersion.String() != givenVersion.String() {
 		t.Fatalf("mismatching version, expected %s, given %s", expectedVersion, givenVersion)
+	}
+}
+
+// Test using `terraform state migrate` subcommand when upgrade changes the provider's schema.
+func TestPrimary_stateStore_stateMigrateCmd_upgradeWithSchemaChange(t *testing.T) {
+	t.Parallel()
+	if !canRunGoBuild {
+		// We're running in a separate-build-then-run context, so we can't
+		// currently execute this test which depends on being able to build
+		// new executable at runtime.
+		//
+		// (See the comment on canRunGoBuild's declaration for more information.)
+		t.Skip("can't run without building a new provider executable")
+	}
+
+	fixturePath := filepath.Join("testdata", "state-migrate-upgrade-2")
+
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
+
+	// Load old state for comparison
+	oldStatePath := filepath.Join(tf.WorkDir(), "v1.tfstate.d", "default", "terraform.tfstate")
+	oldStateFile, err := os.Open(oldStatePath)
+	t.Cleanup(func() { oldStateFile.Close() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldState, err := statefile.Read(oldStateFile)
+	oldStateFile.Close()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// setup FS mirror
+	tmpDir := t.TempDir()
+	mirrorPath := filepath.Join(tmpDir, "mirror")
+	cliCfgFilePath := filepath.Join(tmpDir, "test.tfrc")
+	cfgBody := fmt.Sprintf(`provider_installation {
+  filesystem_mirror {
+    path    = %q
+    include = ["registry.terraform.io/hashicorp/simple6"]
+  }
+  direct {
+    exclude = ["registry.terraform.io/hashicorp/simple6"]
+  }
+}
+`, mirrorPath)
+	os.WriteFile(cliCfgFilePath, []byte(cfgBody), 0o700)
+	tf.AddEnv("TF_CLI_CONFIG_FILE=" + cliCfgFilePath)
+
+	// In order to test integration with PSS we need two provider plugins implementing a state store
+	// which we can tell apart to be able to verify successful upgrade between them.
+	//
+	// To do this we'll change the name of an attribute in the state store implementation's schema at
+	// build time.
+	platform := getproviders.CurrentPlatform.String()
+	// Build v1.0.0 plugin
+	simpleProviderv1 := filepath.Join(t.TempDir(), "terraform-provider-simple6")
+	simpleProviderv1Exe := e2e.GoBuild("github.com/hashicorp/terraform/internal/provider-simple-v6/main",
+		simpleProviderv1, "-ldflags", "-X 'github.com/hashicorp/terraform/internal/provider-simple-v6.AttributeName=attr_v1'")
+	providerv1MirrorPath := filepath.Join(mirrorPath, "registry.terraform.io", "hashicorp", "simple6", "1.0.0")
+	if err := os.MkdirAll(filepath.Join(providerv1MirrorPath, platform), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(simpleProviderv1Exe, filepath.Join(providerv1MirrorPath, platform, "terraform-provider-simple6")); err != nil {
+		t.Fatal(err)
+	}
+	// Build v2.0.0 plugin
+	simpleProviderv2 := filepath.Join(t.TempDir(), "terraform-provider-simple6")
+	simpleProviderv2Exe := e2e.GoBuild("github.com/hashicorp/terraform/internal/provider-simple-v6/main",
+		simpleProviderv2, "-ldflags", "-X 'github.com/hashicorp/terraform/internal/provider-simple-v6.AttributeName=attr_v2'")
+	providerv2MirrorPath := filepath.Join(mirrorPath, "registry.terraform.io", "hashicorp", "simple6", "2.0.0")
+	if err := os.MkdirAll(filepath.Join(providerv2MirrorPath, platform), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(simpleProviderv2Exe, filepath.Join(providerv2MirrorPath, platform, "terraform-provider-simple6")); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := tf.Run("state", "migrate", "-upgrade", "-input=false", "-force-copy", "-no-color")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%q", err, stderr)
+	}
+
+	expectedMsg := []string{
+		`Installing providers...
+- Reusing version 1.0.0 of hashicorp/simple6 from the dependency lock file
+- Installing hashicorp/simple6 v1.0.0...`,
+		`Installing providers...
+- Finding hashicorp/simple6 versions matching "2.0.0"...
+- Installing hashicorp/simple6 v2.0.0...`,
+		`Migrating state from state store "simple6_fs" (hashicorp/simple6 1.0.0) to state store "simple6_fs" (hashicorp/simple6 2.0.0)...`,
+		`Finished migrating state from state store "simple6_fs" (hashicorp/simple6 1.0.0) to state store "simple6_fs" (hashicorp/simple6 2.0.0).`,
+	}
+	for _, expectedMsg := range expectedMsg {
+		if !strings.Contains(stdout, expectedMsg) {
+			t.Fatalf("expected output %q, got %q", expectedMsg, stdout)
+		}
+	}
+
+	// verify state exists in the new location
+	newStatePath := filepath.Join(tf.WorkDir(), "v2.tfstate.d", "default", "terraform.tfstate")
+	newStateFile, err := os.Open(newStatePath)
+	t.Cleanup(func() { newStateFile.Close() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Load new state for comparison
+	newState, err := statefile.Read(newStateFile)
+	newStateFile.Close()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// verify state contents
+	if diff := cmp.Diff(oldState.State.String(), newState.State.String()); diff != "" {
+		t.Fatalf("unexpected state: %s", diff)
+	}
+
+	// verify lockfile was updated
+	lockPath := filepath.Join(tf.WorkDir(), depsfile.LockFilePath)
+	updatedLocks, diags := depsfile.LoadLocksFromFile(lockPath)
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %s", diags)
+	}
+	pAddr := addrs.MustParseProviderSourceString("hashicorp/simple6")
+	pLock := updatedLocks.Provider(pAddr)
+
+	expectedVersion := getproviders.MustParseVersion("2.0.0")
+	givenVersion := pLock.Version()
+	if expectedVersion.String() != givenVersion.String() {
+		t.Fatalf("mismatching version, expected %s, given %s", expectedVersion, givenVersion)
+	}
+
+	// Assert backend state file has the expected description of the state store.
+	statePath := filepath.Join(tf.WorkDir(), ".terraform", command.DefaultStateFilename)
+	sMgr := &clistate.LocalState{Path: statePath}
+	if err := sMgr.RefreshState(); err != nil {
+		t.Fatal("Failed to load state:", err)
+	}
+	s := sMgr.State()
+	if s == nil || s.StateStore == nil {
+		t.Fatal("expected backend state file to be created and include state store details, but it was missing.")
+	}
+	if s.StateStore.Provider.Version.String() != "2.0.0" {
+		t.Fatalf("expected state store provider version to be '2.0.0', got '%s'", s.StateStore.Provider.Version.String())
+	}
+	cfg, err := s.StateStore.ConfigRaw.MarshalJSON()
+	if err != nil {
+		t.Fatalf("failed to marshal state store config: %s", err)
+	}
+	if !strings.Contains(string(cfg), "attr_v2") {
+		t.Fatalf("expected state store config to contain 'attr_v2', got '%s'", string(cfg))
 	}
 }
 

--- a/internal/command/e2etest/pluggable_state_store_test.go
+++ b/internal/command/e2etest/pluggable_state_store_test.go
@@ -469,7 +469,7 @@ func TestPrimary_stateStore_stateMigrateCmd_upgradeWithSchemaChange(t *testing.T
 	// Build v1.0.0 plugin
 	simpleProviderv1 := filepath.Join(t.TempDir(), "terraform-provider-simple6")
 	simpleProviderv1Exe := e2e.GoBuild("github.com/hashicorp/terraform/internal/provider-simple-v6/main",
-		simpleProviderv1, "-ldflags", "-X 'github.com/hashicorp/terraform/internal/provider-simple-v6.AttributeName=attr_v1'")
+		simpleProviderv1, "-ldflags", "-X 'github.com/hashicorp/terraform/internal/provider-simple-v6.attributeName=attr_v1'")
 	providerv1MirrorPath := filepath.Join(mirrorPath, "registry.terraform.io", "hashicorp", "simple6", "1.0.0")
 	if err := os.MkdirAll(filepath.Join(providerv1MirrorPath, platform), os.ModePerm); err != nil {
 		t.Fatal(err)
@@ -480,7 +480,7 @@ func TestPrimary_stateStore_stateMigrateCmd_upgradeWithSchemaChange(t *testing.T
 	// Build v2.0.0 plugin
 	simpleProviderv2 := filepath.Join(t.TempDir(), "terraform-provider-simple6")
 	simpleProviderv2Exe := e2e.GoBuild("github.com/hashicorp/terraform/internal/provider-simple-v6/main",
-		simpleProviderv2, "-ldflags", "-X 'github.com/hashicorp/terraform/internal/provider-simple-v6.AttributeName=attr_v2'")
+		simpleProviderv2, "-ldflags", "-X 'github.com/hashicorp/terraform/internal/provider-simple-v6.attributeName=attr_v2'")
 	providerv2MirrorPath := filepath.Join(mirrorPath, "registry.terraform.io", "hashicorp", "simple6", "2.0.0")
 	if err := os.MkdirAll(filepath.Join(providerv2MirrorPath, platform), os.ModePerm); err != nil {
 		t.Fatal(err)

--- a/internal/command/e2etest/providers_schema_test.go
+++ b/internal/command/e2etest/providers_schema_test.go
@@ -275,10 +275,19 @@ func TestProvidersSchema(t *testing.T) {
                     "version":0,
                     "block": {
                         "attributes": {
+                            "default": {
+                                "type":"string",
+                                "description":"A non-functional attribute whose name can be changed at build time to enable E2E tests using different provider versions, shown by changing schemas. The default attribute name is 'default'.",
+                                "description_kind":"plain",
+                                "optional":true
+                            },
                             "workspace_dir": {
                                 "type":"string",
-                                "description":"The directory where state files will be created. When unset the value will default to terraform.tfstate.d","description_kind":"plain","optional":true}
-                            },
+                                "description":"The directory where state files will be created. When unset the value will default to terraform.tfstate.d",
+                                "description_kind":"plain",
+                                "optional":true
+                            }
+                        },
                         "description_kind":"plain"
                     }
                 },

--- a/internal/command/e2etest/testdata/state-migrate-upgrade-2/.terraform.lock.hcl
+++ b/internal/command/e2etest/testdata/state-migrate-upgrade-2/.terraform.lock.hcl
@@ -1,0 +1,6 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/simple6" {
+  version = "1.0.0"
+}

--- a/internal/command/e2etest/testdata/state-migrate-upgrade-2/upgrade-from.tfmigrate.hcl
+++ b/internal/command/e2etest/testdata/state-migrate-upgrade-2/upgrade-from.tfmigrate.hcl
@@ -1,0 +1,16 @@
+state_store_provider {
+  simple6 = {
+    source  = "registry.terraform.io/hashicorp/simple6"
+    version = "1.0.0"
+  }
+}
+
+from {
+  state_store "simple6_fs" {
+    provider "simple6" {}
+
+    workspace_dir = "v1.tfstate.d"
+    attr_v1 = "foobar" # Attribute name set as 'attr_v1' during build
+  }
+}
+

--- a/internal/command/e2etest/testdata/state-migrate-upgrade-2/upgrade-to.tf
+++ b/internal/command/e2etest/testdata/state-migrate-upgrade-2/upgrade-to.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    simple6 = {
+      source  = "registry.terraform.io/hashicorp/simple6"
+      version = "2.0.0"
+    }
+  }
+
+  state_store "simple6_fs" {
+    provider "simple6" {}
+
+    workspace_dir = "v2.tfstate.d"
+    attr_v2       = "foobar" # Attribute name set as 'attr_v2' during build
+  }
+}
+
+variable "name" {
+  default = "world"
+}
+
+resource "terraform_data" "my-data" {
+  input = "hello ${var.name}"
+}

--- a/internal/command/e2etest/testdata/state-migrate-upgrade-2/v1.tfstate.d/default/terraform.tfstate
+++ b/internal/command/e2etest/testdata/state-migrate-upgrade-2/v1.tfstate.d/default/terraform.tfstate
@@ -1,0 +1,40 @@
+{
+    "version": 4,
+    "terraform_version": "1.16.0",
+    "serial": 1,
+    "lineage": "9e13d881-e480-7a63-d47a-b4f5224e6743",
+    "outputs": {
+        "greeting": {
+            "value": "hello world",
+            "type": "string"
+        }
+    },
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "terraform_data",
+            "name": "my-data",
+            "provider": "provider[\"terraform.io/builtin/terraform\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "id": "d71fb368-2ba1-fb4c-5bd9-6a2b7f05d60c",
+                        "input": {
+                            "value": "hello world",
+                            "type": "string"
+                        },
+                        "output": {
+                            "value": "hello world",
+                            "type": "string"
+                        },
+                        "triggers_replace": null
+                    },
+                    "sensitive_attributes": [],
+                    "identity_schema_version": 0
+                }
+            ]
+        }
+    ],
+    "check_results": null
+}

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
 	"github.com/hashicorp/terraform/internal/providercache"
+	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -461,6 +462,12 @@ func (c *StateMigrateCommand) initializeDestinationStateStore(ctx context.Contex
 	diags = diags.Append(trustDiags)
 	if trustDiags.HasErrors() {
 		return nil, cty.NilVal, cty.NilVal, nil, diags
+	}
+
+	if upgrade {
+		// When upgrading the provider, clear the schema cache to ensure that any new schema changes are picked up.
+		// The source state store's already been initialised by the time we reach this point, which means the older provider version's schema is cached.
+		providers.SchemaCache.Clear()
 	}
 
 	dstB, stateStoreConfig, providerConfig, dstDiags := c.Meta.stateStoreInitFromConfig(rootMod.StateStore, destinationLock)

--- a/internal/provider-simple-v6/state_store.go
+++ b/internal/provider-simple-v6/state_store.go
@@ -1,0 +1,9 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package simple
+
+// AttributeName can be overwritten using -ldflags at build time.
+// This enables E2E tests using this provider implementation to build different
+// versions of the same provider with different schemas.
+var AttributeName string = "default"

--- a/internal/provider-simple-v6/state_store.go
+++ b/internal/provider-simple-v6/state_store.go
@@ -3,7 +3,7 @@
 
 package simple
 
-// AttributeName can be overwritten using -ldflags at build time.
+// attributeName can be overwritten using -ldflags at build time.
 // This enables E2E tests using this provider implementation to build different
 // versions of the same provider with different schemas.
-var AttributeName string = "default"
+var attributeName string = "default"

--- a/internal/provider-simple-v6/state_store_fs.go
+++ b/internal/provider-simple-v6/state_store_fs.go
@@ -22,8 +22,10 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-const fsStoreName = "simple6_fs"
-const defaultStatesDir = "terraform.tfstate.d"
+const (
+	fsStoreName      = "simple6_fs"
+	defaultStatesDir = "terraform.tfstate.d"
+)
 
 // FsStore allows storing state in the local filesystem.
 //
@@ -49,6 +51,14 @@ func stateStoreFsGetSchema() providers.Schema {
 					Type:        cty.String,
 					Optional:    true,
 					Description: "The directory where state files will be created. When unset the value will default to terraform.tfstate.d",
+				},
+
+				// This attribute's name can be overridden at build time using -ldflags.
+				// This is a way to enable E2E tests using different versions of the provider with different schemas.
+				AttributeName: {
+					Type:        cty.String,
+					Optional:    true,
+					Description: "A non-functional attribute whose name can be changed at build time to enable E2E tests using different provider versions, shown by changing schemas. The default attribute name is 'default'.",
 				},
 			},
 		},

--- a/internal/provider-simple-v6/state_store_fs.go
+++ b/internal/provider-simple-v6/state_store_fs.go
@@ -55,7 +55,7 @@ func stateStoreFsGetSchema() providers.Schema {
 
 				// This attribute's name can be overridden at build time using -ldflags.
 				// This is a way to enable E2E tests using different versions of the provider with different schemas.
-				AttributeName: {
+				attributeName: {
 					Type:        cty.String,
 					Optional:    true,
 					Description: "A non-functional attribute whose name can be changed at build time to enable E2E tests using different provider versions, shown by changing schemas. The default attribute name is 'default'.",

--- a/internal/providers/schema_cache.go
+++ b/internal/providers/schema_cache.go
@@ -39,3 +39,16 @@ func (c *schemaCache) Get(p addrs.Provider) (ProviderSchema, bool) {
 	s, ok := c.m[p]
 	return s, ok
 }
+
+// Clear empties the current schema cache. This is useful in
+// rare cases where we want to avoid what's in the cache.
+//
+// The original motivation for this method was the `state migrate`
+// command which may use two versions of the same provider at once.
+// Caching forces the first schema to be reused for the second version.
+func (c *schemaCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.m = make(map[addrs.Provider]ProviderSchema)
+}


### PR DESCRIPTION
# The problem to solve

Terraform has a very hard, baked-in assumption that only a single version of a provider will be used at once. Introducing state migrations while using pluggable state storage breaks that assumption. Users will need to perform state migration when upgrading the provider used for PSS, and that process will require using the old and new version of the provider at once.

A current problem when implementing that state migration feature is that Terraform caches the response to the GetProviderSchema RPC. That cache is a map of provider address to schema (`map[addrs.Provider]ProviderSchema`). Therefore when the `state migrate` command initialises the state store using the older provider version the older version's schema is cached. When the state store using the newer provider version is initialised Terraform will use the schema from the cache, and this may be incorrect and mask schema changes between the two versions.

We need to be able to disable or bypass the cache in this specific scenario.

# This PR

The first commit adds an E2E test where a `state migrate` command upgrades the provider used for state storage. That upgrade includes a schema change (renaming attribute attr_v1 to attr_v2). The test fails because Terraform caches the schema for v1.0.0 of the provider and then erroneously believes that v2.0.0 has the same schema and therefore raises this schema error:

>--- FAIL: TestPrimary_stateStore_stateMigrateCmd_upgradeWithSchemaChange (9.66s)
    pluggable_state_store_test.go:494: unexpected error: exit status 1
        stderr:
        "\nError: Unsupported argument\n\n  on upgrade-to.tf line 13, in terraform:\n  13:     attr_v2       = \"foobar\" # Attribute name set as 'attr_v2' during build\n\nAn argument named \"attr_v2\" is not expected here. Did you mean \"attr_v1\"?\n"
FAIL

The second commit introduces a method of clearing the provider schema cache and lets the `state migrate` clear the cache before initialising the provider used for the migration destination. This only happens during an upgrade scenario as that's the only time the cache causes an issue; the cache will contain the source provider's schema before the destination provider is initialised and if we don't clear the cache the destination provider will be assumed to have the same schema as the source, because the cache is unable to handle multiple versions of a given provider address.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
