### PR TITLE
Remove `NewModuleInstaller` calls without `initializer`

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260904-115914.yaml
+++ b/.changes/v1.16/BUG FIXES-20260904-115914.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix panic in module installation when encoutering invalid module calls
+time: 2026-09-04T11:59:14.121905+02:00
+custom:
+    Issue: "39129"

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -142,19 +142,8 @@ func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir 
 	}
 	walker := i.moduleInstallWalker(ctx, manifest, upgrade, fetcher, hooks...)
 
-	var cfg *configs.Config
-	var instDiags tfdiags.Diagnostics
-	if i.initializer != nil {
-		cfg, instDiags = i.initializer(rootMod, walker)
-		diags = diags.Append(instDiags)
-	} else {
-		cfg, instDiags = i.installDescendantModules(rootMod, walker, installErrsOnly)
-		diags = diags.Append(instDiags)
-
-		finalDiags := configs.LegacyFinalizeConfig(cfg, walker, configs.MockDataLoaderFunc(i.loader.LoadExternalMockData))
-		diags = diags.Append(finalDiags)
-	}
-
+	cfg, instDiags := i.initializer(rootMod, walker)
+	diags = diags.Append(instDiags)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -36,6 +36,12 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func testModuleInstallerInitializer(loader *configload.Loader) Initializer {
+	return func(rootMod *configs.Module, walker configs.ModuleWalker) (*configs.Config, tfdiags.Diagnostics) {
+		return terraform.BuildConfigWithGraph(rootMod, walker, nil, configs.MockDataLoaderFunc(loader.LoadExternalMockData))
+	}
+}
+
 func TestModuleInstaller(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/local-modules")
 	dir, done := tempChdir(t, fixtureDir)
@@ -46,7 +52,7 @@ func TestModuleInstaller(t *testing.T) {
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
@@ -128,7 +134,7 @@ func TestModuleInstaller_error(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 
 	if !diags.HasErrors() {
@@ -149,7 +155,7 @@ func TestModuleInstaller_emptyModuleName(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 
 	if !diags.HasErrors() {
@@ -170,7 +176,7 @@ func TestModuleInstaller_invalidModuleName(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
 
 	if !diags.HasErrors() {
@@ -208,7 +214,7 @@ func TestModuleInstaller_packageEscapeError(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 
 	if !diags.HasErrors() {
@@ -246,7 +252,7 @@ func TestModuleInstaller_explicitPackageBoundary(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 
 	if diags.HasErrors() {
@@ -269,7 +275,7 @@ func TestModuleInstaller_ExactMatchPrerelease(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	cfg, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 
 	if diags.HasErrors() {
@@ -296,7 +302,7 @@ func TestModuleInstaller_PartialMatchPrerelease(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	cfg, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, hooks)
 
 	if diags.HasErrors() {
@@ -319,7 +325,7 @@ func TestModuleInstaller_invalid_version_constraint_error(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 
 	if !diags.HasErrors() {
@@ -345,7 +351,7 @@ func TestModuleInstaller_invalidVersionConstraintGetter(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 
 	if !diags.HasErrors() {
@@ -371,7 +377,7 @@ func TestModuleInstaller_invalidVersionConstraintLocal(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 
 	if !diags.HasErrors() {
@@ -397,7 +403,7 @@ func TestModuleInstaller_symlink(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
@@ -491,7 +497,7 @@ func TestLoaderInstallModules_invalidRegistry(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
 
 	if !diags.HasErrors() {
@@ -530,7 +536,7 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
@@ -734,7 +740,7 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
@@ -884,7 +890,7 @@ func TestModuleInstaller_fromTests(t *testing.T) {
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
@@ -898,10 +904,6 @@ func TestModuleInstaller_fromTests(t *testing.T) {
 			ModuleAddr:  "test.tests.main.setup",
 			PackageAddr: "",
 			LocalPath:   "setup",
-		},
-		{
-			Name:       "ModuleSourceResolved",
-			ModuleAddr: "test.tests.main.setup",
 		},
 	}
 
@@ -957,7 +959,7 @@ func TestLoadInstallModules_registryFromTest(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), testModuleInstallerInitializer(loader))
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
 	tfdiags.AssertNoDiagnostics(t, diags)
 

--- a/internal/lang/globalref/testing_test.go
+++ b/internal/lang/globalref/testing_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/registry"
 	"github.com/hashicorp/terraform/internal/terraform"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // testAnalyzer creates an analyzer for testing by loading a configuration
@@ -29,7 +30,10 @@ func testAnalyzer(t *testing.T, fixtureName string) *globalref.Analyzer {
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
 
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
+	initializer := func(rootMod *configs.Module, walker configs.ModuleWalker) (*configs.Config, tfdiags.Diagnostics) {
+		return terraform.BuildConfigWithGraph(rootMod, walker, nil, configs.MockDataLoaderFunc(loader.LoadExternalMockData))
+	}
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), initializer)
 	_, instDiags := inst.InstallModules(context.Background(), configDir, "tests", true, false)
 	if instDiags.HasErrors() {
 		t.Fatalf("unexpected module installation errors: %s", instDiags.Err().Error())

--- a/internal/moduletest/graph/eval_context_test.go
+++ b/internal/moduletest/graph/eval_context_test.go
@@ -835,7 +835,10 @@ func testModuleInline(t *testing.T, sources map[string]string) *configs.Config {
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
+	initializer := func(rootMod *configs.Module, walker configs.ModuleWalker) (*configs.Config, tfdiags.Diagnostics) {
+		return terraform.BuildConfigWithGraph(rootMod, walker, nil, configs.MockDataLoaderFunc(loader.LoadExternalMockData))
+	}
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), initializer)
 	_, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false)
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())

--- a/internal/refactoring/testing_test.go
+++ b/internal/refactoring/testing_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/refactoring"
 	"github.com/hashicorp/terraform/internal/registry"
 	"github.com/hashicorp/terraform/internal/terraform"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // loadRefactoringFixture reads a configuration from the given directory and
@@ -27,7 +28,10 @@ func loadRefactoringFixture(t *testing.T, dir string) (*configs.Config, instance
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
 
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
+	initializer := func(rootMod *configs.Module, walker configs.ModuleWalker) (*configs.Config, tfdiags.Diagnostics) {
+		return terraform.BuildConfigWithGraph(rootMod, walker, nil, configs.MockDataLoaderFunc(loader.LoadExternalMockData))
+	}
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), initializer)
 	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false)
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())

--- a/internal/terraform/node_module_install.go
+++ b/internal/terraform/node_module_install.go
@@ -126,7 +126,10 @@ func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdia
 
 	modCfg, v, modDiags := n.Walker.LoadModule(req)
 	diags = diags.Append(modDiags)
-	if diags.HasErrors() {
+	if diags.HasErrors() || modCfg == nil {
+		// nil can be returned if the source address was invalid and so
+		// nothing could be loaded whatsoever. LoadModule should've
+		// returned at least one error diagnostic in that case.
 		return diags
 	}
 

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -65,10 +65,13 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 	// We need to be able to exercise experimental features in our integration tests.
 	loader.AllowLanguageExperiments(true)
 
+	initializer := func(rootMod *configs.Module, walker configs.ModuleWalker) (*configs.Config, tfdiags.Diagnostics) {
+		return BuildConfigWithGraph(rootMod, walker, nil, configs.MockDataLoaderFunc(loader.LoadExternalMockData))
+	}
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), initializer)
 	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false)
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
@@ -161,10 +164,13 @@ func testModuleInlineWithVars(t testing.TB, sources map[string]string, vars Inpu
 	// We need to be able to exercise experimental features in our integration tests.
 	loader.AllowLanguageExperiments(true)
 
+	initializer := func(rootMod *configs.Module, walker configs.ModuleWalker) (*configs.Config, tfdiags.Diagnostics) {
+		return BuildConfigWithGraph(rootMod, walker, vars, configs.MockDataLoaderFunc(loader.LoadExternalMockData))
+	}
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), initializer)
 	_, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false)
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())

--- a/internal/terraform/testing/config.go
+++ b/internal/terraform/testing/config.go
@@ -41,7 +41,10 @@ func LoadConfigForTests(t *testing.T, rootDir string, testsDir string) (*configs
 	var diags tfdiags.Diagnostics
 
 	loader, cleanup := configload.NewLoaderForTests(t)
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
+	initializer := func(rootMod *configs.Module, walker configs.ModuleWalker) (*configs.Config, tfdiags.Diagnostics) {
+		return terraform.BuildConfigWithGraph(rootMod, walker, nil, configs.MockDataLoaderFunc(loader.LoadExternalMockData))
+	}
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), initializer)
 
 	_, moreDiags := inst.InstallModules(context.Background(), rootDir, testsDir, true, false)
 	diags = diags.Append(moreDiags)


### PR DESCRIPTION
This the first PR in my quest of getting rid of `BuildConfig` in `internal/configs`. This must be done as part of the dynamic provider sources work, but can happen in separate PRs. It also fixes a panic along the way and can be backported to 1.16

Calling the installer without an initializer led to the legacy behavior of calling BuildConfig via installDescendantModules. We want to remove BuildConfig in the future, so we need to get rid of any calls.

Furthermore this discovered a crash in Terraform when dealing with modules with an empty name. Now, that the test case is using the init-graph, the crash was surfaced.

Fixes https://github.com/hashicorp/terraform/issues/38580

## UX
**Before**
```
❯ ~/Downloads/terraform_1.16.1_darwin_arm64/terraform init
Initializing the backend...

Initializing modules...

!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

Terraform crashed! This is always indicative of a bug within Terraform.
Please report the crash with Terraform[1] so that we can fix this.

When reporting bugs, please include your terraform version, the stack trace
shown below, and any additional information which may help replicate the issue.

[1]: https://github.com/hashicorp/terraform/issues

!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

panic: runtime error: invalid memory address or nil pointer dereference
goroutine 27 [running]:
runtime/debug.Stack()
        runtime/debug/stack.go:26 +0x64
github.com/hashicorp/terraform/internal/logging.PanicHandler()
        github.com/hashicorp/terraform/internal/logging/panic.go:84 +0x164
panic({0x107d9b600?, 0x1088c7ac0?})
        runtime/panic.go:860 +0x12c
github.com/hashicorp/terraform/internal/terraform.(*Graph).walk.func1.1()
        github.com/hashicorp/terraform/internal/terraform/graph.go:59 +0x2f4
panic({0x107d9b600?, 0x1088c7ac0?})
        runtime/panic.go:860 +0x12c
github.com/hashicorp/terraform/internal/terraform.(*nodeInstallModule).validateModuleConfig(0x0?, 0x0, {0x51cb61b081e0, 0x1, 0x1})
        github.com/hashicorp/terraform/internal/terraform/node_module_install.go:167 +0x30
github.com/hashicorp/terraform/internal/terraform.(*nodeInstallModule).Execute(0x51cb61bd8120, {0x1086cf5a8, 0x51cb61b16140}, 0x70?)
        github.com/hashicorp/terraform/internal/terraform/node_module_install.go:147 +0xb9c
github.com/hashicorp/terraform/internal/terraform.(*ContextGraphWalker).Execute(0x51cb61c18160, {0x1086cf5a8, 0x51cb61b16140}, {0x131b94070, 0x51cb61bd8120})
        github.com/hashicorp/terraform/internal/terraform/graph_walk_context.go:173 +0xa0
github.com/hashicorp/terraform/internal/terraform.(*Graph).walk.func1({0x1081a7200, 0x51cb61bd8120})
        github.com/hashicorp/terraform/internal/terraform/graph.go:143 +0x56c
github.com/hashicorp/terraform/internal/dag.(*Walker).walkVertex(0x51cb61bd81e0, {0x1081a7200, 0x51cb61bd8120}, 0x51cb61b25140)
        github.com/hashicorp/terraform/internal/dag/walk.go:412 +0x300
created by github.com/hashicorp/terraform/internal/dag.(*Walker).Update in goroutine 1
        github.com/hashicorp/terraform/internal/dag/walk.go:331 +0xb98
```

**After**
```
❯ terraform init
Initializing the backend...

Initializing modules...
╷
│ Error: Invalid module instance name
│
│   on main.tf line 1, in module "":
│    1: module "" {
│
│ A name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes.
╵
```

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
