### PR TITLE
Use graph-based approach in `init --from-module`

### DIFF
--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -341,8 +341,13 @@ func (m *Meta) initDirFromModule(ctx context.Context, targetDir string, addr str
 		return true, diags
 	}
 
+	initializer := func(rootMod *configs.Module, walker configs.ModuleWalker) (*configs.Config, tfdiags.Diagnostics) {
+		// We can't pass any variables here, because the fake root module used in the
+		// from-module initialization process doesn't have any variables defined.
+		return terraform.BuildConfigWithGraph(rootMod, walker, nil, configs.MockDataLoaderFunc(loader.LoadExternalMockData))
+	}
 	targetDir = m.normalizePath(targetDir)
-	moreDiags := initwd.DirFromModule(ctx, loader, targetDir, m.modulesDir(), addr, m.registryClient(), hooks)
+	moreDiags := initwd.DirFromModule(ctx, loader, targetDir, m.modulesDir(), addr, m.registryClient(), initializer, hooks)
 	diags = diags.Append(moreDiags)
 	if ctx.Err() == context.Canceled {
 		m.showDiagnostics(diags)

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -48,7 +48,7 @@ const initFromModuleRootKeyPrefix = initFromModuleRootCallName + "."
 // references using ../ from that module to be unresolvable. Error diagnostics
 // are produced in that case, to prompt the user to rewrite the source strings
 // to be absolute references to the original remote module.
-func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modulesDir, sourceAddrStr string, reg *registry.Client, hooks ...ModuleInstallHook) tfdiags.Diagnostics {
+func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modulesDir, sourceAddrStr string, reg *registry.Client, initializer Initializer, hooks ...ModuleInstallHook) tfdiags.Diagnostics {
 
 	var diags tfdiags.Diagnostics
 
@@ -94,7 +94,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 	}
 
 	instDir := filepath.Join(rootDir, ".terraform/init-from-module")
-	inst := NewModuleInstaller(instDir, loader, reg, nil)
+	inst := NewModuleInstaller(instDir, loader, reg, initializer)
 	log.Printf("[DEBUG] installing modules in %s to initialize working directory from %q", instDir, sourceAddrStr)
 	os.RemoveAll(instDir) // if this fails then we'll fail on MkdirAll below too
 	err := os.MkdirAll(instDir, os.ModePerm)
@@ -139,6 +139,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 			initFromModuleRootCallName: {
 				Name:       initFromModuleRootCallName,
 				SourceExpr: hcl.StaticExpr(cty.StringVal(sourceAddrStr), fakeRange),
+				Config:     hcl.EmptyBody(),
 				DeclRange:  fakeRange,
 			},
 		},
@@ -159,11 +160,37 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 	}
 	fetcher := getmodules.NewPackageFetcher()
 
+	// When attempting to initialize the current directory with a module
+	// source, some use cases may want to ignore configuration errors from the
+	// building of the entire configuration structure, but we still need to
+	// capture installation errors. Because the actual module installation
+	// happens in the ModuleWalkFunc callback while building the config, we
+	// need to create a closure to capture the installation diagnostics
+	// separately.
 	walker := inst.moduleInstallWalker(ctx, instManifest, true, fetcher, wrapHooks)
-	_, cDiags := inst.installDescendantModules(fakeRootModule, walker, true)
-	if cDiags.HasErrors() {
-		return diags.Append(cDiags)
+	var installDiags hcl.Diagnostics
+	initWalker := configs.ModuleWalkerFunc(func(req *configs.ModuleRequest) (*configs.Module, *version.Version, hcl.Diagnostics) {
+		mod, version, moreDiags := walker.LoadModule(req)
+		installDiags = installDiags.Extend(moreDiags)
+		return mod, version, moreDiags
+	})
+	_, initDiags := initializer(fakeRootModule, initWalker)
+	diags = diags.Append(initDiags)
+	if installDiags.HasErrors() {
+		// We can't continue if there was an error during installation, but
+		// return all diagnostics in case there happens to be anything else
+		// useful when debugging the problem. Any instDiags will be included in
+		// diags already.
+		return diags
 	}
+
+	// If there are any errors here, they must be only from building the
+	// config structures. We don't want to block initialization at this
+	// point, so convert these into warnings. Any actual errors in the
+	// configuration will be raised as soon as the config is loaded again.
+	// We continue below because writing the manifest is required to finish
+	// module installation.
+	diags = tfdiags.OverrideAll(diags, tfdiags.Warning, nil)
 
 	err = instManifest.WriteSnapshotToDir(instDir)
 	if err != nil {

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -45,7 +45,7 @@ func TestDirFromModule_registry(t *testing.T) {
 	reg := registry.NewClient(nil, nil)
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
-	diags := DirFromModule(context.Background(), loader, dir, modsDir, "hashicorp/module-installer-acctest/aws//examples/main", reg, hooks)
+	diags := DirFromModule(context.Background(), loader, dir, modsDir, "hashicorp/module-installer-acctest/aws//examples/main", reg, testModuleInstallerInitializer(loader), hooks)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
 	v := version.Must(version.NewVersion("0.0.2"))
@@ -169,7 +169,7 @@ func TestDirFromModule_submodules(t *testing.T) {
 
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
-	diags := DirFromModule(context.Background(), loader, dir, modInstallDir, fromModuleDir, nil, hooks)
+	diags := DirFromModule(context.Background(), loader, dir, modInstallDir, fromModuleDir, nil, testModuleInstallerInitializer(loader), hooks)
 	tfdiags.AssertNoDiagnostics(t, diags)
 	wantCalls := []testInstallHookCall{
 		{
@@ -265,7 +265,7 @@ func TestDirFromModule_submodulesWithProvider(t *testing.T) {
 
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
-	diags := DirFromModule(context.Background(), loader, dir, modInstallDir, fromModuleDir, nil, hooks)
+	diags := DirFromModule(context.Background(), loader, dir, modInstallDir, fromModuleDir, nil, testModuleInstallerInitializer(loader), hooks)
 
 	for _, d := range diags {
 		if d.Severity() != tfdiags.Warning {
@@ -317,7 +317,7 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 	sourceDir := "../local-modules"
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
-	diags := DirFromModule(context.Background(), loader, ".", modInstallDir, sourceDir, nil, hooks)
+	diags := DirFromModule(context.Background(), loader, ".", modInstallDir, sourceDir, nil, testModuleInstallerInitializer(loader), hooks)
 	tfdiags.AssertNoDiagnostics(t, diags)
 	wantCalls := []testInstallHookCall{
 		{
@@ -409,7 +409,7 @@ func TestDirFromModule_submodulesWithDynamicSources(t *testing.T) {
 
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
-	diags := DirFromModule(context.Background(), loader, dir, modInstallDir, fromModuleDir, nil, hooks)
+	diags := DirFromModule(context.Background(), loader, dir, modInstallDir, fromModuleDir, nil, testModuleInstallerInitializer(loader), hooks)
 
 	wantDiags := tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
 		Severity: hcl.DiagError,

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -322,49 +322,6 @@ func (i *ModuleInstaller) moduleInstallWalker(ctx context.Context, manifest mods
 	)
 }
 
-func (i *ModuleInstaller) installDescendantModules(rootMod *configs.Module, installWalker configs.ModuleWalker, installErrsOnly bool) (*configs.Config, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	// When attempting to initialize the current directory with a module
-	// source, some use cases may want to ignore configuration errors from the
-	// building of the entire configuration structure, but we still need to
-	// capture installation errors. Because the actual module installation
-	// happens in the ModuleWalkFunc callback while building the config, we
-	// need to create a closure to capture the installation diagnostics
-	// separately.
-	var instDiags hcl.Diagnostics
-	walker := installWalker
-	if installErrsOnly {
-		walker = configs.ModuleWalkerFunc(func(req *configs.ModuleRequest) (*configs.Module, *version.Version, hcl.Diagnostics) {
-			mod, version, diags := installWalker.LoadModule(req)
-			instDiags = instDiags.Extend(diags)
-			return mod, version, diags
-		})
-	}
-
-	cfg, cDiags := configs.BuildConfig(rootMod, walker, configs.MockDataLoaderFunc(i.loader.LoadExternalMockData))
-	diags = diags.Append(cDiags)
-	if installErrsOnly {
-		// We can't continue if there was an error during installation, but
-		// return all diagnostics in case there happens to be anything else
-		// useful when debugging the problem. Any instDiags will be included in
-		// diags already.
-		if instDiags.HasErrors() {
-			return cfg, diags
-		}
-
-		// If there are any errors here, they must be only from building the
-		// config structures. We don't want to block initialization at this
-		// point, so convert these into warnings. Any actual errors in the
-		// configuration will be raised as soon as the config is loaded again.
-		// We continue below because writing the manifest is required to finish
-		// module installation.
-		diags = tfdiags.OverrideAll(diags, tfdiags.Warning, nil)
-	}
-
-	return cfg, diags
-}
-
 func (i *ModuleInstaller) installLocalModule(ctx context.Context, req *configs.ModuleRequest, key string, manifest modsdir.Manifest, hooks ...ModuleInstallHook) (*configs.Module, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 

--- a/internal/initwd/testdata/local-module-dynamic-sources/main.tf
+++ b/internal/initwd/testdata/local-module-dynamic-sources/main.tf
@@ -5,4 +5,5 @@ module "name" {
 variable "path" {
   type    = string
   default = "child"
+  const   = true
 }


### PR DESCRIPTION
This the second PR in my quest of getting rid of `BuildConfig` in `internal/configs`. It updates parts of the `DirFromModule` installation logic to get rid of the `BuildConfig` call via `installDescendantModules`.

The updates still does not allow dynamic module sources to be used in conjunction with dynamic module sources. But this maybe can shipped as an improvement later when there is demand and we figured out a way to pass variable values.

## Related

* https://github.com/hashicorp/terraform/pull/39129

## Target Release

I think it makes sense to backport these changes, in case we need to fix a module-related bug in 1.16. Keeping the 1.16 branch closer to `main` will make this easier.

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
