### PR TITLE
more precise deferral checks

### DIFF
--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -304,16 +304,16 @@ func (d *Deferred) ShouldDeferResourceInstanceChanges(addr addrs.AbsResourceInst
 	}
 	d.mu.Unlock()
 
-	return d.DependenciesDeferred(deps)
+	return d.DependenciesDeferred(addr.Module, deps)
 }
 
-// DependenciesDeferred returns true if any of the given configuration
-// resources have had their planned actions deferred, either because they
-// themselves were deferred or because they depend on something that was
-// deferred.
-//
-// As
-func (d *Deferred) DependenciesDeferred(deps []addrs.ConfigResource) bool {
+// DependenciesDeferred returns true if any of the given configuration resources
+// have had their planned actions deferred, either because they themselves were
+// deferred or because they depend on something that was deferred. The srcMod
+// argument is used to check for the case where a dependency might be deferred
+// from a module instance outside of the src module path, which indicates that
+// there could be no data flow between the two.
+func (d *Deferred) DependenciesDeferred(srcMod addrs.ModuleInstance, deps []addrs.ConfigResource) bool {
 	if !d.deferralAllowed {
 		return false
 	}
@@ -325,45 +325,42 @@ func (d *Deferred) DependenciesDeferred(deps []addrs.ConfigResource) bool {
 		return true
 	}
 
-	// If neither of our resource-deferral-tracking collections have anything
-	// in them then we definitely don't need to defer. This special case is
-	// here primarily to minimize the amount of code from here that will run
-	// when the deferred-actions-related experiments are inactive, so we can
-	// minimize the risk of impacting non-participants.
-	// (Maybe we'll remove this check once this stuff is non-experimental.)
 	if d.resourceInstancesDeferred.Len() == 0 && d.partialExpandedResourcesDeferred.Len() == 0 {
 		return false
 	}
 
-	// For this initial implementation we're taking the shortcut of assuming
-	// that all of the configDeps are required. It would be better to do a
-	// more precise analysis that takes into account how data could possibly
-	// flow between instances of resources across different module paths,
-	// but that may have some subtlety due to dynamic data flow, so we'll
-	// need to do some more theory work to figure out what kind of analysis
-	// we'd need to do to get this to be more precise.
-	//
-	// This conservative approach is a starting point so we can focus on
-	// developing the workflow around deferred changes before making its
-	// analyses more precise. This will defer more changes than strictly
-	// necessary, but that's better than not deferring changes that should
-	// have been deferred.
-	//
-	// (FWIW, it does seem like we _should_ be able to eliminate some
-	// dynamic instances from consideration by relying on constraints such as
-	// how a multi-instance module call can't have an object in one instance
-	// depending on an object for another instance, but we'll need to make sure
-	// any additional logic here is well-reasoned to avoid violating dependency
-	// invariants.)
 	for _, configDep := range deps {
-		if d.resourceInstancesDeferred.Has(configDep) {
-			// For now we don't consider exactly which instances of that
-			// configuration block were deferred; there being at least
-			// one is enough.
-			return true
+		if defers, ok := d.resourceInstancesDeferred.GetOk(configDep); ok {
+			// fast path for module which can't have instances
+			if srcMod.IsRoot() {
+				return true
+			}
+
+			for def := range defers.Keys().Iter() {
+				if reachableDependencyPath(srcMod, def.Module) {
+					return true
+				}
+			}
 		}
-		if d.partialExpandedResourcesDeferred.Has(configDep) {
-			return true
+		if defers, ok := d.partialExpandedResourcesDeferred.GetOk(configDep); ok {
+			// fast path for module which can't have instances
+			if srcMod.IsRoot() {
+				return true
+			}
+
+			// in the case of a partially expanded resource, we can only compare
+			// the known portion of the module path
+			for def := range defers.Keys().Iter() {
+				defMod, ok := def.ModuleInstance()
+				if !ok {
+					partial, _ := def.PartialExpandedModule()
+					defMod = partial.KnownPrefix()
+				}
+
+				if reachableDependencyPath(srcMod, defMod) {
+					return true
+				}
+			}
 		}
 
 		// We don't check d.partialExpandedModulesDeferred here because
@@ -389,7 +386,7 @@ func (d *Deferred) ReportResourceExpansionDeferred(addr addrs.PartialExpandedRes
 		// null change. Note, if we don't make this check here, then we'll
 		// just crash later anyway. This way the stack trace points to the
 		// source of the problem.
-		panic("change must not be nil")
+		panic("managed resource change must not be nil")
 	}
 
 	d.mu.Lock()
@@ -441,7 +438,7 @@ func (d *Deferred) ReportResourceInstanceDeferred(addr addrs.AbsResourceInstance
 		// null change. Note, if we don't make this check here, then we'll
 		// just crash later anyway. This way the stack trace points to the
 		// source of the problem.
-		panic("managed resoursce change must not be nil")
+		panic("managed resource change must not be nil")
 	}
 
 	d.mu.Lock()
@@ -556,6 +553,36 @@ func (d *Deferred) ShouldDeferActionInvocation(ai *plans.ActionInvocationInstanc
 		}
 	}
 	return false
+}
+
+// reachableDependencyPath returns true if a resource instance within src can
+// have a functional dependency with a resource instance within dep. If the dep
+// Module path has a matching subpath of the src Module path, but the subpath
+// instance keys don't match, then there is no way a data could flow from one to
+// the other because instances cannot reference one another.
+func reachableDependencyPath(src, dep addrs.ModuleInstance) bool {
+	// We slice off the first step, which is the root module, because they will
+	// always match.
+	srcAnc := src.Ancestors()[1:]
+	depAnc := dep.Ancestors()[1:]
+
+	for i := 0; i < min(len(srcAnc), len(depAnc)); i++ {
+		// if the configured modules don't match, we can return early since we're
+		// not in the same module path.
+		if !srcAnc[i].Module().Equal(depAnc[i].Module()) {
+			return true
+		}
+
+		// We share a module ancestor, but if the ancestor instance doesn't
+		// match then we can be sure that src cannot see any data from dep.
+		if !srcAnc[i].Equal(depAnc[i]) {
+			return false
+		}
+	}
+
+	// we either originate from the same module instance, or have divergent
+	// paths which means there's a chance that data could flow from dep to src
+	return true
 }
 
 // UnexpectedProviderDeferralDiagnostic is a diagnostic that indicates that a

--- a/internal/plans/deferring/deferred_test.go
+++ b/internal/plans/deferring/deferred_test.go
@@ -382,3 +382,121 @@ func TestDeferred_partialExpandedResource(t *testing.T) {
 		}
 	})
 }
+
+func TestDeferred_resourceInstanceDeferredInSiblingModuleInstance(t *testing.T) {
+	instA0 := addrs.AbsResourceInstance{
+		Module: addrs.RootModuleInstance.Child("foo", addrs.IntKey(0)),
+		Resource: addrs.ResourceInstance{
+			Key: addrs.StringKey("0"),
+			Resource: addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test",
+				Name: "a",
+			},
+		},
+	}
+
+	// the theoretical sibling instance module.foo[1].test.a["1"] is not deferred
+
+	instB0 := addrs.AbsResourceInstance{
+		Module: addrs.RootModuleInstance.Child("foo", addrs.IntKey(0)).Child("bar", addrs.IntKey(0)),
+		Resource: addrs.ResourceInstance{
+			Resource: addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test",
+				Name: "b",
+			},
+		},
+	}
+
+	instB1 := addrs.AbsResourceInstance{
+		Module: addrs.RootModuleInstance.Child("foo", addrs.IntKey(1)).Child("bar", addrs.IntKey(0)),
+		Resource: addrs.ResourceInstance{
+			Resource: addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test",
+				Name: "b",
+			},
+		},
+	}
+
+	// dependencies are only tracked at the config resource level, but only
+	// resources in foo[0] are going to be deferred
+	bDeps := []addrs.ConfigResource{instA0.ConfigResource()}
+
+	deferred := NewDeferred(true)
+
+	// Instance A0 has its Create action deferred for some reason.
+	deferred.ReportResourceInstanceDeferred(instA0, providers.DeferredReasonResourceConfigUnknown, &plans.ResourceInstanceChange{
+		Addr: instA0,
+		Change: plans.Change{
+			Action: plans.Create,
+			After:  cty.DynamicVal,
+		},
+	})
+
+	if !deferred.ShouldDeferResourceInstanceChanges(instB0, bDeps) {
+		t.Errorf("%s was not reported as needing deferred; should be deferred", instB0)
+	}
+	if deferred.ShouldDeferResourceInstanceChanges(instB1, bDeps) {
+		t.Errorf("%s reported as needing deferred; should not be", instB1)
+	}
+}
+
+func TestDeferred_partialExpandedResourceDeferredInSiblingModuleInstance(t *testing.T) {
+	moduleFoo0 := addrs.RootModuleInstance.Child("foo", addrs.IntKey(0))
+	instA0 := addrs.AbsResourceInstance{
+		Module: moduleFoo0.Child("bar", addrs.IntKey(0)),
+		Resource: addrs.ResourceInstance{
+			Resource: addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test",
+				Name: "a",
+			},
+		},
+	}
+	instAPartial := moduleFoo0.
+		UnexpandedChild(addrs.ModuleCall{Name: "bar"}).
+		Resource(instA0.Resource.Resource)
+
+	instB0 := addrs.AbsResourceInstance{
+		Module: moduleFoo0.Child("bar", addrs.IntKey(0)),
+		Resource: addrs.ResourceInstance{
+			Resource: addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test",
+				Name: "b",
+			},
+		},
+	}
+	instB1 := addrs.AbsResourceInstance{
+		Module: addrs.RootModuleInstance.Child("foo", addrs.IntKey(1)).Child("bar", addrs.IntKey(0)),
+		Resource: addrs.ResourceInstance{
+			Resource: addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test",
+				Name: "b",
+			},
+		},
+	}
+
+	// Dependencies are only tracked at the config resource level, but only
+	// partially-expanded resources beneath foo[0] are deferred.
+	bDeps := []addrs.ConfigResource{instA0.ConfigResource()}
+
+	deferred := NewDeferred(true)
+	deferred.ReportResourceExpansionDeferred(instAPartial, &plans.ResourceInstanceChange{
+		Addr: instA0,
+		Change: plans.Change{
+			Action: plans.Create,
+			After:  cty.DynamicVal,
+		},
+	})
+
+	if !deferred.ShouldDeferResourceInstanceChanges(instB0, bDeps) {
+		t.Errorf("%s was not reported as needing deferred; should be deferred", instB0)
+	}
+	if deferred.ShouldDeferResourceInstanceChanges(instB1, bDeps) {
+		t.Errorf("%s reported as needing deferred; should not be", instB1)
+	}
+}

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -863,7 +863,7 @@ func (n *NodeApplyableOutput) setValue(namedVals *namedvals.State, state *states
 		// not serialized.
 		if n.Addr.Module.IsRoot() {
 			val, _ = val.UnmarkDeep()
-			if deferred.DependenciesDeferred(n.Dependencies) {
+			if deferred.DependenciesDeferred(n.Path(), n.Dependencies) {
 				// If the output is from deferred resources then we return a
 				// simple null value representing that the value is really
 				// unknown as the dependencies were not properly computed.

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -73,11 +73,15 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 				addr := resource.Addr().InModule(c.Path)
 				schema := schema.SchemaForResourceAddr(addr.Resource)
 
-				// Before checking the data to see if there is a match, check if there is a deferral for this address.
+				// Before checking the data to see if there is a match, check if
+				// there is a deferral for this address.
 				//
-				// If there is a deferral, we can't use the data to determine if there is a match so we'll indicate
-				// the callback return is a partial result.
-				deferred := ctx.Deferrals().DependenciesDeferred([]addrs.ConfigResource{addr})
+				// If there is a deferral, we can't use the data to determine if
+				// there is a match so we'll indicate the callback return is a
+				// partial result. Since we don't have a module instance, check
+				// deferrals from the root instance scope indicating we can
+				// depend on anything.
+				deferred := ctx.Deferrals().DependenciesDeferred(addrs.RootModuleInstance, []addrs.ConfigResource{addr})
 				if deferred {
 					isPartialResult = true
 					continue


### PR DESCRIPTION
Dependencies are only tracked at the configuration level, but it's possible for the same resource to be deferred within one module instance and not another. If resource instances share a module path with a deferred resource, but have different ancestor module instances, they don't need to be deferred based on that dependency.

For example:


```mermaid
flowchart RL
  subgraph "root"
     A@{ shape: processes, label: "test_resource.root[x]"} 
  end
  
  B0 --> A
  B1 --> A
  C0 --> B0
  C1 --> B1
  
  subgraph "module.foo"
    subgraph "module.foo[0]"
      B0@{ shape: processes, label: "test_resource[x] (deferred)"} 
    end
    subgraph "module.foo[1]"
      B1@{ shape: processes, label: "test_resource[x]"}
    end
  end
  
  subgraph "module.foo.module.bar"
    subgraph "module.foo[0].module.bar"
      C0@{ shape: processes, label: "test_resource[x] (deffered)"}
    end
    subgraph "module.foo[1].module.bar"
      C1@{ shape: processes, label: "test_resource[x]"}
    end
  end
```

In the diagram above, `module.foo[0].test_resource` is deferred first using the config address of `module.foo.test_resource`, while there is no deferral for the sibling `module.foo[1].test_resource`. When planning reaches `module.foo.module.bar.test_resource`, the check for deferred dependencies will look for `module.foo.module.bar.test_resource` and find a deferral. Previously this would universally defer all depedenants in the `bar` module instances. Now the resource instances beneath `module.foo[0]` using the deferred resource can still be deferred; but the instances beneath `module.foo[1]` can continue planning since there is no way for them to have references between the two `mofule.foo` instances and the true dependency of `module.foo[1].test_resource` is stil being planned normally.
