### PR TITLE
🤖🤖🤖 Fix inconsistent result multiple marks

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260904-100136.yaml
+++ b/.changes/v1.17/BUG FIXES-20260904-100136.yaml
@@ -1,0 +1,8 @@
+kind: BUG FIXES
+body: 'Filesystem functions such as `templatefile` and `file` no longer intermittently
+    fail with "function returned an inconsistent result" when a value they receive
+    carries more than one mark, such as a sensitive value combined with a deprecated
+    provider attribute or module output'
+time: 2026-09-04T10:01:36.000000-07:00
+custom:
+    Issue: "REPLACE_WITH_PR_NUMBER"

--- a/.changes/v1.17/BUG FIXES-20260904-100136.yaml
+++ b/.changes/v1.17/BUG FIXES-20260904-100136.yaml
@@ -5,4 +5,4 @@ body: 'Filesystem functions such as `templatefile` and `file` no longer intermit
     provider attribute or module output'
 time: 2026-09-04T10:01:36.000000-07:00
 custom:
-    Issue: "REPLACE_WITH_PR_NUMBER"
+    Issue: "39137"

--- a/internal/lang/function_results.go
+++ b/internal/lang/function_results.go
@@ -72,14 +72,25 @@ func (f *FunctionResults) CheckPriorProvider(provider addrs.Provider, name strin
 		// cty.Values have a Hash method, but it is not collision resistant. We
 		// are going to rely on the GoString formatting instead, which gives
 		// detailed results for all values.
-		io.WriteString(argSum, "|"+arg.GoString())
+		//
+		// Marks are removed before hashing. They describe how a caller may use
+		// a value rather than the data the function was given, so they have no
+		// bearing on whether the function behaved consistently. Retaining them
+		// would also make the hash unstable, because cty.ValueMarks.GoString
+		// iterates a Go map without sorting and so can render the same set of
+		// two or more marks in a different order from one call to the next.
+		unmarkedArg, _ := arg.UnmarkDeep()
+		io.WriteString(argSum, "|"+unmarkedArg.GoString())
 	}
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
+	// Hash the unmarked result, for the same reasons as the arguments above.
+	unmarkedResult, _ := result.UnmarkDeep()
+
 	argHash := [sha256.Size]byte(argSum.Sum(nil))
-	resHash := sha256.Sum256([]byte(result.GoString()))
+	resHash := sha256.Sum256([]byte(unmarkedResult.GoString()))
 
 	res, ok := f.results[argHash]
 	if !ok {

--- a/internal/lang/function_results_test.go
+++ b/internal/lang/function_results_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 
 	// set the correct global logger for tests
@@ -157,6 +158,23 @@ func TestFunctionCache(t *testing.T) {
 			},
 			// OK because args changed from unknown to known
 		},
+		{
+			first: testCall{
+				provider: testAddr,
+				name:     "fun",
+				args:     []cty.Value{cty.StringVal("ok").Mark(marks.Sensitive)},
+				result:   cty.StringVal("a"),
+			},
+			second: testCall{
+				provider: testAddr,
+				name:     "fun",
+				args:     []cty.Value{cty.StringVal("ok").Mark(marks.Ephemeral)},
+				result:   cty.StringVal("b"),
+			},
+			// The marks differ but the underlying arguments do not, so this is
+			// still the same call and the differing result is inconsistent.
+			expectErr: true,
+		},
 	}
 
 	for i, test := range tests {
@@ -184,6 +202,54 @@ func TestFunctionCache(t *testing.T) {
 
 			if originalErr != reloadedErr {
 				t.Fatalf("original check returned err:%t, reloaded check returned err:%t", originalErr, reloadedErr)
+			}
+		})
+	}
+}
+
+// A value carrying two or more marks must hash consistently. cty renders a
+// single mark deterministically, but falls back to ValueMarks.GoString for two
+// or more, which iterates a Go map without sorting. Since Go randomizes map
+// iteration order, hashing the marked value directly gave a different result
+// from one call to the next and reported spurious inconsistencies.
+//
+// Every combination of mark types is covered, because the defect is in how the
+// set of marks is rendered and so is indifferent to which marks are present.
+// Each case is repeated often enough that an unstable hash is certain to be
+// caught.
+func TestFunctionCacheMarkedValues(t *testing.T) {
+	deprecated := marks.NewDeprecation("deprecated", "test")
+	alsoDeprecated := marks.NewDeprecation("deprecated by something else", "test")
+
+	tests := map[string]cty.ValueMarks{
+		"sensitive and ephemeral":   cty.NewValueMarks(marks.Sensitive, marks.Ephemeral),
+		"sensitive and type":        cty.NewValueMarks(marks.Sensitive, marks.TypeType),
+		"sensitive and deprecated":  cty.NewValueMarks(marks.Sensitive, deprecated),
+		"ephemeral and deprecated":  cty.NewValueMarks(marks.Ephemeral, deprecated),
+		"two distinct deprecations": cty.NewValueMarks(deprecated, alsoDeprecated),
+		"three marks": cty.NewValueMarks(
+			marks.Sensitive, marks.Ephemeral, deprecated,
+		),
+	}
+
+	for name, valMarks := range tests {
+		t.Run(name, func(t *testing.T) {
+			args := []cty.Value{cty.StringVal("template").WithMarks(valMarks)}
+			result := cty.StringVal("rendered").WithMarks(valMarks)
+
+			results := NewFunctionResultsTable(nil)
+			for i := 0; i < 100; i++ {
+				if err := results.CheckPrior("fun", args, result); err != nil {
+					t.Fatalf("call %d returned an unexpected error: %s", i, err)
+				}
+			}
+
+			// Results reloaded from a plan must agree with the in-memory table.
+			reloaded := NewFunctionResultsTable(results.GetHashes())
+			for i := 0; i < 100; i++ {
+				if err := reloaded.CheckPrior("fun", args, result); err != nil {
+					t.Fatalf("reloaded call %d returned an unexpected error: %s", i, err)
+				}
 			}
 		})
 	}

--- a/internal/lang/function_results_test.go
+++ b/internal/lang/function_results_test.go
@@ -221,7 +221,7 @@ func TestFunctionCacheMarkedValues(t *testing.T) {
 	deprecated := marks.NewDeprecation("deprecated", "test")
 	alsoDeprecated := marks.NewDeprecation("deprecated by something else", "test")
 
-	tests := map[string]cty.ValueMarks{
+	markSets := map[string]cty.ValueMarks{
 		"sensitive and ephemeral":   cty.NewValueMarks(marks.Sensitive, marks.Ephemeral),
 		"sensitive and type":        cty.NewValueMarks(marks.Sensitive, marks.TypeType),
 		"sensitive and deprecated":  cty.NewValueMarks(marks.Sensitive, deprecated),
@@ -232,10 +232,46 @@ func TestFunctionCacheMarkedValues(t *testing.T) {
 		),
 	}
 
-	for name, valMarks := range tests {
+	type testCase struct {
+		args   []cty.Value
+		result cty.Value
+	}
+
+	tests := map[string]testCase{}
+	for name, valMarks := range markSets {
+		tests[name] = testCase{
+			args:   []cty.Value{cty.StringVal("template").WithMarks(valMarks)},
+			result: cty.StringVal("rendered").WithMarks(valMarks),
+		}
+	}
+
+	// Marks are commonly nested within compound arguments rather than applied
+	// at the top level, as in templatefile(path, { key = sensitive(...) }), so
+	// hashing must also be stable when UnmarkDeep has to descend into an
+	// object to strip them.
+	tests["marks nested in object"] = testCase{
+		args: []cty.Value{
+			cty.StringVal("template.tftpl"),
+			cty.ObjectVal(map[string]cty.Value{
+				"password": cty.StringVal("hunter2").WithMarks(
+					cty.NewValueMarks(marks.Sensitive, marks.Ephemeral),
+				),
+				"tags": cty.MapVal(map[string]cty.Value{
+					"owner": cty.StringVal("ops").WithMarks(
+						cty.NewValueMarks(marks.Sensitive, deprecated),
+					),
+				}),
+				"plain": cty.StringVal("unmarked"),
+			}),
+		},
+		result: cty.StringVal("rendered").WithMarks(
+			cty.NewValueMarks(marks.Sensitive, marks.Ephemeral),
+		),
+	}
+
+	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			args := []cty.Value{cty.StringVal("template").WithMarks(valMarks)}
-			result := cty.StringVal("rendered").WithMarks(valMarks)
+			args, result := test.args, test.result
 
 			results := NewFunctionResultsTable(nil)
 			for i := 0; i < 100; i++ {


### PR DESCRIPTION
Filesystem functions (`templatefile`, `file`, `filebase64`, …) and provider-defined functions
have their results recorded during the plan walk and re-verified when the call is evaluated again
during the apply walk. Both the cache key and the recorded result are derived from cty's
`GoString()` rendering of the values:

```go
io.WriteString(argSum, "|"+arg.GoString())
...
resHash := sha256.Sum256([]byte(result.GoString()))
```

Because `templatefile`/`file` declare `AllowMarked: true`, marks are still attached to the values
at this point and so are included in those hashes.

cty renders a value carrying a *single* mark deterministically, but for two or more it falls
through to `ValueMarks.GoString()`, which serialises by ranging a Go map with no sorting:

```go
func (m ValueMarks) GoString() string {
	...
	for mv := range m {                     // no sorting
		s.WriteString(fmt.Sprintf("%#v", mv))
	}
```

Go randomises map iteration order, so the same value can render its marks in a different order on
each call. The plan walk and the apply walk each build a fresh marks map for a given value, so the
recorded hash and the recomputed hash disagreed at random and the check reported an inconsistent
result when nothing had actually changed.

This is reachable from ordinary configuration by giving a filesystem function any two distinct
marks — for example a `sensitive` value passed to `templatefile` alongside a deprecated provider
attribute or module output. `templatefile` aggregates the marks of *all* its template variables
onto its single result via `args[1].UnmarkDeep()`, so the two marks need not be on the same
variable. Affected configurations fail intermittently, at a rate that varies by machine because it
derives from map iteration order: between roughly 25% and 100% of applies on the reporter's
hardware, with no configuration change between runs.

## The change

Strip marks from the arguments and the result before hashing them.

Marks describe how a caller may use a value rather than the data the function was given, so they
have no bearing on whether a function behaved consistently and should not influence the purity
hash. The function's actual return value is untouched — only the local copies used to compute the
hashes are unmarked.

This has one intended behavioural consequence worth calling out: calls whose arguments differ
*only* by their marks now share a cache entry, and so are compared against each other rather than
being treated as separate calls. That makes the check marginally stricter, which seems correct —
the underlying arguments are identical, so the results should be too.

An alternative would be to sort the marks inside `ValueMarks.GoString()` in `go-cty`. That would
also remove the non-determinism, but it leaves marks influencing a hash they should have no part
in, and it requires an upstream dependency release. Happy to pursue that instead, or in addition,
if maintainers prefer.

### Note for reviewers

The key derivation changes, so function-result hashes recorded by an older Terraform will not match
those computed by a patched one. Since Terraform declines to apply a saved plan produced by a
different version, this should not be reachable in practice; flagging it in case that reasoning is
incomplete for HCP Terraform or the stacks runtime.

## Testing

`TestFunctionCacheMarkedValues` is table-driven over every combination of mark types
(`Sensitive`, `Ephemeral`, `TypeType`, `DeprecationMark`), repeating each check enough times that
an unstable hash is certain to be caught. All six cases fail against the unpatched
`function_results.go` and pass with it. An existing-behaviour case was also added to
`TestFunctionCache` covering arguments that differ only by their marks.

Verified with a binary built from this branch against the reproduction in the linked issue: 11/30
failing applies on stock v1.16.1, 0/30 with the patch. (The rate on stock varies by machine, since
it derives from map iteration order.) The check still fires for a *genuine* inconsistency —
changing the template file between the plan and apply walks still fails the apply — so this does
not weaken it.

`./internal/lang/...`, `./internal/terraform/`, `./internal/plans/...`, `./internal/providers/...`
and `./internal/stacks/stackplan/...` all pass. The provider packages are included because
provider-defined functions share `CheckPriorProvider` and have carried this defect since v1.8.0.

## AI usage disclosure

Per the AI Usage section of CONTRIBUTING.md: this change was developed with the assistance of an
LLM agent (Claude Code). It was used to investigate the root cause — building throwaway
reproductions, measuring failure rates, and locating the relevant code paths in Terraform and
go-cty — and to draft the patch, the tests and this description.

Every verification step listed under Testing above is reproducible from this branch. In
particular, reverting only `internal/lang/function_results.go` to its parent commit makes
`TestFunctionCache/8` and all six `TestFunctionCacheMarkedValues` cases fail, so the tests
genuinely cover the defect rather than merely passing alongside it.

Fixes #39137

## Target Release

1.17.x

Also a backport candidate for 1.16.x and 1.15.x, which are both affected. Happy to add the
relevant backport labels if maintainers agree that is appropriate.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No. Sensitive-value handling is unchanged: the values returned by these functions keep their marks,
nothing new is stored or logged, and the debug value retained for the error message is still the
marked value. The only difference is that the sha256 inputs are computed from unmarked copies, and
those hashes were already one-way and already recorded in the plan file.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
