### PR TITLE
command: normalize elapsed duration in test output comparisons

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260906-072800.yaml
+++ b/.changes/v1.17/BUG FIXES-20260906-072800.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'tests: Normalize dynamic elapsed duration in command and policy output comparisons'
+time: 2026-09-06T07:28:00.000000Z
+custom:
+    Issue: "39026"

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"testing"
@@ -1219,10 +1220,33 @@ func checkParameterizedGoldenReferenceHumanOutput(t *testing.T, output *terminal
 
 	want = strings.ReplaceAll(want, "\n", " ")
 
+	got = normalizeElapsedDuration(got)
+	want = normalizeElapsedDuration(want)
+
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("wrong output\n%s\n"+
 			"NOTE: This failure may indicate a UI change affecting the behavior of structured run output on TFC.\n"+
 			"Please communicate with HCP Terraform team before resolving", diff)
+	}
+}
+
+var reElapsedDuration = regexp.MustCompile(`\b(complete|errored|progress) after \S+`)
+
+// normalizeElapsedDuration replaces non-deterministic elapsed execution durations
+// (e.g. "complete after 1s [id=...]") with a fixed "0s" duration to prevent CI flakes.
+func normalizeElapsedDuration(s string) string {
+	return reElapsedDuration.ReplaceAllString(s, "$1 after 0s")
+}
+
+func normalizeJSONLogMap(m map[string]interface{}) {
+	delete(m, "@timestamp") // Timestamps always differ
+	if hook, ok := m["hook"].(map[string]interface{}); ok {
+		if _, hasElapsed := hook["elapsed_seconds"]; hasElapsed {
+			hook["elapsed_seconds"] = float64(0)
+		}
+	}
+	if msg, ok := m["@message"].(string); ok {
+		m["@message"] = normalizeElapsedDuration(msg)
 	}
 }
 
@@ -1307,7 +1331,7 @@ func checkGoldenReferenceStr(t *testing.T, output *terminal.TestOutput, want str
 		if _, ok := gotMap["@timestamp"]; !ok {
 			t.Errorf("missing @timestamp field in log: %s", gotLines[index])
 		}
-		delete(gotMap, "@timestamp")
+		normalizeJSONLogMap(gotMap)
 		gotLineMaps = append(gotLineMaps, gotMap)
 	}
 	var wantLineMaps []map[string]interface{}
@@ -1317,7 +1341,7 @@ func checkGoldenReferenceStr(t *testing.T, output *terminal.TestOutput, want str
 		if err := json.Unmarshal([]byte(line), &wantMap); err != nil {
 			t.Errorf("failed to unmarshal want line %d: %s\n%s", index, err, wantLines[index])
 		}
-		delete(wantMap, "@timestamp") // If the test fixture includes timestamps ignore and don't compare them, since they will always differ
+		normalizeJSONLogMap(wantMap)
 		wantLineMaps = append(wantLineMaps, wantMap)
 	}
 	if diff := cmp.Diff(wantLineMaps, gotLineMaps); diff != "" {
@@ -1326,3 +1350,39 @@ func checkGoldenReferenceStr(t *testing.T, output *terminal.TestOutput, want str
 			"Please communicate with HCP Terraform team before resolving", diff)
 	}
 }
+
+func TestNormalizeElapsedDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "data.test_data_source.a: Refresh complete after 1s [id=zzzzz]",
+			want:  "data.test_data_source.a: Refresh complete after 0s [id=zzzzz]",
+		},
+		{
+			input: "data.test_data_source.a: Read complete after 12s [id=zzzzz]",
+			want:  "data.test_data_source.a: Read complete after 0s [id=zzzzz]",
+		},
+		{
+			input: "test_instance.foo: Creation complete after 1m4s",
+			want:  "test_instance.foo: Creation complete after 0s",
+		},
+		{
+			input: "test_instance.foo: Creation errored after 500ms",
+			want:  "test_instance.foo: Creation errored after 0s",
+		},
+		{
+			input: "test_instance.foo: Modifications complete after 0s [id=foo]",
+			want:  "test_instance.foo: Modifications complete after 0s [id=foo]",
+		},
+	}
+
+	for _, tt := range tests {
+		got := normalizeElapsedDuration(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeElapsedDuration(%q) = %q; want %q", tt.input, got, tt.want)
+		}
+	}
+}
+

--- a/internal/command/plan_policy_test.go
+++ b/internal/command/plan_policy_test.go
@@ -450,7 +450,7 @@ Note: You didn't use the -out option to save this plan, so Terraform can't
 guarantee to take exactly these actions if you run "terraform apply" now.
 `
 
-	if actual, diff := output.Stdout(), cmp.Diff(expected, output.Stdout()); diff != "" {
+	if actual, diff := output.Stdout(), cmp.Diff(expected, normalizeElapsedDuration(output.Stdout())); diff != "" {
 		t.Fatalf("unexpected output:\n%s. \nDiff: %s", actual, diff)
 	}
 }
@@ -653,7 +653,7 @@ Note: You didn't use the -out option to save this plan, so Terraform can't
 guarantee to take exactly these actions if you run "terraform apply" now.
 `
 
-	if actual, diff := output.Stdout(), cmp.Diff(expected, output.Stdout()); diff != "" {
+	if actual, diff := output.Stdout(), cmp.Diff(expected, normalizeElapsedDuration(output.Stdout())); diff != "" {
 		t.Fatalf("unexpected output:\n%s. \nDiff: %s", actual, diff)
 	}
 }
@@ -903,7 +903,7 @@ Plan: 0 to add, 0 to change, 1 to destroy.
 Note: You didn't use the -out option to save this plan, so Terraform can't
 guarantee to take exactly these actions if you run "terraform apply" now.
 `
-	if diff := cmp.Diff(expectedStdout, output.Stdout()); diff != "" {
+	if diff := cmp.Diff(expectedStdout, normalizeElapsedDuration(output.Stdout())); diff != "" {
 		t.Fatalf("unexpected stdout output:\n%s", diff)
 	}
 
@@ -1026,7 +1026,7 @@ Note: You didn't use the -out option to save this plan, so Terraform can't
 guarantee to take exactly these actions if you run "terraform apply" now.
 `
 
-	if diff := cmp.Diff(expectedStdOut, output.Stdout()); diff != "" {
+	if diff := cmp.Diff(expectedStdOut, normalizeElapsedDuration(output.Stdout())); diff != "" {
 		t.Fatalf("unexpected stdout output:\n%s", diff)
 	}
 


### PR DESCRIPTION
Fixes #39026
Fixes #39025
Fixes #38968

### Description

This PR resolves intermittent test failures across `internal/command` caused by non-deterministic elapsed duration output.

#### Root Cause
Terraform operation hooks calculate duration dynamically from wall-clock time (`time.Now().Sub(state.Start)`).
In JSON log views (`internal/command/views/json/hook.go`), hooks output `elapsed_seconds: float64` and format `@message` strings such as `"... complete after 0s"`.
In human-readable views and plan policy tests, output contains tokens like `"... complete after 0s"`.

Golden test comparisons in `command_test.go` and `plan_policy_test.go` previously expected a hardcoded `0s` and `elapsed_seconds: 0`. When tests ran under load, high concurrency, or with `-race`, executions taking $\ge 1\text{s}$ caused diff mismatches against golden outputs (e.g., `elapsed_seconds: 1` or `complete after 1s`).

#### Solution
- Added `normalizeElapsedDuration` helper in `internal/command/command_test.go` using regular expressions (`\b(complete|errored|progress) after \S+`) to normalize dynamic duration tokens to `0s` in both human-readable test output comparisons and structured JSON log `@message` fields.
- Added `normalizeJSONLogMap` in `checkGoldenReferenceStr` to zero out `hook["elapsed_seconds"]` across test log fixtures before comparison.
- Added regression unit test `TestNormalizeElapsedDuration`.
- Applied `normalizeElapsedDuration` to policy test comparison strings in `internal/command/plan_policy_test.go`.

### Target Release
1.17.x

### Rollback Plan
- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls
None. This strictly touches internal test comparison utilities and test suites.

### CHANGELOG entry
- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
