### PR TITLE
🤖🤖🤖 Fix inverted TargetContains check and subset blind spot in apply

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260906-171500.yaml
+++ b/.changes/v1.17/BUG FIXES-20260906-171500.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'backend/local: `apply` of a saved plan no longer emits an incorrect "target doesn''t match plan" warning when a `-target` flag is more specific than a target recorded in the plan, and now correctly warns when the plan contains additional targets not covered by a narrower `-target` flag'
+time: 2026-09-06T17:15:00.000000+05:30
+custom:
+    Issue: "39139"

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -425,23 +425,7 @@ func (b *Local) opApply(
 	// If the user erroneously included any plan options flags when they supplied a plan file,
 	// we'll return an error if the flag values don't match the plan file.
 	if len(op.Targets) != 0 {
-		// Do target flags all match targets in the plan?
-		for _, target := range op.Targets {
-			found := false
-			for _, planTarget := range plan.TargetAddrs {
-				if target.TargetContains(planTarget) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Warning,
-					"Can't change resource targeting when applying a saved plan",
-					fmt.Sprintf("The target address %q was supplied using a -target flag but does not match a target in the saved plan file. This flag will be ignored and won't influence the apply operation.", target),
-				))
-			}
-		}
+		diags = diags.Append(targetMismatchDiags(op.Targets, plan.TargetAddrs))
 	}
 	if op.PlanMode != plan.UIMode {
 		if op.PlanMode == plans.DestroyMode {
@@ -520,6 +504,65 @@ func (b *Local) opApply(
 	// here just before we show the summary and next steps. If we encountered
 	// errors then we would've returned early at some other point above.
 	op.View.Diagnostics(diags)
+}
+
+// targetMismatchDiags compares the -target addresses supplied on the command
+// line against the target addresses recorded in a saved plan file, returning
+// a warning for each address on either side that isn't covered by (equal to,
+// containing, or contained by) at least one address on the other side.
+//
+// Two separate mismatches are possible here:
+//   - A -target flag whose address has nothing to do with any address in the
+//     saved plan: applying the saved plan can't be narrowed down by it, so
+//     it's pointless and will be ignored.
+//   - An address in the saved plan that isn't covered by any -target flag:
+//     that part of the plan will still be applied even though the user's
+//     -target flags suggested they only wanted a subset of it.
+func targetMismatchDiags(cliTargets, planTargets []addrs.Targetable) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// Two targets are considered compatible if either one contains the
+	// other (or they're equal, which TargetContains also treats as
+	// containment), regardless of which side is the more specific one.
+	compatible := func(a, b addrs.Targetable) bool {
+		return a.TargetContains(b) || b.TargetContains(a)
+	}
+
+	for _, target := range cliTargets {
+		found := false
+		for _, planTarget := range planTargets {
+			if compatible(target, planTarget) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				"Can't change resource targeting when applying a saved plan",
+				fmt.Sprintf("The target address %q was supplied using a -target flag but does not match a target in the saved plan file. This flag will be ignored and won't influence the apply operation.", target),
+			))
+		}
+	}
+
+	for _, planTarget := range planTargets {
+		found := false
+		for _, target := range cliTargets {
+			if compatible(target, planTarget) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				"Can't change resource targeting when applying a saved plan",
+				fmt.Sprintf("The saved plan file includes changes for %q, which isn't covered by any of the -target flags supplied to apply. This part of the plan will still be applied.", planTarget),
+			))
+		}
+	}
+
+	return diags
 }
 
 // backupStateForError is called in a scenario where we're unable to persist the

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -434,3 +434,78 @@ func TestApply_applyCanceledAutoApprove(t *testing.T) {
 	}
 
 }
+
+func mustParseApplyTarget(t *testing.T, str string) addrs.Targetable {
+	t.Helper()
+	target, diags := addrs.ParseTargetStr(str)
+	if diags.HasErrors() {
+		t.Fatalf("failed to parse target %q: %s", str, diags.Err())
+	}
+	return target.Subject
+}
+
+func TestTargetMismatchDiags(t *testing.T) {
+	target := func(str string) addrs.Targetable { return mustParseApplyTarget(t, str) }
+
+	tests := map[string]struct {
+		cliTargets, planTargets []addrs.Targetable
+		wantSummaries           []string
+	}{
+		"exact match, no warnings": {
+			cliTargets:    []addrs.Targetable{target("null_resource.a")},
+			planTargets:   []addrs.Targetable{target("null_resource.a")},
+			wantSummaries: nil,
+		},
+		"cli target more specific than plan target: covered, no warnings": {
+			// Regression case for the reported "inverted containment
+			// check": applying a plan that targeted the whole module with
+			// a more specific -target inside that module must not warn,
+			// since the resource was included under the module target.
+			cliTargets:    []addrs.Targetable{target("module.foo.null_resource.bar")},
+			planTargets:   []addrs.Targetable{target("module.foo")},
+			wantSummaries: nil,
+		},
+		"cli target broader than plan target: covered, no warnings": {
+			cliTargets:    []addrs.Targetable{target("module.foo")},
+			planTargets:   []addrs.Targetable{target("module.foo.null_resource.bar")},
+			wantSummaries: nil,
+		},
+		"cli target unrelated to the only plan target: warns both ways": {
+			// Neither address relates to the other at all, so both the
+			// "cli target doesn't match anything in the plan" loop and the
+			// "plan target isn't covered by any cli target" loop fire.
+			cliTargets:  []addrs.Targetable{target("null_resource.unrelated")},
+			planTargets: []addrs.Targetable{target("null_resource.a")},
+			wantSummaries: []string{
+				"Can't change resource targeting when applying a saved plan",
+				"Can't change resource targeting when applying a saved plan",
+			},
+		},
+		"plan target not covered by any cli target: warns once": {
+			// Regression case for the reported "subset / re-targeting
+			// blind spot": a plan with two targets, applied with -target
+			// covering only one of them, must warn about the other one
+			// still being applied. The covered target produces no warning
+			// in either direction, so only one warning is expected.
+			cliTargets:  []addrs.Targetable{target("null_resource.a")},
+			planTargets: []addrs.Targetable{target("null_resource.a"), target("null_resource.b")},
+			wantSummaries: []string{
+				"Can't change resource targeting when applying a saved plan",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			diags := targetMismatchDiags(test.cliTargets, test.planTargets)
+			if len(diags) != len(test.wantSummaries) {
+				t.Fatalf("got %d diagnostics, want %d: %s", len(diags), len(test.wantSummaries), diags.Err())
+			}
+			for i, wantSummary := range test.wantSummaries {
+				if got := diags[i].Description().Summary; got != wantSummary {
+					t.Errorf("diag %d summary = %q, want %q", i, got, wantSummary)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #39139 (draft — opening for early feedback per the contributing guide, since this hasn't had maintainer discussion on the issue yet).

`backend_apply.go`'s check for whether `-target` flags are consistent with a saved plan's own recorded targets had two bugs, both described in detail in #39139:

1. **Inverted containment direction.** It called `cliTarget.TargetContains(planTarget)`, which only checks whether the CLI target contains the plan target. If the plan targeted `module.foo` and apply passed the more specific `-target=module.foo.null_resource.bar`, the check went the wrong way and incorrectly warned that the resource "does not match a target in the saved plan file" — even though it *was* included, via `module.foo`.

2. **Subset / re-targeting blind spot.** The check only verified each CLI target matched *something* in the plan's target list, never the reverse. If the plan targeted `[A, B]` and apply passed only `-target=A`, `A` trivially matches itself, so no warning is emitted — but `B` is still applied despite never being requested via `-target`.

## Fix

Extracted the logic into a standalone `targetMismatchDiags(cliTargets, planTargets []addrs.Targetable) tfdiags.Diagnostics`, so it's directly unit-testable without needing the full backend/provider/plan-file test harness. The containment check between any two targets is now bidirectional (`a.TargetContains(b) || b.TargetContains(a)`), and there are now two loops: one warning about CLI targets unrelated to anything in the plan (the original, correctly-oriented behavior), and one warning about plan targets not covered by any CLI target (the previously-missing check).

## Testing

- Added `TestTargetMismatchDiags` with 5 subtests covering: exact match, CLI-more-specific-than-plan (regression case 1), CLI-broader-than-plan, fully unrelated targets (warns both directions), and the subset blind spot (regression case 2).
- Verified the new test fails against the original logic (temporarily swapped `targetMismatchDiags`'s body back to the single-direction, CLI→plan-only check) — 3 of 5 subtests fail exactly as expected — then confirmed it passes again with the fix restored.
- Full `internal/backend/local` and `internal/addrs` package test suites pass.
- `go vet` and `gofmt -l` are clean on both changed files.
- Added a `changie` change file at `.changes/v1.17/`.

## AI Disclosure

This PR was developed with Claude Sonnet 5 (Claude Code). The AI performed the code archaeology (tracing `TargetContains`'s semantics via `internal/addrs`), wrote the fix and the regression tests, and verified the fix against the original buggy logic before/after. I (the PR author) have reviewed the change and can explain the bidirectional-containment reasoning and both regression scenarios if asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)