### PR TITLE
providercache: make a shared global plugin cache safe for concurrent use

### DIFF
--- a/.changes/v1.17/ENHANCEMENTS-20260906-125042.yaml
+++ b/.changes/v1.17/ENHANCEMENTS-20260906-125042.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'providercache: multiple Terraform processes can now safely share a global plugin cache directory (`plugin_cache_dir` / `TF_PLUGIN_CACHE_DIR`) concurrently, coordinated by per-provider advisory file locks'
+time: 2026-09-06T12:50:42.000000Z
+custom:
+    Issue: "39142"

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dylanmei/winrmtest v0.0.0-20210303004826-fbc9ae56efb6
 	github.com/go-test/deep v1.0.3
+	github.com/gofrs/flock v0.10.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/cli v1.1.7
@@ -169,7 +170,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
-	github.com/gofrs/flock v0.10.0 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect

--- a/internal/providercache/dir.go
+++ b/internal/providercache/dir.go
@@ -36,19 +36,19 @@ type Dir struct {
 	// that the cache is cold. The cache will be invalidated (set back to nil)
 	// by any operation that modifies the contents of the cache directory.
 	//
-	// We intentionally don't make effort to detect modifications to the
-	// directory made by other codepaths because the contract for NewDir
-	// explicitly defines using the same directory for multiple purposes
-	// as undefined behavior.
+	// The global-cache installer also invalidates this after acquiring a
+	// package lock, because another process might have populated the cache
+	// while waiting for that lock.
 	metaCache map[addrs.Provider][]CachedProvider
 }
 
 // NewDir creates and returns a new Dir object that will read and write
 // provider plugins in the given filesystem directory.
 //
-// If two instances of Dir are concurrently operating on a particular base
-// directory, or if a Dir base directory is also used as a filesystem mirror
-// source directory, the behavior is undefined.
+// A Dir is not itself safe for concurrent use. Installer coordinates separate
+// Terraform processes that use the same directory as a global cache, but direct
+// concurrent calls to Dir methods and using a Dir as both a cache and a
+// filesystem mirror source remain undefined.
 func NewDir(baseDir string) *Dir {
 	return &Dir{
 		baseDir:        baseDir,

--- a/internal/providercache/dir_lock.go
+++ b/internal/providercache/dir_lock.go
@@ -1,0 +1,108 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providercache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gofrs/flock"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/hashicorp/terraform/internal/replacefile"
+)
+
+const providerLockRetryInterval = 100 * time.Millisecond
+
+const providerCacheMetadataVersion = 1
+
+type providerCacheMetadata struct {
+	Version      int                 `json:"version"`
+	PackageHash  getproviders.Hash   `json:"package_hash"`
+	SignedHashes []getproviders.Hash `json:"signed_hashes,omitempty"`
+}
+
+func (d *Dir) providerVersionPath(provider addrs.Provider, version getproviders.Version) string {
+	return getproviders.UnpackedDirectoryPathForPackage(
+		d.baseDir, provider, version, d.targetPlatform,
+	)
+}
+
+// lockProviderVersion acquires an advisory lock for one exact provider package
+// in this cache directory. The lock file remains after unlocking so all
+// contenders continue to coordinate through the same filesystem object.
+func (d *Dir) lockProviderVersion(ctx context.Context, provider addrs.Provider, version getproviders.Version) (func() error, error) {
+	packagePath := d.providerVersionPath(provider, version)
+	lockPath := packagePath + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+		return nil, fmt.Errorf("failed to create provider cache lock directory: %w", err)
+	}
+
+	log.Printf("[TRACE] providercache.Dir: waiting for lock on %s v%s", provider, version)
+	fileLock := flock.New(filepath.FromSlash(lockPath))
+	locked, err := fileLock.TryLockContext(ctx, providerLockRetryInterval)
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire provider cache lock for %s v%s: %w", provider, version, err)
+	}
+	if !locked {
+		return nil, fmt.Errorf("failed to acquire provider cache lock for %s v%s", provider, version)
+	}
+	log.Printf("[TRACE] providercache.Dir: acquired lock on %s v%s", provider, version)
+
+	// Another process might have populated this package while we waited.
+	d.metaCache = nil
+
+	return func() error {
+		log.Printf("[TRACE] providercache.Dir: releasing lock on %s v%s", provider, version)
+		return fileLock.Unlock()
+	}, nil
+}
+
+// readProviderCacheMetadata returns the completion metadata written by a
+// successful installer. Callers must hold the corresponding provider lock.
+func (d *Dir) readProviderCacheMetadata(provider addrs.Provider, version getproviders.Version) (*providerCacheMetadata, error) {
+	metadataPath := d.providerVersionPath(provider, version) + ".metadata.json"
+	src, err := os.ReadFile(filepath.FromSlash(metadataPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read provider cache metadata: %w", err)
+	}
+
+	var metadata providerCacheMetadata
+	if err := json.Unmarshal(src, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to decode provider cache metadata: %w", err)
+	}
+	if metadata.Version != providerCacheMetadataVersion || metadata.PackageHash == "" {
+		return nil, fmt.Errorf("provider cache metadata has an unsupported or incomplete format")
+	}
+	return &metadata, nil
+}
+
+// writeProviderCacheMetadata publishes a successful install's verified hash
+// information atomically. Callers must hold the corresponding provider lock.
+func (d *Dir) writeProviderCacheMetadata(provider addrs.Provider, version getproviders.Version, packageHash getproviders.Hash, signedHashes []getproviders.Hash) error {
+	metadata := providerCacheMetadata{
+		Version:      providerCacheMetadataVersion,
+		PackageHash:  packageHash,
+		SignedHashes: signedHashes,
+	}
+	src, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to encode provider cache metadata: %w", err)
+	}
+
+	metadataPath := filepath.FromSlash(d.providerVersionPath(provider, version) + ".metadata.json")
+	if err := replacefile.AtomicWriteFile(metadataPath, src, 0600); err != nil {
+		return fmt.Errorf("failed to write provider cache metadata: %w", err)
+	}
+	return nil
+}

--- a/internal/providercache/dir_lock_test.go
+++ b/internal/providercache/dir_lock_test.go
@@ -1,0 +1,141 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providercache
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/getproviders"
+)
+
+func TestDirLockProviderVersion_serializesSamePackage(t *testing.T) {
+	cacheDir := t.TempDir()
+	platform := getproviders.Platform{OS: "linux", Arch: "amd64"}
+	provider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/aws")
+	version := getproviders.MustParseVersion("5.100.0")
+
+	first := NewDirWithPlatform(cacheDir, platform)
+	unlockFirst, err := first.lockProviderVersion(context.Background(), provider, version)
+	if err != nil {
+		t.Fatalf("failed to acquire first provider lock: %s", err)
+	}
+	t.Cleanup(func() {
+		_ = unlockFirst()
+	})
+
+	lockPath := getproviders.UnpackedDirectoryPathForPackage(cacheDir, provider, version, platform) + ".lock"
+	if _, err := os.Lstat(filepath.FromSlash(lockPath)); err != nil {
+		t.Fatalf("lock file does not exist at package-specific path %q: %s", lockPath, err)
+	}
+
+	type lockResult struct {
+		unlock func() error
+		err    error
+	}
+	resultCh := make(chan lockResult, 1)
+	second := NewDirWithPlatform(cacheDir, platform)
+	go func() {
+		unlock, err := second.lockProviderVersion(context.Background(), provider, version)
+		resultCh <- lockResult{unlock: unlock, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		if result.err == nil {
+			_ = result.unlock()
+		}
+		t.Fatalf("second lock returned before first lock was released: %v", result.err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	if err := unlockFirst(); err != nil {
+		t.Fatalf("failed to release first provider lock: %s", err)
+	}
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("second lock failed after first lock was released: %s", result.err)
+		}
+		if err := result.unlock(); err != nil {
+			t.Fatalf("failed to release second provider lock: %s", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("second lock did not acquire after first lock was released")
+	}
+}
+
+func TestDirLockProviderVersion_differentPackagesDoNotBlock(t *testing.T) {
+	cacheDir := t.TempDir()
+	platform := getproviders.Platform{OS: "linux", Arch: "amd64"}
+	version := getproviders.MustParseVersion("5.100.0")
+	awsProvider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/aws")
+	googleProvider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/google")
+
+	awsDir := NewDirWithPlatform(cacheDir, platform)
+	unlockAWS, err := awsDir.lockProviderVersion(context.Background(), awsProvider, version)
+	if err != nil {
+		t.Fatalf("failed to acquire AWS provider lock: %s", err)
+	}
+	defer func() {
+		_ = unlockAWS()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	googleDir := NewDirWithPlatform(cacheDir, platform)
+	unlockGoogle, err := googleDir.lockProviderVersion(ctx, googleProvider, version)
+	if err != nil {
+		t.Fatalf("Google provider lock was blocked by AWS provider lock: %s", err)
+	}
+	if err := unlockGoogle(); err != nil {
+		t.Fatalf("failed to release Google provider lock: %s", err)
+	}
+}
+
+func TestDirLockProviderVersion_waitHonorsCancellation(t *testing.T) {
+	cacheDir := t.TempDir()
+	platform := getproviders.Platform{OS: "linux", Arch: "amd64"}
+	provider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/aws")
+	version := getproviders.MustParseVersion("5.100.0")
+
+	first := NewDirWithPlatform(cacheDir, platform)
+	unlockFirst, err := first.lockProviderVersion(context.Background(), provider, version)
+	if err != nil {
+		t.Fatalf("failed to acquire first provider lock: %s", err)
+	}
+	defer func() {
+		_ = unlockFirst()
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	second := NewDirWithPlatform(cacheDir, platform)
+	go func() {
+		_, err := second.lockProviderVersion(ctx, provider, version)
+		resultCh <- err
+	}()
+
+	select {
+	case err := <-resultCh:
+		t.Fatalf("waiting lock returned before cancellation: %v", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waiting lock error = %v; want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("waiting lock did not return after cancellation")
+	}
+}

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -381,286 +381,283 @@ NeedProvider:
 			continue
 		}
 
-		lock := locks.Provider(provider)
-		var preferredHashes []getproviders.Hash
-		if lock != nil && lock.Version() == version { // hash changes are expected if the version is also changing
-			preferredHashes = lock.PreferredHashes()
-		}
+		func() {
+			lock := locks.Provider(provider)
+			var preferredHashes []getproviders.Hash
+			if lock != nil && lock.Version() == version { // hash changes are expected if the version is also changing
+				preferredHashes = lock.PreferredHashes()
+			}
 
-		// If our target directory already has the provider version that fulfills the lock file, carry on
-		if installed := i.targetDir.ProviderVersion(provider, version); installed != nil {
-			if len(preferredHashes) > 0 {
-				if matches, _ := installed.MatchesAnyHash(preferredHashes); matches {
-					if cb := evts.ProviderAlreadyInstalled; cb != nil {
-						cb(provider, version)
+			// If our target directory already has the provider version that fulfills the lock file, carry on
+			if installed := i.targetDir.ProviderVersion(provider, version); installed != nil {
+				if len(preferredHashes) > 0 {
+					if matches, _ := installed.MatchesAnyHash(preferredHashes); matches {
+						if cb := evts.ProviderAlreadyInstalled; cb != nil {
+							cb(provider, version)
+						}
+						return
 					}
-					continue
 				}
 			}
-		}
 
-		if i.globalCacheDir != nil {
-			// Step 3a: If our global cache already has this version available then
-			// we'll just link it in.
-			if cached := i.globalCacheDir.ProviderVersion(provider, version); cached != nil {
-				// An existing cache entry is only an acceptable choice
-				// if there is already a lock file entry for this provider
-				// and the cache entry matches its checksums.
-				//
-				// If there was no lock file entry at all then we need to
-				// install the package for real so that we can lock as complete
-				// as possible a set of checksums for all of this provider's
-				// packages.
-				//
-				// If there was a lock file entry but the cache doesn't match
-				// it then we assume that the lock file checksums were only
-				// partially populated (e.g. from a local mirror where we can
-				// only see one package to checksum it) and so we'll fetch
-				// from upstream to see if the origin can give us a package
-				// that _does_ match. This might still not work out, but if
-				// it does then it allows us to avoid returning a checksum
-				// mismatch error.
-				acceptablePackage := false
-				if len(preferredHashes) != 0 {
-					var err error
-					acceptablePackage, err = cached.MatchesAnyHash(preferredHashes)
-					if err != nil {
-						// If we can't calculate the checksum for the cached
-						// package then we'll just treat it as a checksum failure.
-						acceptablePackage = false
+			if i.globalCacheDir != nil {
+				unlock, err := i.globalCacheDir.lockProviderVersion(ctx, provider, version)
+				if err != nil {
+					errs[provider] = err
+					if cb := evts.LinkFromCacheFailure; cb != nil {
+						cb(provider, version, err)
 					}
+					return
 				}
+				defer func() {
+					if err := unlock(); err != nil {
+						log.Printf("[ERROR] Failed to release provider cache lock for %s v%s: %s", provider, version, err)
+					}
+				}()
 
-				if !acceptablePackage && i.globalCacheDirMayBreakDependencyLockFile {
-					// The "may break dependency lock file" setting effectively
-					// means that we'll accept any matching package that's
-					// already in the cache, regardless of whether it matches
-					// what's in the dependency lock file.
+				// Step 3a: If our global cache already has this version available then
+				// we'll just link it in.
+				if cached := i.globalCacheDir.ProviderVersion(provider, version); cached != nil {
+					// An existing cache entry is only an acceptable choice
+					// if there is already a lock file entry for this provider
+					// and the cache entry matches its checksums.
 					//
-					// That means two less-ideal situations might occur:
-					// - If this provider is not currently tracked in the lock
-					//   file at all then after installation the lock file will
-					//   only accept the package that was already present in
-					//   the cache as a valid checksum. That means the generated
-					//   lock file won't be portable to other operating systems
-					//   or CPU architectures.
-					// - If the provider _is_ currently tracked in the lock file
-					//   but the checksums there don't match what was in the
-					//   cache then the LinkFromOtherCache call below will
-					//   fail with a checksum error, and the user will need to
-					//   either manually remove the entry from the lock file
-					//   or remove the mismatching item from the cache,
-					//   depending on which of these they prefer to use as the
-					//   source of truth for the expected contents of the
-					//   package.
+					// If there was no lock file entry and no verified completion
+					// metadata from an earlier installer then we need to install
+					// the package for real so that we can lock as complete as
+					// possible a set of checksums for all of this provider's packages.
 					//
-					// If the lock file already includes this provider and the
-					// cache entry matches one of the locked checksums then
-					// there's no problem, but in that case we wouldn't enter
-					// this branch because acceptablePackage would already be
-					// true from the check above.
-					log.Printf(
-						"[WARN] plugin_cache_may_break_dependency_lock_file: Using global cache dir package for %s v%s even though it doesn't match this configuration's dependency lock file",
-						provider.String(), version.String(),
-					)
-					acceptablePackage = true
-				}
-
-				// TODO: Should we emit an event through the events object
-				// for "there was an entry in the cache but we ignored it
-				// because the checksum didn't match"? We can't use
-				// LinkFromCacheFailure in that case because this isn't a
-				// failure. For now we'll just be quiet about it.
-
-				if acceptablePackage {
-					if cb := evts.LinkFromCacheBegin; cb != nil {
-						cb(provider, version, i.globalCacheDir.baseDir)
-					}
-					if _, err := cached.ExecutableFile(); err != nil {
-						err := fmt.Errorf("provider binary not found: %s", err)
-						errs[provider] = err
-						if cb := evts.LinkFromCacheFailure; cb != nil {
-							cb(provider, version, err)
+					// If there was a lock file entry but the cache doesn't match
+					// it then we assume that the lock file checksums were only
+					// partially populated (e.g. from a local mirror where we can
+					// only see one package to checksum it) and so we'll fetch
+					// from upstream to see if the origin can give us a package
+					// that _does_ match. This might still not work out, but if
+					// it does then it allows us to avoid returning a checksum
+					// mismatch error.
+					acceptablePackage := false
+					var cachedSignedHashes []getproviders.Hash
+					if len(preferredHashes) != 0 {
+						var err error
+						acceptablePackage, err = cached.MatchesAnyHash(preferredHashes)
+						if err != nil {
+							// If we can't calculate the checksum for the cached
+							// package then we'll just treat it as a checksum failure.
+							acceptablePackage = false
 						}
-						continue
-					}
-
-					err := i.targetDir.LinkFromOtherCache(cached, preferredHashes)
-					if err != nil {
-						errs[provider] = err
-						if cb := evts.LinkFromCacheFailure; cb != nil {
-							cb(provider, version, err)
+					} else {
+						metadata, err := i.globalCacheDir.readProviderCacheMetadata(provider, version)
+						if err != nil {
+							log.Printf("[WARN] Ignoring completion metadata for %s v%s in the global cache: %s", provider, version, err)
+						} else if metadata != nil {
+							cachedHash, err := cached.Hash()
+							if err != nil {
+								log.Printf("[WARN] Failed to verify completion metadata for %s v%s in the global cache: %s", provider, version, err)
+							} else if cachedHash == metadata.PackageHash {
+								acceptablePackage = true
+								cachedSignedHashes = append(cachedSignedHashes, metadata.SignedHashes...)
+								log.Printf("[TRACE] Using completed global cache entry for %s v%s", provider, version)
+							}
 						}
-						continue
-					}
-					// We'll fetch what we just linked to make sure it actually
-					// did show up there.
-					new := i.targetDir.ProviderVersion(provider, version)
-					if new == nil {
-						err := fmt.Errorf("after linking %s from provider cache at %s it is still not detected in the target directory; this is a bug in Terraform", provider, i.globalCacheDir.baseDir)
-						errs[provider] = err
-						if cb := evts.LinkFromCacheFailure; cb != nil {
-							cb(provider, version, err)
-						}
-						continue
 					}
 
-					// The LinkFromOtherCache call above should've verified that
-					// the package matches one of the hashes previously recorded,
-					// if any. We'll now augment those hashes with one freshly
-					// calculated from the package we just linked, which allows
-					// the lock file to gradually transition to recording newer hash
-					// schemes when they become available.
-					var priorHashes []getproviders.Hash
-					if lock != nil && lock.Version() == version {
-						// If the version we're installing is identical to the
-						// one we previously locked then we'll keep all of the
-						// hashes we saved previously and add to it. Otherwise
-						// we'll be starting fresh, because each version has its
-						// own set of packages and thus its own hashes.
-						priorHashes = append(priorHashes, preferredHashes...)
-
-						// NOTE: The behavior here is unfortunate when a particular
-						// provider version was already cached on the first time
-						// the current configuration requested it, because that
-						// means we don't currently get the opportunity to fetch
-						// and verify the checksums for the new package from
-						// upstream. That's currently unavoidable because upstream
-						// checksums are in the "ziphash" format and so we can't
-						// verify them against our cache directory's unpacked
-						// packages: we'd need to go fetch the package from the
-						// origin and compare against it, which would defeat the
-						// purpose of the global cache.
+					if !acceptablePackage && i.globalCacheDirMayBreakDependencyLockFile {
+						// The "may break dependency lock file" setting effectively
+						// means that we'll accept any matching package that's
+						// already in the cache, regardless of whether it matches
+						// what's in the dependency lock file.
 						//
-						// If we fetch from upstream on the first encounter with
-						// a particular provider then we'll end up in the other
-						// codepath below where we're able to also include the
-						// checksums from the origin registry.
-					}
-					newHash, err := cached.Hash()
-					if err != nil {
-						err := fmt.Errorf("after linking %s from provider cache at %s, failed to compute a checksum for it: %s", provider, i.globalCacheDir.baseDir, err)
-						errs[provider] = err
-						if cb := evts.LinkFromCacheFailure; cb != nil {
-							cb(provider, version, err)
-						}
-						continue
-					}
-					// The hashes slice gets deduplicated in the lock file
-					// implementation, so we don't worry about potentially
-					// creating a duplicate here.
-					var newHashes []getproviders.Hash
-					newHashes = append(newHashes, priorHashes...)
-					newHashes = append(newHashes, newHash)
-					locks.SetProvider(provider, version, reqs[provider], newHashes)
-					if cb := evts.ProvidersLockUpdated; cb != nil {
-						// We want to ensure that newHash and priorHashes are
-						// sorted. newHash is a single value, so it's definitely
-						// sorted. priorHashes are pulled from the lock file, so
-						// are also already sorted.
-						cb(provider, version, []getproviders.Hash{newHash}, nil, priorHashes)
+						// That means two less-ideal situations might occur:
+						// - If this provider is not currently tracked in the lock
+						//   file at all then after installation the lock file will
+						//   only accept the package that was already present in
+						//   the cache as a valid checksum. That means the generated
+						//   lock file won't be portable to other operating systems
+						//   or CPU architectures.
+						// - If the provider _is_ currently tracked in the lock file
+						//   but the checksums there don't match what was in the
+						//   cache then the LinkFromOtherCache call below will
+						//   fail with a checksum error, and the user will need to
+						//   either manually remove the entry from the lock file
+						//   or remove the mismatching item from the cache,
+						//   depending on which of these they prefer to use as the
+						//   source of truth for the expected contents of the
+						//   package.
+						//
+						// If the lock file already includes this provider and the
+						// cache entry matches one of the locked checksums then
+						// there's no problem, but in that case we wouldn't enter
+						// this branch because acceptablePackage would already be
+						// true from the check above.
+						log.Printf(
+							"[WARN] plugin_cache_may_break_dependency_lock_file: Using global cache dir package for %s v%s even though it doesn't match this configuration's dependency lock file",
+							provider.String(), version.String(),
+						)
+						acceptablePackage = true
 					}
 
-					if cb := evts.LinkFromCacheSuccess; cb != nil {
-						cb(provider, version, new.PackageDir)
+					// TODO: Should we emit an event through the events object
+					// for "there was an entry in the cache but we ignored it
+					// because the checksum didn't match"? We can't use
+					// LinkFromCacheFailure in that case because this isn't a
+					// failure. For now we'll just be quiet about it.
+
+					if acceptablePackage {
+						if cb := evts.LinkFromCacheBegin; cb != nil {
+							cb(provider, version, i.globalCacheDir.baseDir)
+						}
+						if _, err := cached.ExecutableFile(); err != nil {
+							err := fmt.Errorf("provider binary not found: %s", err)
+							errs[provider] = err
+							if cb := evts.LinkFromCacheFailure; cb != nil {
+								cb(provider, version, err)
+							}
+							return
+						}
+
+						err := i.targetDir.LinkFromOtherCache(cached, preferredHashes)
+						if err != nil {
+							errs[provider] = err
+							if cb := evts.LinkFromCacheFailure; cb != nil {
+								cb(provider, version, err)
+							}
+							return
+						}
+						// We'll fetch what we just linked to make sure it actually
+						// did show up there.
+						new := i.targetDir.ProviderVersion(provider, version)
+						if new == nil {
+							err := fmt.Errorf("after linking %s from provider cache at %s it is still not detected in the target directory; this is a bug in Terraform", provider, i.globalCacheDir.baseDir)
+							errs[provider] = err
+							if cb := evts.LinkFromCacheFailure; cb != nil {
+								cb(provider, version, err)
+							}
+							return
+						}
+
+						// The LinkFromOtherCache call above should've verified that
+						// the package matches one of the hashes previously recorded,
+						// if any. We'll now augment those hashes with one freshly
+						// calculated from the package we just linked, which allows
+						// the lock file to gradually transition to recording newer hash
+						// schemes when they become available.
+						var priorHashes []getproviders.Hash
+						if lock != nil && lock.Version() == version {
+							// If the version we're installing is identical to the
+							// one we previously locked then we'll keep all of the
+							// hashes we saved previously and add to it. Otherwise
+							// we'll be starting fresh, because each version has its
+							// own set of packages and thus its own hashes.
+							priorHashes = append(priorHashes, preferredHashes...)
+
+							// NOTE: The behavior here is unfortunate when a particular
+							// provider version was already cached on the first time
+							// the current configuration requested it, because that
+							// means we don't currently get the opportunity to fetch
+							// and verify the checksums for the new package from
+							// upstream. That's currently unavoidable because upstream
+							// checksums are in the "ziphash" format and so we can't
+							// verify them against our cache directory's unpacked
+							// packages: we'd need to go fetch the package from the
+							// origin and compare against it, which would defeat the
+							// purpose of the global cache.
+							//
+							// If we fetch from upstream on the first encounter with
+							// a particular provider then we'll end up in the other
+							// codepath below where we're able to also include the
+							// checksums from the origin registry.
+						}
+						newHash, err := cached.Hash()
+						if err != nil {
+							err := fmt.Errorf("after linking %s from provider cache at %s, failed to compute a checksum for it: %s", provider, i.globalCacheDir.baseDir, err)
+							errs[provider] = err
+							if cb := evts.LinkFromCacheFailure; cb != nil {
+								cb(provider, version, err)
+							}
+							return
+						}
+						// The hashes slice gets deduplicated in the lock file
+						// implementation, so we don't worry about potentially
+						// creating a duplicate here.
+						var newHashes []getproviders.Hash
+						newHashes = append(newHashes, priorHashes...)
+						newHashes = append(newHashes, newHash)
+						newHashes = append(newHashes, cachedSignedHashes...)
+						locks.SetProvider(provider, version, reqs[provider], newHashes)
+						if cb := evts.ProvidersLockUpdated; cb != nil {
+							// We want to ensure that newHash and priorHashes are
+							// sorted. newHash is a single value, so it's definitely
+							// sorted. priorHashes are pulled from the lock file, so
+							// are also already sorted.
+							sort.Slice(cachedSignedHashes, func(i, j int) bool {
+								return string(cachedSignedHashes[i]) < string(cachedSignedHashes[j])
+							})
+							cb(provider, version, []getproviders.Hash{newHash}, cachedSignedHashes, priorHashes)
+						}
+
+						if cb := evts.LinkFromCacheSuccess; cb != nil {
+							cb(provider, version, new.PackageDir)
+						}
+						return // Don't need to do full install, then.
 					}
-					continue // Don't need to do full install, then.
 				}
 			}
-		}
 
-		// Step 3b: Get the package metadata for the selected version from our
-		// provider source.
-		//
-		// This is the step where we might detect and report that the provider
-		// isn't available for the current platform.
-		if cb := evts.FetchPackageMeta; cb != nil {
-			cb(provider, version)
-		}
-		meta, err := i.source.PackageMeta(ctx, provider, version, targetPlatform)
-		if err != nil {
-			errs[provider] = err
-			if cb := evts.FetchPackageFailure; cb != nil {
-				cb(provider, version, err)
+			// Step 3b: Get the package metadata for the selected version from our
+			// provider source.
+			//
+			// This is the step where we might detect and report that the provider
+			// isn't available for the current platform.
+			if cb := evts.FetchPackageMeta; cb != nil {
+				cb(provider, version)
 			}
-			continue
-		}
-
-		// Step 3c: Retrieve the package indicated by the metadata we received,
-		// either directly into our target directory or via the global cache
-		// directory.
-		if cb := evts.FetchPackageBegin; cb != nil {
-			cb(provider, version, meta.Location)
-		}
-		var installTo, linkTo *Dir
-		if i.globalCacheDir != nil {
-			installTo = i.globalCacheDir
-			linkTo = i.targetDir
-		} else {
-			installTo = i.targetDir
-			linkTo = nil // no linking needed
-		}
-
-		allowedHashes := preferredHashes
-		if mode.forceInstallChecksums() {
-			allowedHashes = []getproviders.Hash{}
-		}
-
-		authResult, err := installTo.InstallPackage(ctx, meta, allowedHashes)
-		if err != nil {
-			// TODO: Consider retrying for certain kinds of error that seem
-			// likely to be transient. For now, we just treat all errors equally.
-			errs[provider] = err
-			if cb := evts.FetchPackageFailure; cb != nil {
-				cb(provider, version, err)
-			}
-			continue
-		}
-		new := installTo.ProviderVersion(provider, version)
-		if new == nil {
-			err := fmt.Errorf("after installing %s it is still not detected in %s; this is a bug in Terraform", provider, installTo.BasePath())
-			errs[provider] = err
-			if cb := evts.FetchPackageFailure; cb != nil {
-				cb(provider, version, err)
-			}
-			continue
-		}
-		if _, err := new.ExecutableFile(); err != nil {
-			err := fmt.Errorf("provider binary not found: %s", err)
-			errs[provider] = err
-			if cb := evts.FetchPackageFailure; cb != nil {
-				cb(provider, version, err)
-			}
-			continue
-		}
-		if linkTo != nil {
-			// We skip emitting the "LinkFromCache..." events here because
-			// it's simpler for the caller to treat them as mutually exclusive.
-			// We can just subsume the linking step under the "FetchPackage..."
-			// series here (and that's why we use FetchPackageFailure below).
-			// We also don't do a hash check here because we already did that
-			// as part of the installTo.InstallPackage call above.
-			err := linkTo.LinkFromOtherCache(new, nil)
+			meta, err := i.source.PackageMeta(ctx, provider, version, targetPlatform)
 			if err != nil {
 				errs[provider] = err
 				if cb := evts.FetchPackageFailure; cb != nil {
 					cb(provider, version, err)
 				}
-				continue
+				return
 			}
 
-			// We should now also find the package in the linkTo dir, which
-			// gives us the final value of "new" where the path points in to
-			// the true target directory, rather than possibly the global
-			// cache directory.
-			new = linkTo.ProviderVersion(provider, version)
-			if new == nil {
-				err := fmt.Errorf("after installing %s it is still not detected in %s; this is a bug in Terraform", provider, linkTo.BasePath())
+			// Step 3c: Retrieve the package indicated by the metadata we received,
+			// either directly into our target directory or via the global cache
+			// directory.
+			if cb := evts.FetchPackageBegin; cb != nil {
+				cb(provider, version, meta.Location)
+			}
+			var installTo, linkTo *Dir
+			if i.globalCacheDir != nil {
+				installTo = i.globalCacheDir
+				linkTo = i.targetDir
+			} else {
+				installTo = i.targetDir
+				linkTo = nil // no linking needed
+			}
+
+			allowedHashes := preferredHashes
+			if mode.forceInstallChecksums() {
+				allowedHashes = []getproviders.Hash{}
+			}
+
+			authResult, err := installTo.InstallPackage(ctx, meta, allowedHashes)
+			if err != nil {
+				// TODO: Consider retrying for certain kinds of error that seem
+				// likely to be transient. For now, we just treat all errors equally.
 				errs[provider] = err
 				if cb := evts.FetchPackageFailure; cb != nil {
 					cb(provider, version, err)
 				}
-				continue
+				return
+			}
+			new := installTo.ProviderVersion(provider, version)
+			if new == nil {
+				err := fmt.Errorf("after installing %s it is still not detected in %s; this is a bug in Terraform", provider, installTo.BasePath())
+				errs[provider] = err
+				if cb := evts.FetchPackageFailure; cb != nil {
+					cb(provider, version, err)
+				}
+				return
 			}
 			if _, err := new.ExecutableFile(); err != nil {
 				err := fmt.Errorf("provider binary not found: %s", err)
@@ -668,74 +665,119 @@ NeedProvider:
 				if cb := evts.FetchPackageFailure; cb != nil {
 					cb(provider, version, err)
 				}
-				continue
+				return
 			}
-		}
-		authResults[provider] = authResult
+			if linkTo != nil {
+				// We skip emitting the "LinkFromCache..." events here because
+				// it's simpler for the caller to treat them as mutually exclusive.
+				// We can just subsume the linking step under the "FetchPackage..."
+				// series here (and that's why we use FetchPackageFailure below).
+				// We also don't do a hash check here because we already did that
+				// as part of the installTo.InstallPackage call above.
+				err := linkTo.LinkFromOtherCache(new, nil)
+				if err != nil {
+					errs[provider] = err
+					if cb := evts.FetchPackageFailure; cb != nil {
+						cb(provider, version, err)
+					}
+					return
+				}
 
-		// The InstallPackage call above should've verified that
-		// the package matches one of the hashes previously recorded,
-		// if any. We'll now augment those hashes with a new set populated
-		// with the hashes returned by the upstream source and from the
-		// package we've just installed, which allows the lock file to
-		// gradually transition to newer hash schemes when they become
-		// available.
-		//
-		// This is assuming that if a package matches both a hash we saw before
-		// _and_ a new hash then the new hash is a valid substitute for
-		// the previous hash.
-		//
-		// The hashes slice gets deduplicated in the lock file
-		// implementation, so we don't worry about potentially
-		// creating duplicates here.
-		var priorHashes []getproviders.Hash
-		if lock != nil && lock.Version() == version {
-			// If the version we're installing is identical to the
-			// one we previously locked then we'll keep all of the
-			// hashes we saved previously and add to it. Otherwise
-			// we'll be starting fresh, because each version has its
-			// own set of packages and thus its own hashes.
-			priorHashes = append(priorHashes, preferredHashes...)
-		}
-		newHash, err := new.Hash()
-		if err != nil {
-			err := fmt.Errorf("after installing %s, failed to compute a checksum for it: %s", provider, err)
-			errs[provider] = err
-			if cb := evts.FetchPackageFailure; cb != nil {
-				cb(provider, version, err)
+				// We should now also find the package in the linkTo dir, which
+				// gives us the final value of "new" where the path points in to
+				// the true target directory, rather than possibly the global
+				// cache directory.
+				new = linkTo.ProviderVersion(provider, version)
+				if new == nil {
+					err := fmt.Errorf("after installing %s it is still not detected in %s; this is a bug in Terraform", provider, linkTo.BasePath())
+					errs[provider] = err
+					if cb := evts.FetchPackageFailure; cb != nil {
+						cb(provider, version, err)
+					}
+					return
+				}
+				if _, err := new.ExecutableFile(); err != nil {
+					err := fmt.Errorf("provider binary not found: %s", err)
+					errs[provider] = err
+					if cb := evts.FetchPackageFailure; cb != nil {
+						cb(provider, version, err)
+					}
+					return
+				}
 			}
-			continue
-		}
+			authResults[provider] = authResult
 
-		var signedHashes []getproviders.Hash
-		if authResult.SignedByAnyParty() {
-			// We'll trust new hashes from upstream only if they were verified
-			// as signed by a suitable key. Otherwise, we'd record only
-			// a new hash we just calculated ourselves from the bytes on disk,
-			// and so the hashes would cover only the current platform.
-			signedHashes = append(signedHashes, meta.AcceptableHashes()...)
-		}
+			// The InstallPackage call above should've verified that
+			// the package matches one of the hashes previously recorded,
+			// if any. We'll now augment those hashes with a new set populated
+			// with the hashes returned by the upstream source and from the
+			// package we've just installed, which allows the lock file to
+			// gradually transition to newer hash schemes when they become
+			// available.
+			//
+			// This is assuming that if a package matches both a hash we saw before
+			// _and_ a new hash then the new hash is a valid substitute for
+			// the previous hash.
+			//
+			// The hashes slice gets deduplicated in the lock file
+			// implementation, so we don't worry about potentially
+			// creating duplicates here.
+			var priorHashes []getproviders.Hash
+			if lock != nil && lock.Version() == version {
+				// If the version we're installing is identical to the
+				// one we previously locked then we'll keep all of the
+				// hashes we saved previously and add to it. Otherwise
+				// we'll be starting fresh, because each version has its
+				// own set of packages and thus its own hashes.
+				priorHashes = append(priorHashes, preferredHashes...)
+			}
+			newHash, err := new.Hash()
+			if err != nil {
+				err := fmt.Errorf("after installing %s, failed to compute a checksum for it: %s", provider, err)
+				errs[provider] = err
+				if cb := evts.FetchPackageFailure; cb != nil {
+					cb(provider, version, err)
+				}
+				return
+			}
 
-		var newHashes []getproviders.Hash
-		newHashes = append(newHashes, newHash)
-		newHashes = append(newHashes, priorHashes...)
-		newHashes = append(newHashes, signedHashes...)
-
-		locks.SetProvider(provider, version, reqs[provider], newHashes)
-		if cb := evts.ProvidersLockUpdated; cb != nil {
-			// newHash and priorHashes are already sorted.
-			// But we do need to sort signedHashes so we can reason about it
-			// sensibly.
+			var signedHashes []getproviders.Hash
+			if authResult.SignedByAnyParty() {
+				// We'll trust new hashes from upstream only if they were verified
+				// as signed by a suitable key. Otherwise, we'd record only
+				// a new hash we just calculated ourselves from the bytes on disk,
+				// and so the hashes would cover only the current platform.
+				signedHashes = append(signedHashes, meta.AcceptableHashes()...)
+			}
 			sort.Slice(signedHashes, func(i, j int) bool {
 				return string(signedHashes[i]) < string(signedHashes[j])
 			})
 
-			cb(provider, version, []getproviders.Hash{newHash}, signedHashes, priorHashes)
-		}
+			if i.globalCacheDir != nil {
+				if err := i.globalCacheDir.writeProviderCacheMetadata(provider, version, newHash, signedHashes); err != nil {
+					err := fmt.Errorf("after installing %s, failed to record its completed cache entry: %w", provider, err)
+					errs[provider] = err
+					if cb := evts.FetchPackageFailure; cb != nil {
+						cb(provider, version, err)
+					}
+					return
+				}
+			}
 
-		if cb := evts.FetchPackageSuccess; cb != nil {
-			cb(provider, version, new.PackageDir, authResult)
-		}
+			var newHashes []getproviders.Hash
+			newHashes = append(newHashes, newHash)
+			newHashes = append(newHashes, priorHashes...)
+			newHashes = append(newHashes, signedHashes...)
+
+			locks.SetProvider(provider, version, reqs[provider], newHashes)
+			if cb := evts.ProvidersLockUpdated; cb != nil {
+				cb(provider, version, []getproviders.Hash{newHash}, signedHashes, priorHashes)
+			}
+
+			if cb := evts.FetchPackageSuccess; cb != nil {
+				cb(provider, version, new.PackageDir, authResult)
+			}
+		}()
 	}
 
 	// Emit final event for fetching if any were successfully fetched

--- a/internal/providercache/installer_concurrency_test.go
+++ b/internal/providercache/installer_concurrency_test.go
@@ -1,0 +1,458 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providercache
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders"
+)
+
+func TestEnsureProviderVersionsConcurrent_samePackage(t *testing.T) {
+	provider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/aws")
+	version := getproviders.MustParseVersion("5.100.0")
+	constraints := getproviders.MustParseVersionConstraints("= 5.100.0")
+	platform := getproviders.CurrentPlatform
+
+	archive, checksum, err := getproviders.CreateFakeFileWithChecksumForProvider(
+		t, provider, version, platform, "",
+	)
+	if err != nil {
+		t.Fatalf("failed to create provider archive: %s", err)
+	}
+	archiveBytes, err := os.ReadFile(archive.Name())
+	if err != nil {
+		t.Fatalf("failed to read provider archive: %s", err)
+	}
+
+	var downloadCount atomic.Int32
+	firstRequestStarted := make(chan struct{})
+	secondRequestStarted := make(chan struct{})
+	releaseDownload := make(chan struct{})
+	var signalFirst sync.Once
+	var releaseOnce sync.Once
+	releaseDownloads := func() {
+		releaseOnce.Do(func() {
+			close(releaseDownload)
+		})
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestNumber := downloadCount.Add(1)
+		signalFirst.Do(func() {
+			close(firstRequestStarted)
+		})
+		if requestNumber == 2 {
+			close(secondRequestStarted)
+		}
+		<-releaseDownload
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(archiveBytes)
+	}))
+	defer server.Close()
+	defer releaseDownloads()
+
+	meta := getproviders.PackageMeta{
+		Provider:         provider,
+		Version:          version,
+		ProtocolVersions: getproviders.VersionList{getproviders.MustParseVersion("5.0.0")},
+		TargetPlatform:   platform,
+		Filename:         filepath.Base(archive.Name()),
+		Location:         getproviders.PackageHTTPURL(server.URL + "/terraform-provider-aws.zip"),
+		Authentication:   getproviders.NewArchiveChecksumAuthentication(platform, checksum),
+	}
+	reqs := getproviders.Requirements{
+		provider: constraints,
+	}
+	newLocks := func() *depsfile.Locks {
+		return depsfile.NewLocks()
+	}
+
+	globalCachePath := t.TempDir()
+	firstTarget := NewDirWithPlatform(t.TempDir(), platform)
+	secondTarget := NewDirWithPlatform(t.TempDir(), platform)
+	firstInstaller := NewInstaller(firstTarget, getproviders.NewMockSource([]getproviders.PackageMeta{meta}, nil))
+	firstInstaller.SetGlobalCacheDir(NewDirWithPlatform(globalCachePath, platform))
+	secondInstaller := NewInstaller(secondTarget, getproviders.NewMockSource([]getproviders.PackageMeta{meta}, nil))
+	secondInstaller.SetGlobalCacheDir(NewDirWithPlatform(globalCachePath, platform))
+
+	type installResult struct {
+		locks *depsfile.Locks
+		err   error
+	}
+	firstResult := make(chan installResult, 1)
+	secondResult := make(chan installResult, 1)
+	go func() {
+		locks, err := firstInstaller.EnsureProviderVersions(
+			context.Background(), newLocks(), reqs, InstallNewProvidersOnly,
+		)
+		firstResult <- installResult{locks: locks, err: err}
+	}()
+
+	select {
+	case <-firstRequestStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first provider download did not start")
+	}
+
+	go func() {
+		locks, err := secondInstaller.EnsureProviderVersions(
+			context.Background(), newLocks(), reqs, InstallNewProvidersOnly,
+		)
+		secondResult <- installResult{locks: locks, err: err}
+	}()
+
+	// On the unsafe implementation the second download starts while the first
+	// is blocked. With package locking it waits for the first to complete.
+	select {
+	case <-secondRequestStarted:
+	case <-time.After(500 * time.Millisecond):
+	}
+	releaseDownloads()
+
+	for name, resultCh := range map[string]<-chan installResult{
+		"first":  firstResult,
+		"second": secondResult,
+	} {
+		select {
+		case result := <-resultCh:
+			if result.err != nil {
+				t.Errorf("%s provider installation failed: %s", name, result.err)
+			}
+			if result.locks == nil || result.locks.Provider(provider) == nil {
+				t.Errorf("%s provider installation returned no dependency lock", name)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s provider installation did not complete", name)
+		}
+	}
+
+	if got, want := downloadCount.Load(), int32(1); got != want {
+		t.Fatalf("provider archive download count = %d; want %d", got, want)
+	}
+
+	globalPackagePath := getproviders.UnpackedDirectoryPathForPackage(
+		globalCachePath, provider, version, platform,
+	)
+	for name, target := range map[string]*Dir{
+		"first":  firstTarget,
+		"second": secondTarget,
+	} {
+		entry := target.ProviderVersion(provider, version)
+		if entry == nil {
+			t.Errorf("%s target has no provider cache entry", name)
+			continue
+		}
+		if runtime.GOOS != "windows" {
+			info, err := os.Lstat(filepath.FromSlash(entry.PackageDir))
+			if err != nil {
+				t.Errorf("%s target package cannot be inspected: %s", name, err)
+				continue
+			}
+			if info.Mode()&os.ModeSymlink == 0 {
+				t.Errorf("%s target package is not a symlink", name)
+			}
+		}
+		resolved, err := filepath.EvalSymlinks(filepath.FromSlash(entry.PackageDir))
+		if err != nil {
+			t.Errorf("%s target package symlink cannot be resolved: %s", name, err)
+			continue
+		}
+		wantResolved, err := filepath.EvalSymlinks(filepath.FromSlash(globalPackagePath))
+		if err != nil {
+			t.Fatalf("global package path cannot be resolved: %s", err)
+		}
+		if resolved != wantResolved {
+			t.Errorf("%s target resolves to %q; want %q", name, resolved, wantResolved)
+		}
+	}
+}
+
+func TestEnsureProviderVersionsConcurrent_differentPackages(t *testing.T) {
+	version := getproviders.MustParseVersion("5.100.0")
+	constraints := getproviders.MustParseVersionConstraints("= 5.100.0")
+	platform := getproviders.CurrentPlatform
+	awsProvider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/aws")
+	googleProvider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/google")
+
+	awsArchive, awsChecksum, err := getproviders.CreateFakeFileWithChecksumForProvider(
+		t, awsProvider, version, platform, "",
+	)
+	if err != nil {
+		t.Fatalf("failed to create AWS provider archive: %s", err)
+	}
+	awsBytes, err := os.ReadFile(awsArchive.Name())
+	if err != nil {
+		t.Fatalf("failed to read AWS provider archive: %s", err)
+	}
+	googleArchive, googleChecksum, err := getproviders.CreateFakeFileWithChecksumForProvider(
+		t, googleProvider, version, platform, "",
+	)
+	if err != nil {
+		t.Fatalf("failed to create Google provider archive: %s", err)
+	}
+	googleBytes, err := os.ReadFile(googleArchive.Name())
+	if err != nil {
+		t.Fatalf("failed to read Google provider archive: %s", err)
+	}
+
+	awsStarted := make(chan struct{})
+	googleStarted := make(chan struct{})
+	releaseAWS := make(chan struct{})
+	var signalAWS sync.Once
+	var signalGoogle sync.Once
+	var releaseOnce sync.Once
+	releaseAWSDownload := func() {
+		releaseOnce.Do(func() {
+			close(releaseAWS)
+		})
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		switch r.URL.Path {
+		case "/aws.zip":
+			signalAWS.Do(func() {
+				close(awsStarted)
+			})
+			<-releaseAWS
+			_, _ = w.Write(awsBytes)
+		case "/google.zip":
+			signalGoogle.Do(func() {
+				close(googleStarted)
+			})
+			_, _ = w.Write(googleBytes)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	defer releaseAWSDownload()
+
+	awsMeta := getproviders.PackageMeta{
+		Provider:         awsProvider,
+		Version:          version,
+		ProtocolVersions: getproviders.VersionList{getproviders.MustParseVersion("5.0.0")},
+		TargetPlatform:   platform,
+		Filename:         filepath.Base(awsArchive.Name()),
+		Location:         getproviders.PackageHTTPURL(server.URL + "/aws.zip"),
+		Authentication:   getproviders.NewArchiveChecksumAuthentication(platform, awsChecksum),
+	}
+	googleMeta := getproviders.PackageMeta{
+		Provider:         googleProvider,
+		Version:          version,
+		ProtocolVersions: getproviders.VersionList{getproviders.MustParseVersion("5.0.0")},
+		TargetPlatform:   platform,
+		Filename:         filepath.Base(googleArchive.Name()),
+		Location:         getproviders.PackageHTTPURL(server.URL + "/google.zip"),
+		Authentication:   getproviders.NewArchiveChecksumAuthentication(platform, googleChecksum),
+	}
+
+	globalCachePath := t.TempDir()
+	runInstall := func(provider addrs.Provider, meta getproviders.PackageMeta) <-chan error {
+		resultCh := make(chan error, 1)
+		targetPath := t.TempDir()
+		go func() {
+			target := NewDirWithPlatform(targetPath, platform)
+			installer := NewInstaller(target, getproviders.NewMockSource([]getproviders.PackageMeta{meta}, nil))
+			installer.SetGlobalCacheDir(NewDirWithPlatform(globalCachePath, platform))
+			_, err := installer.EnsureProviderVersions(
+				context.Background(),
+				depsfile.NewLocks(),
+				getproviders.Requirements{provider: constraints},
+				InstallNewProvidersOnly,
+			)
+			resultCh <- err
+		}()
+		return resultCh
+	}
+
+	awsResult := runInstall(awsProvider, awsMeta)
+	select {
+	case <-awsStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("AWS provider download did not start")
+	}
+
+	googleResult := runInstall(googleProvider, googleMeta)
+	select {
+	case <-googleStarted:
+		// The Google package has a different lock identity and must not wait.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Google provider download was blocked by AWS provider download")
+	}
+	releaseAWSDownload()
+
+	for name, resultCh := range map[string]<-chan error{
+		"AWS":    awsResult,
+		"Google": googleResult,
+	} {
+		select {
+		case err := <-resultCh:
+			if err != nil {
+				t.Errorf("%s provider installation failed: %s", name, err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s provider installation did not complete", name)
+		}
+	}
+}
+
+func TestEnsureProviderVersionsConcurrent_failedInstallReleasesLock(t *testing.T) {
+	provider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/aws")
+	version := getproviders.MustParseVersion("5.100.0")
+	constraints := getproviders.MustParseVersionConstraints("= 5.100.0")
+	platform := getproviders.CurrentPlatform
+
+	archive, checksum, err := getproviders.CreateFakeFileWithChecksumForProvider(
+		t, provider, version, platform, "",
+	)
+	if err != nil {
+		t.Fatalf("failed to create provider archive: %s", err)
+	}
+	archiveBytes, err := os.ReadFile(archive.Name())
+	if err != nil {
+		t.Fatalf("failed to read provider archive: %s", err)
+	}
+	packageHash, err := getproviders.PackageHashV1(getproviders.PackageLocalArchive(archive.Name()))
+	if err != nil {
+		t.Fatalf("failed to calculate provider package hash: %s", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		switch r.URL.Path {
+		case "/bad.zip":
+			_, _ = w.Write([]byte("not the expected provider archive"))
+		case "/good.zip":
+			_, _ = w.Write(archiveBytes)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	meta := func(path string) getproviders.PackageMeta {
+		return getproviders.PackageMeta{
+			Provider:         provider,
+			Version:          version,
+			ProtocolVersions: getproviders.VersionList{getproviders.MustParseVersion("5.0.0")},
+			TargetPlatform:   platform,
+			Filename:         filepath.Base(archive.Name()),
+			Location:         getproviders.PackageHTTPURL(server.URL + path),
+			Authentication:   getproviders.NewArchiveChecksumAuthentication(platform, checksum),
+		}
+	}
+	newLocks := func() *depsfile.Locks {
+		locks := depsfile.NewLocks()
+		locks.SetProvider(provider, version, constraints, []getproviders.Hash{packageHash})
+		return locks
+	}
+	globalCachePath := t.TempDir()
+	runInstall := func(ctx context.Context, packageMeta getproviders.PackageMeta) error {
+		target := NewDirWithPlatform(t.TempDir(), platform)
+		installer := NewInstaller(target, getproviders.NewMockSource([]getproviders.PackageMeta{packageMeta}, nil))
+		installer.SetGlobalCacheDir(NewDirWithPlatform(globalCachePath, platform))
+		_, err := installer.EnsureProviderVersions(
+			ctx,
+			newLocks(),
+			getproviders.Requirements{provider: constraints},
+			InstallNewProvidersOnly,
+		)
+		return err
+	}
+
+	if err := runInstall(context.Background(), meta("/bad.zip")); err == nil {
+		t.Fatal("checksum-mismatching provider installation succeeded")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := runInstall(ctx, meta("/good.zip")); err != nil {
+		t.Fatalf("valid provider installation failed after prior failure: %s", err)
+	}
+}
+
+func TestEnsureProviderVersionsConcurrent_waitHonorsCancellation(t *testing.T) {
+	provider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/aws")
+	version := getproviders.MustParseVersion("5.100.0")
+	constraints := getproviders.MustParseVersionConstraints("= 5.100.0")
+	platform := getproviders.CurrentPlatform
+	globalCachePath := t.TempDir()
+
+	globalCache := NewDirWithPlatform(globalCachePath, platform)
+	unlock, err := globalCache.lockProviderVersion(context.Background(), provider, version)
+	if err != nil {
+		t.Fatalf("failed to acquire provider lock: %s", err)
+	}
+	defer func() {
+		_ = unlock()
+	}()
+
+	meta, err := getproviders.FakeInstallablePackageMeta(
+		t,
+		provider,
+		version,
+		getproviders.VersionList{getproviders.MustParseVersion("5.0.0")},
+		platform,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("failed to create provider metadata: %s", err)
+	}
+	packageHash, err := getproviders.PackageHashV1(meta.Location)
+	if err != nil {
+		t.Fatalf("failed to calculate provider package hash: %s", err)
+	}
+	locks := depsfile.NewLocks()
+	locks.SetProvider(provider, version, constraints, []getproviders.Hash{packageHash})
+
+	installer := NewInstaller(
+		NewDirWithPlatform(t.TempDir(), platform),
+		getproviders.NewMockSource([]getproviders.PackageMeta{meta}, nil),
+	)
+	installer.SetGlobalCacheDir(NewDirWithPlatform(globalCachePath, platform))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := installer.EnsureProviderVersions(
+			ctx,
+			locks,
+			getproviders.Requirements{provider: constraints},
+			InstallNewProvidersOnly,
+		)
+		resultCh <- err
+	}()
+
+	select {
+	case err := <-resultCh:
+		t.Fatalf("installer returned before cancellation: %v", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		var installerErr InstallerError
+		if !errors.As(err, &installerErr) {
+			t.Fatalf("installer error type = %T; want InstallerError", err)
+		}
+		if !errors.Is(installerErr.ProviderErrors[provider], context.Canceled) {
+			t.Fatalf("provider lock error = %v; want context.Canceled", installerErr.ProviderErrors[provider])
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("installer did not return after cancellation")
+	}
+}


### PR DESCRIPTION
## Description

Terraform's global provider plugin cache (`plugin_cache_dir` / `TF_PLUGIN_CACHE_DIR`)
is not safe for use by multiple Terraform processes at once. When several
`terraform init` runs share a single cache directory — common in CI, monorepos,
and parallel-workspace automation — they can race while downloading and unpacking
the same provider package into the same location, producing corrupted cache
entries, checksum-mismatch errors, or partially written packages.

This PR makes the shared global cache safe for concurrent use by introducing
provider-package-scoped advisory file locking, so cooperating Terraform
processes can share one cache without stepping on each other.

### What changed

- **Per-package advisory locks** (`internal/providercache/dir_lock.go`): before an
  installer reads from or writes to the global cache for a given
  provider+version+platform, it acquires an advisory file lock
  (`github.com/gofrs/flock`) on a `.lock` file next to that package's unpacked
  directory. The lock is scoped to the exact package, so unrelated providers still
  install fully in parallel — only concurrent installs of the *same* package
  serialize. Lock acquisition honors context cancellation. The lock file is left
  in place after unlock so all contenders coordinate through the same filesystem
  object.
- **Completion metadata** (`internal/providercache/dir_lock.go`): a successful
  install atomically writes a `<package>.metadata.json` recording the verified
  package hash and any upstream-signed hashes. A later process that finds the
  package already cached (with no matching dependency-lock entry to check against)
  can verify the on-disk hash against this metadata and reuse the recorded signed
  hashes instead of re-downloading from upstream just to recover portable
  checksums. This keeps cross-platform lock-file portability intact across
  processes.
- **Installer integration** (`internal/providercache/installer.go`): the
  per-provider install body is wrapped so the lock is held around the whole
  global-cache read/link/install sequence and released via `defer` before the next
  provider is processed. After acquiring the lock the in-memory `metaCache` is
  invalidated, because another process may have populated the package while this
  one was waiting.
- **Docs** (`internal/providercache/dir.go`): updated the `Dir` / `NewDir`
  concurrency contract to reflect that the installer now coordinates separate
  processes sharing a directory as a global cache. A single `Dir` is still not safe
  for direct concurrent method calls, and using a directory as both a cache and a
  filesystem-mirror source remains undefined.
- **Dependency** (`go.mod`): promotes `github.com/gofrs/flock` from an indirect to
  a direct dependency (it is already present in the module graph).

### Scope / limitations

- The lock coordinates *cooperating* Terraform processes. It does not defend
  against unrelated tools mutating the cache directory concurrently.
- Lock files (`.lock`) and completion metadata (`.metadata.json`) are siblings of
  the unpacked package directory. They are safely ignored by
  `getproviders.SearchLocalDirectory` (they are files at the platform-directory
  level, not directories), so they do not register as spurious provider packages.

### Tests

- `dir_lock_test.go`: same-package locks serialize; different packages don't block;
  waiting respects context cancellation.
- `installer_concurrency_test.go`: concurrent installers sharing a cache download a
  package only once and both link it; different packages install in parallel; a
  failed install releases the lock so a later run succeeds; cancellation propagates
  as a provider install error.

Fixes #31964
Fixes #32901

## Target Release

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to access controls, encryption, or logging. The new `.metadata.json`
completion file records verified hashes for packages already present in the local
cache directory; it is trusted at the same level as the cache directory contents
themselves (a party able to write to the cache can already substitute package
bytes). New `[TRACE]` log lines record lock acquire/release and cache-completion
decisions.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
