### PR TITLE
refactor: Move user-facing init message codes into centralised location, stop using them to access message strings - Part 3

### DIFF
--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -447,7 +447,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	view.Diagnostics(diags)
 	_, cloud := back.(*cloud.Cloud)
 	if cloud {
-		view.Output(views.OutputInitSuccessCloudMessage)
+		view.LogInitSuccessCloud()
 	} else {
 		view.LogInitSuccess()
 	}

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -446,18 +446,17 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	// still the final thing shown.
 	view.Diagnostics(diags)
 	_, cloud := back.(*cloud.Cloud)
-	output := views.OutputInitSuccessMessage
 	if cloud {
-		output = views.OutputInitSuccessCloudMessage
+		view.Output(views.OutputInitSuccessCloudMessage)
+	} else {
+		view.LogInitSuccess()
 	}
-
-	view.Output(output)
 
 	if !c.RunningInAutomation {
 		// If we're not running in an automation wrapper, give the user
 		// some more detailed next steps that are appropriate for interactive
 		// shell usage.
-		output = views.OutputInitSuccessCLIMessage
+		output := views.OutputInitSuccessCLIMessage
 		if cloud {
 			output = views.OutputInitSuccessCLICloudMessage
 		}

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -110,7 +110,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		return 1
 	}
 	if empty {
-		view.Output(views.OutputInitEmptyMessage)
+		view.LogInitSuccessEmpty()
 		return 0
 	}
 

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -456,11 +456,11 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		// If we're not running in an automation wrapper, give the user
 		// some more detailed next steps that are appropriate for interactive
 		// shell usage.
-		output := views.OutputInitSuccessCLIMessage
 		if cloud {
-			output = views.OutputInitSuccessCLICloudMessage
+			view.LogCallToActionCLICloud()
+		} else {
+			view.LogCallToActionCLI()
 		}
-		view.Output(output)
 	}
 	return 0
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -123,7 +123,7 @@ func TestInit_only_test_files(t *testing.T) {
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", done(t).All())
 	}
-	exp := views.MessageRegistry[views.OutputInitSuccessCLIMessage].JSONValue
+	exp := "You may now begin working with Terraform"
 	actual := cleanString(done(t).All())
 	if !strings.Contains(actual, cleanString(exp)) {
 		t.Fatalf("expected output to be %q\n, got %q", exp, actual)
@@ -139,7 +139,7 @@ func TestInit_two_source_provider_download(t *testing.T) {
 		"providers required by only the state file": {
 			workDirPath: "init-provider-download/state-file-only",
 			expectedDownloadMsgs: []string{
-				views.MessageRegistry[views.OutputInitSuccessCLIMessage].JSONValue,
+				"You may now begin working with Terraform",
 				`Initializing the backend...
 				Successfully configured the backend "local"!`, // No providers found in the configuration so next output is backend-related
 				`Initializing provider plugins...
@@ -150,7 +150,7 @@ func TestInit_two_source_provider_download(t *testing.T) {
 		"different providers required by config and state": {
 			workDirPath: "init-provider-download/config-and-state-different-providers",
 			expectedDownloadMsgs: []string{
-				views.MessageRegistry[views.OutputInitSuccessCLIMessage].JSONValue,
+				"You may now begin working with Terraform",
 				"Initializing provider plugins...",
 				// Config - null provider is affected by a version constraint
 				`- Finding hashicorp/null versions matching "< 9.0.0"...`,

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -92,7 +92,7 @@ func TestInit_empty(t *testing.T) {
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", done(t).All())
 	}
-	exp := views.MessageRegistry[views.OutputInitEmptyMessage].JSONValue
+	exp := "Terraform initialized in an empty directory!"
 	actual := cleanString(done(t).All())
 	if !strings.Contains(actual, cleanString(exp)) {
 		t.Fatalf("expected output to be %q\n, got %q", exp, actual)

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -42,6 +42,9 @@ type Init interface {
 	// LogInitSuccess reports a successful init command completing
 	LogInitSuccess()
 
+	// LogInitSuccessEmpty reports a successful init command completing, but notes that the config was empty
+	LogInitSuccessEmpty()
+
 	ModuleInstallationLogger
 	ProviderInstallationLogger
 	ProviderLockingLogger
@@ -122,6 +125,11 @@ func (v *InitHuman) LogInitializingHCPTerraformStart() {
 
 func (v *InitHuman) LogInitSuccess() {
 	msg := strings.TrimSpace(outputInitSuccess)
+	v.print(msg)
+}
+
+func (v *InitHuman) LogInitSuccessEmpty() {
+	msg := strings.TrimSpace(outputInitEmpty)
 	v.print(msg)
 }
 
@@ -349,6 +357,11 @@ func (v *InitJSON) LogInitSuccess() {
 	v.initOutputLog(msg, json.MessageOutputInitSuccessMessage)
 }
 
+func (v *InitJSON) LogInitSuccessEmpty() {
+	msg := strings.TrimSpace(outputInitEmptyJSON)
+	v.initOutputLog(msg, json.MessageOutputInitEmptyMessage)
+}
+
 // logInitMessage is an internalised version of an old method `LogInitMessage`.
 // New methods have since been added that replace the old `LogInitMessage` method,
 // but to ensure that the same JSON output is produced we keep `logInitMessage` to
@@ -554,10 +567,6 @@ type InitMessage struct {
 }
 
 var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMessage{
-	"output_init_empty_message": {
-		HumanValue: outputInitEmpty,
-		JSONValue:  outputInitEmptyJSON,
-	},
 	"output_init_success_cloud_message": {
 		HumanValue: outputInitSuccessCloud,
 		JSONValue:  outputInitSuccessCloudJSON,
@@ -658,7 +667,6 @@ const (
 	// Following message codes are used and documented EXTERNALLY
 	// Keep docs/internals/machine-readable-ui.mdx up to date with
 	// this list when making changes here.
-	OutputInitEmptyMessage           InitMessageCode = "output_init_empty_message"
 	OutputInitSuccessCloudMessage    InitMessageCode = "output_init_success_cloud_message"
 	OutputInitSuccessCLIMessage      InitMessageCode = "output_init_success_cli_message"
 	OutputInitSuccessCLICloudMessage InitMessageCode = "output_init_success_cli_cloud_message"

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -39,6 +39,9 @@ type Init interface {
 	// LogInitializingHCPTerraformStart indicates progress initializing the `cloud` backend.
 	LogInitializingHCPTerraformStart()
 
+	// LogInitSuccess reports a successful init command completing
+	LogInitSuccess()
+
 	ModuleInstallationLogger
 	ProviderInstallationLogger
 	ProviderLockingLogger
@@ -114,6 +117,11 @@ func (v *InitHuman) LogInitializingBackendStart() {
 
 func (v *InitHuman) LogInitializingHCPTerraformStart() {
 	msg := "\n[reset][bold]Initializing HCP Terraform..."
+	v.print(msg)
+}
+
+func (v *InitHuman) LogInitSuccess() {
+	msg := strings.TrimSpace(outputInitSuccess)
 	v.print(msg)
 }
 
@@ -336,6 +344,11 @@ func (v *InitJSON) LogInitializingHCPTerraformStart() {
 	v.initOutputLog(msg, json.MessageInitializingTerraformCloudMessage)
 }
 
+func (v *InitJSON) LogInitSuccess() {
+	msg := strings.TrimSpace(outputInitSuccessJSON)
+	v.initOutputLog(msg, json.MessageOutputInitSuccessMessage)
+}
+
 // logInitMessage is an internalised version of an old method `LogInitMessage`.
 // New methods have since been added that replace the old `LogInitMessage` method,
 // but to ensure that the same JSON output is produced we keep `logInitMessage` to
@@ -545,10 +558,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: outputInitEmpty,
 		JSONValue:  outputInitEmptyJSON,
 	},
-	"output_init_success_message": {
-		HumanValue: outputInitSuccess,
-		JSONValue:  outputInitSuccessJSON,
-	},
 	"output_init_success_cloud_message": {
 		HumanValue: outputInitSuccessCloud,
 		JSONValue:  outputInitSuccessCloudJSON,
@@ -650,7 +659,6 @@ const (
 	// Keep docs/internals/machine-readable-ui.mdx up to date with
 	// this list when making changes here.
 	OutputInitEmptyMessage           InitMessageCode = "output_init_empty_message"
-	OutputInitSuccessMessage         InitMessageCode = "output_init_success_message"
 	OutputInitSuccessCloudMessage    InitMessageCode = "output_init_success_cloud_message"
 	OutputInitSuccessCLIMessage      InitMessageCode = "output_init_success_cli_message"
 	OutputInitSuccessCLICloudMessage InitMessageCode = "output_init_success_cli_cloud_message"

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -42,6 +42,9 @@ type Init interface {
 	// LogInitSuccess reports a successful init command completing
 	LogInitSuccess()
 
+	// LogInitSuccessCloud is just like LogInitSuccess but uses HCP Terraform-specific language
+	LogInitSuccessCloud()
+
 	// LogInitSuccessEmpty reports a successful init command completing, but notes that the config was empty
 	LogInitSuccessEmpty()
 
@@ -125,6 +128,11 @@ func (v *InitHuman) LogInitializingHCPTerraformStart() {
 
 func (v *InitHuman) LogInitSuccess() {
 	msg := strings.TrimSpace(outputInitSuccess)
+	v.print(msg)
+}
+
+func (v *InitHuman) LogInitSuccessCloud() {
+	msg := strings.TrimSpace(outputInitSuccessCloud)
 	v.print(msg)
 }
 
@@ -357,6 +365,11 @@ func (v *InitJSON) LogInitSuccess() {
 	v.initOutputLog(msg, json.MessageOutputInitSuccessMessage)
 }
 
+func (v *InitJSON) LogInitSuccessCloud() {
+	msg := strings.TrimSpace(outputInitSuccessCloudJSON)
+	v.initOutputLog(msg, json.MessageOutputInitSuccessCloudMessage)
+}
+
 func (v *InitJSON) LogInitSuccessEmpty() {
 	msg := strings.TrimSpace(outputInitEmptyJSON)
 	v.initOutputLog(msg, json.MessageOutputInitEmptyMessage)
@@ -567,10 +580,6 @@ type InitMessage struct {
 }
 
 var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMessage{
-	"output_init_success_cloud_message": {
-		HumanValue: outputInitSuccessCloud,
-		JSONValue:  outputInitSuccessCloudJSON,
-	},
 	"output_init_success_cli_message": {
 		HumanValue: outputInitSuccessCLI,
 		JSONValue:  outputInitSuccessCLI_JSON,
@@ -667,7 +676,6 @@ const (
 	// Following message codes are used and documented EXTERNALLY
 	// Keep docs/internals/machine-readable-ui.mdx up to date with
 	// this list when making changes here.
-	OutputInitSuccessCloudMessage    InitMessageCode = "output_init_success_cloud_message"
 	OutputInitSuccessCLIMessage      InitMessageCode = "output_init_success_cli_message"
 	OutputInitSuccessCLICloudMessage InitMessageCode = "output_init_success_cli_cloud_message"
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -48,6 +48,12 @@ type Init interface {
 	// LogInitSuccessEmpty reports a successful init command completing, but notes that the config was empty
 	LogInitSuccessEmpty()
 
+	// LogCallToActionCLI is used when Terraform is not running in automation and prompt users about using the primary workflow
+	LogCallToActionCLI()
+
+	// LogCallToActionCLICloud is just like LogCallToActionCLI but uses HCP Terraform-specific language
+	LogCallToActionCLICloud()
+
 	ModuleInstallationLogger
 	ProviderInstallationLogger
 	ProviderLockingLogger
@@ -138,6 +144,16 @@ func (v *InitHuman) LogInitSuccessCloud() {
 
 func (v *InitHuman) LogInitSuccessEmpty() {
 	msg := strings.TrimSpace(outputInitEmpty)
+	v.print(msg)
+}
+
+func (v *InitHuman) LogCallToActionCLI() {
+	msg := strings.TrimSpace(outputInitSuccessCLI)
+	v.print(msg)
+}
+
+func (v *InitHuman) LogCallToActionCLICloud() {
+	msg := strings.TrimSpace(outputInitSuccessCLICloud)
 	v.print(msg)
 }
 
@@ -375,6 +391,16 @@ func (v *InitJSON) LogInitSuccessEmpty() {
 	v.initOutputLog(msg, json.MessageOutputInitEmptyMessage)
 }
 
+func (v *InitJSON) LogCallToActionCLI() {
+	msg := strings.TrimSpace(outputInitSuccessCLI_JSON)
+	v.initOutputLog(msg, json.MessageOutputInitSuccessCLIMessage)
+}
+
+func (v *InitJSON) LogCallToActionCLICloud() {
+	msg := strings.TrimSpace(outputInitSuccessCLICloudJSON)
+	v.initOutputLog(msg, json.MessageOutputInitSuccessCLICloudMessage)
+}
+
 // logInitMessage is an internalised version of an old method `LogInitMessage`.
 // New methods have since been added that replace the old `LogInitMessage` method,
 // but to ensure that the same JSON output is produced we keep `logInitMessage` to
@@ -580,14 +606,6 @@ type InitMessage struct {
 }
 
 var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMessage{
-	"output_init_success_cli_message": {
-		HumanValue: outputInitSuccessCLI,
-		JSONValue:  outputInitSuccessCLI_JSON,
-	},
-	"output_init_success_cli_cloud_message": {
-		HumanValue: outputInitSuccessCLICloud,
-		JSONValue:  outputInitSuccessCLICloudJSON,
-	},
 	"provider_already_installed_message": {
 		HumanValue: logProviderVersionAlreadyInstalledHuman,
 		JSONValue:  logProviderVersionAlreadyInstalledJSON,
@@ -676,8 +694,6 @@ const (
 	// Following message codes are used and documented EXTERNALLY
 	// Keep docs/internals/machine-readable-ui.mdx up to date with
 	// this list when making changes here.
-	OutputInitSuccessCLIMessage      InitMessageCode = "output_init_success_cli_message"
-	OutputInitSuccessCLICloudMessage InitMessageCode = "output_init_success_cli_cloud_message"
 
 	//// Message codes below are ONLY used INTERNALLY (for now)
 

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -958,6 +958,29 @@ func TestNewInit_LogInitializingHCPTerraformStart_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogInitSuccess_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogInitSuccess()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Terraform has been successfully initialized!"`,
+		`"@module":"terraform.ui"`,
+		`"message_code":"output_init_success_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -981,6 +981,29 @@ func TestNewInit_LogInitSuccess_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogInitSuccessCloud_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogInitSuccessCloud()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"HCP Terraform has been successfully initialized!"`,
+		`"@module":"terraform.ui"`,
+		`"message_code":"output_init_success_cloud_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_LogInitSuccessEmpty_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -1027,6 +1027,52 @@ func TestNewInit_LogInitSuccessEmpty_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogCallToActionCLI_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogCallToActionCLI()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"You may now begin working with Terraform. Try running \"terraform plan\"`, // @message : we don't assert the full contents due to size
+		`"@module":"terraform.ui"`,
+		`"message_code":"output_init_success_cli_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
+func TestNewInit_LogCallToActionCLICloud_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogCallToActionCLICloud()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"You may now begin working with HCP Terraform. Try running \"terraform plan\"`, // @message : we don't assert the full contents due to size
+		`"@module":"terraform.ui"`,
+		`"message_code":"output_init_success_cli_cloud_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -981,6 +981,29 @@ func TestNewInit_LogInitSuccess_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogInitSuccessEmpty_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogInitSuccessEmpty()
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Terraform initialized in an empty directory!`, // @message : we don't assert the full contents due to size
+		`"@module":"terraform.ui"`,
+		`"message_code":"output_init_empty_message"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -109,6 +109,7 @@ const (
 	// and changes are potentially breaking.
 	MessageCopyingConfigurationMessage       MessageType = "copying_configuration_message"
 	MessageOutputInitSuccessMessage          MessageType = "output_init_success_message"
+	MessageOutputInitEmptyMessage            MessageType = "output_init_empty_message"
 	MessageUpgradingModulesMessage           MessageType = "upgrading_modules_message"
 	MessageInitializingTerraformCloudMessage MessageType = "initializing_terraform_cloud_message"
 	MessageInitializingModulesMessage        MessageType = "initializing_modules_message"

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -110,6 +110,7 @@ const (
 	MessageCopyingConfigurationMessage       MessageType = "copying_configuration_message"
 	MessageOutputInitSuccessMessage          MessageType = "output_init_success_message"
 	MessageOutputInitEmptyMessage            MessageType = "output_init_empty_message"
+	MessageOutputInitSuccessCloudMessage     MessageType = "output_init_success_cloud_message"
 	MessageUpgradingModulesMessage           MessageType = "upgrading_modules_message"
 	MessageInitializingTerraformCloudMessage MessageType = "initializing_terraform_cloud_message"
 	MessageInitializingModulesMessage        MessageType = "initializing_modules_message"

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -108,6 +108,7 @@ const (
 	// elsewhere in the CLI. For now these consts are here to demonstrate that they're public-facing
 	// and changes are potentially breaking.
 	MessageCopyingConfigurationMessage       MessageType = "copying_configuration_message"
+	MessageOutputInitSuccessMessage          MessageType = "output_init_success_message"
 	MessageUpgradingModulesMessage           MessageType = "upgrading_modules_message"
 	MessageInitializingTerraformCloudMessage MessageType = "initializing_terraform_cloud_message"
 	MessageInitializingModulesMessage        MessageType = "initializing_modules_message"

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -119,4 +119,7 @@ const (
 	MessageInitializingProviderPluginMessage MessageType = "initializing_provider_plugin_message"
 	MessageLockInfo                          MessageType = "lock_info"
 	MessageDependenciesLockChangesInfo       MessageType = "dependencies_lock_changes_info"
+	// TODO - Remove these and their JSON output; machine readable output does not need calls to action
+	MessageOutputInitSuccessCLIMessage      MessageType = "output_init_success_cli_message"
+	MessageOutputInitSuccessCLICloudMessage MessageType = "output_init_success_cli_cloud_message"
 )


### PR DESCRIPTION
This PR is part of removing the use of `prepareMessage` and the message registry map when producing output for the `init` command.

For each commit (this may be worth reviewing commit-by-commit) I remove an entry from the map and remove the const used to access values from the map. Instead, methods implemented on the human and JSON views have the template for the message declared inside the method.

Previously this wasn't possible because there were 2 methods used to produce logs from init, but now there is a method per event to be logged.

There is no user-facing change in the JSON output, this is just a refactor.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
