### PR TITLE
refactor: Move user-facing init message codes into centralised location, stop using them to access message strings - Part 4

### DIFF
--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -1830,7 +1830,7 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 	// message is handled as part of the final init message
 	if _, ok := b.(*cloud.Cloud); !ok {
 		view := views.NewInit(vt, m.View)
-		view.Output(views.BackendConfiguredSuccessMessage, s.Backend.Type)
+		view.LogBackendConfiguredSuccess(s.Backend.Type)
 	}
 
 	return b, diags
@@ -1957,7 +1957,7 @@ func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *clista
 		// message is handled as part of the final init message
 		if _, ok := b.(*cloud.Cloud); !ok {
 			view := views.NewInit(vt, m.View)
-			view.Output(views.BackendConfiguredSuccessMessage, s.Backend.Type)
+			view.LogBackendConfiguredSuccess(s.Backend.Type)
 		}
 	}
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -54,6 +54,9 @@ type Init interface {
 	// LogCallToActionCLICloud is just like LogCallToActionCLI but uses HCP Terraform-specific language
 	LogCallToActionCLICloud()
 
+	// LogBackendConfiguredSuccess reports that the backend was successfully configured.
+	LogBackendConfiguredSuccess(backendType string)
+
 	ModuleInstallationLogger
 	ProviderInstallationLogger
 	ProviderLockingLogger
@@ -154,6 +157,11 @@ func (v *InitHuman) LogCallToActionCLI() {
 
 func (v *InitHuman) LogCallToActionCLICloud() {
 	msg := strings.TrimSpace(outputInitSuccessCLICloud)
+	v.print(msg)
+}
+
+func (v *InitHuman) LogBackendConfiguredSuccess(backendType string) {
+	msg := fmt.Sprintf(strings.TrimSpace(backendConfiguredSuccessHuman), backendType)
 	v.print(msg)
 }
 
@@ -399,6 +407,11 @@ func (v *InitJSON) LogCallToActionCLI() {
 func (v *InitJSON) LogCallToActionCLICloud() {
 	msg := strings.TrimSpace(outputInitSuccessCLICloudJSON)
 	v.initOutputLog(msg, json.MessageOutputInitSuccessCLICloudMessage)
+}
+
+func (v *InitJSON) LogBackendConfiguredSuccess(backendType string) {
+	msg := fmt.Sprintf(strings.TrimSpace(backendConfiguredSuccessJSON), backendType)
+	v.initOutputLog(msg, json.MessageBackendConfiguredSuccess)
 }
 
 // logInitMessage is an internalised version of an old method `LogInitMessage`.
@@ -650,10 +663,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "Migrating from %q state store to %q backend.",
 		JSONValue:  "Migrating from %q state store to %q backend.",
 	},
-	"backend_configured_success": {
-		HumanValue: backendConfiguredSuccessHuman,
-		JSONValue:  backendConfiguredSuccessJSON,
-	},
 	"backend_configured_unset": {
 		HumanValue: backendConfiguredUnsetHuman,
 		JSONValue:  backendConfiguredUnsetJSON,
@@ -697,8 +706,6 @@ const (
 
 	//// Message codes below are ONLY used INTERNALLY (for now)
 
-	// BackendConfiguredSuccessMessage indicates successful backend configuration
-	BackendConfiguredSuccessMessage InitMessageCode = "backend_configured_success"
 	// BackendConfiguredUnsetMessage indicates successful backend unsetting
 	BackendConfiguredUnsetMessage InitMessageCode = "backend_configured_unset"
 	// BackendMigrateToCloudMessage indicates migration to HCP Terraform

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -700,10 +700,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 type InitMessageCode string
 
 const (
-	// Following message codes are used and documented EXTERNALLY
-	// Keep docs/internals/machine-readable-ui.mdx up to date with
-	// this list when making changes here.
-
 	//// Message codes below are ONLY used INTERNALLY (for now)
 
 	// BackendConfiguredUnsetMessage indicates successful backend unsetting

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -1073,6 +1073,29 @@ func TestNewInit_LogCallToActionCLICloud_json(t *testing.T) {
 	}
 }
 
+func TestNewInit_LogBackendConfiguredSuccess_json(t *testing.T) {
+	streams, done := terminal.StreamsForTesting(t)
+	view := NewView(streams)
+	initView := NewInit(arguments.ViewJSON, view)
+
+	initView.LogBackendConfiguredSuccess("s3")
+
+	// Assert output
+	output := done(t)
+	expectedOutputFields := []string{
+		`"@level":"info"`,
+		`"@message":"Successfully configured the backend \"s3\"! Terraform will automatically\nuse this backend unless the backend configuration changes."`,
+		`"@module":"terraform.ui"`,
+		`"message_code":"backend_configured_success"`,
+		`"type":"init_output"`,
+	}
+	for _, snippet := range expectedOutputFields {
+		if !strings.Contains(output.Stdout(), snippet) {
+			t.Fatalf("output didn't include expected snippet:\n expected: %s\n got:\n %s", snippet, output.Stdout())
+		}
+	}
+}
+
 func TestNewInit_Spacer_json(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	view := NewView(streams)

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -122,4 +122,5 @@ const (
 	// TODO - Remove these and their JSON output; machine readable output does not need calls to action
 	MessageOutputInitSuccessCLIMessage      MessageType = "output_init_success_cli_message"
 	MessageOutputInitSuccessCLICloudMessage MessageType = "output_init_success_cli_cloud_message"
+	MessageBackendConfiguredSuccess         MessageType = "backend_configured_success"
 )


### PR DESCRIPTION
This stack of PRs has moved all public-facing constant strings used in JSON output into ./internal/command//views/json.

There was one message code that wasn't flagged as user-facing but is, which is moved in this PR.

Once that's done we're finished - all 'codes' listed in views/init.go are now purely internal. 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
