### PR TITLE
configs: discover dot-prefixed query files

### DIFF
--- a/.changes/v1.17/BUG FIXES-20260907-193000.yaml
+++ b/.changes/v1.17/BUG FIXES-20260907-193000.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: "query: `terraform query` now discovers `.tfquery.hcl` query files whose names begin with a dot, which were previously skipped as hidden files and reported as \"No resources to query\"."
+time: 2026-09-07T19:30:00Z
+custom:
+  Issue: "39151"

--- a/internal/configs/parser_config_dir_test.go
+++ b/internal/configs/parser_config_dir_test.go
@@ -181,6 +181,11 @@ func TestParserLoadConfigDirWithQueries(t *testing.T) {
 			managedResources: 1,
 		},
 		{
+			name:          "dot-prefixed query file",
+			directory:     "testdata/query-files/valid/dot-prefixed",
+			listResources: 1,
+		},
+		{
 			name:             "loading query lists with no-experiments",
 			directory:        "testdata/query-files/valid/mixed",
 			managedResources: 1,

--- a/internal/configs/parser_file_matcher.go
+++ b/internal/configs/parser_file_matcher.go
@@ -103,11 +103,19 @@ func (p *Parser) rootFiles(dir string, matchers []FileMatcher, fileSet *ConfigFi
 	}
 
 	for _, info := range infos {
-		if info.IsDir() || IsIgnoredFile(info.Name()) {
+		if info.IsDir() {
 			continue
 		}
 
 		name := info.Name()
+
+		// Query files (.tfquery.hcl) and state migration files (.tfmigrate.hcl)
+		// legitimately begin with a dot, so they must not be filtered out by the
+		// hidden-file check below.
+		if IsIgnoredFile(name) && !isDotPrefixedConfigFile(name) {
+			continue
+		}
+
 		fullPath := filepath.Join(dir, name)
 
 		// Try each matcher to see if it matches
@@ -266,4 +274,14 @@ func (s *stateMigrateFiles) Matches(name string) bool {
 func (s *stateMigrateFiles) DirFiles(dir string, options *parserConfig, fileSet *ConfigFileSet) hcl.Diagnostics {
 	// There are no special directories for .tfmigrate.hcl files.
 	return nil
+}
+
+// isDotPrefixedConfigFile returns true if name is a Terraform configuration
+// file whose conventional name begins with a dot, such as ".tfquery.hcl" or
+// ".tfmigrate.hcl". These are matched by their suffix, but must not be skipped
+// by the hidden-file heuristic that otherwise ignores dot-prefixed names.
+func isDotPrefixedConfigFile(name string) bool {
+	return strings.HasSuffix(name, ".tfquery.hcl") ||
+		strings.HasSuffix(name, ".tfquery.json") ||
+		strings.HasSuffix(name, ".tfmigrate.hcl")
 }

--- a/internal/configs/testdata/query-files/valid/dot-prefixed/.tfquery.hcl
+++ b/internal/configs/testdata/query-files/valid/dot-prefixed/.tfquery.hcl
@@ -1,0 +1,9 @@
+list "aws_instance" "test" {
+  provider = aws
+  count = 1
+  config {
+    tags = {
+      Name = "test"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Fixes a bug where `terraform query` silently ignores `.tfquery.hcl` query files whose names begin with a dot, reporting "No resources to query" even when a `list` block is present.

The `query` command documents searching for `.tfquery.hcl` files, but `IsIgnoredFile` treats any dot-prefixed filename as a hidden file and skips it before the query file matcher runs. This means a file named `.tfquery.hcl` (the documented name) is never loaded, so `ListResources` stays empty and the user sees a confusing "No resources to query" error.

The fix skips the hidden-file heuristic for query files (`.tfquery.hcl`, `.tfquery.json`) and state migration files (`.tfmigrate.hcl`), which are matched by suffix and legitimately begin with a dot.

A regression test was added under `internal/configs/testdata/query-files/valid/dot-prefixed/` and a test case in `TestParserLoadConfigDirWithQueries`.

## Target Release

1.17.x

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
