### PR TITLE
test: Using PSS in combination with dynamic provider sources

### DIFF
--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command"
 	"github.com/hashicorp/terraform/internal/command/clistate"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/e2e"
 	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -936,4 +937,124 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenSuccessiveInits(t *tes
 			t.Fatalf("expected error about state store configuration changing, but got:\n%s", stderr)
 		}
 	})
+}
+
+// Test using dynamic provider sources in combination with pluggable state storage for multiple commands:
+// - init
+// - plan
+// - apply
+// - refresh
+// - query
+func TestPrimary_stateStore_dynamicProviderSources(t *testing.T) {
+	t.Parallel()
+	if !canRunGoBuild {
+		// We're running in a separate-build-then-run context, so we can't
+		// currently execute this test which depends on being able to build
+		// new executable at runtime.
+		//
+		// (See the comment on canRunGoBuild's declaration for more information.)
+		t.Skip("can't run without building a new provider executable")
+	}
+
+	fixturePath := filepath.Join("testdata", "full-workflow-with-dyn-sourced-state-store-fs")
+
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
+
+	// Build the simple6 provider binary and supply it to `init` via the -plugin-dir flag.
+	simple6Provider := filepath.Join(tf.WorkDir(), "terraform-provider-simple6")
+	simple6ProviderExe := e2e.GoBuild("github.com/hashicorp/terraform/internal/provider-simple-v6/main", simple6Provider)
+	platform := getproviders.CurrentPlatform.String()
+	hashiDir := "cache/registry.terraform.io/hashicorp/"
+	if err := os.MkdirAll(tf.Path(hashiDir, "simple6/0.0.1/", platform), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(simple6ProviderExe, tf.Path(hashiDir, "simple6/0.0.1/", platform, "terraform-provider-simple6")); err != nil {
+		t.Fatal(err)
+	}
+
+	// INIT
+	stdout, stderr, err := tf.Run(
+		"init",
+		"-enable-pluggable-state-storage-experiment",
+		"-plugin-dir=cache",
+		"-var", "provider_source=registry.terraform.io/hashicorp/simple6",
+		"-var", "provider_version=0.0.1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%q", err, stderr)
+	}
+
+	expectedMsg := `Finding hashicorp/simple6 versions matching "0.0.1"...`
+	if !strings.Contains(stdout, expectedMsg) {
+		t.Fatalf("expected output %q, got %q", expectedMsg, stdout)
+	}
+
+	// Verify the lockfile includes expected provider and version
+	lockPath := filepath.Join(tf.WorkDir(), depsfile.LockFilePath)
+	locks, diags := depsfile.LoadLocksFromFile(lockPath)
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %s", diags)
+	}
+	pAddr := addrs.MustParseProviderSourceString("hashicorp/simple6")
+	pLock := locks.Provider(pAddr)
+
+	expectedVersion := getproviders.MustParseVersion("0.0.1")
+	givenVersion := pLock.Version()
+	if expectedVersion.String() != givenVersion.String() {
+		t.Fatalf("mismatching version, expected %s, given %s", expectedVersion, givenVersion)
+	}
+
+	// PLAN
+	_, stderr, err = tf.Run(
+		"plan",
+		"-var", "provider_source=registry.terraform.io/hashicorp/simple6",
+		"-var", "provider_version=0.0.1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%q", err, stderr)
+	}
+
+	// APPLY
+	_, stderr, err = tf.Run(
+		"apply",
+		"-var", "provider_source=registry.terraform.io/hashicorp/simple6",
+		"-var", "provider_version=0.0.1",
+		"-auto-approve",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%q", err, stderr)
+	}
+
+	// REFRESH
+	_, stderr, err = tf.Run(
+		"refresh",
+		"-var", "provider_source=registry.terraform.io/hashicorp/simple6",
+		"-var", "provider_version=0.0.1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%q", err, stderr)
+	}
+
+	// QUERY
+	// TODO: Need to check if the provider implements necessary logic for performing a query.
+
+	// Add a .tfquery.hcl file and then run the query command
+	queryFilePath := tf.Path("main.tfquery.hcl")
+	os.WriteFile(queryFilePath, []byte(`
+list "simple_resource" "test" {
+  provider = simple6
+  include_resource = true
+  config {
+    value = "dynamic_value"
+  }
+}
+`), 0644)
+	_, stderr, err = tf.Run(
+		"query",
+		"-var", "provider_source=registry.terraform.io/hashicorp/simple6",
+		"-var", "provider_version=0.0.1",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%q", err, stderr)
+	}
 }

--- a/internal/command/e2etest/testdata/full-workflow-with-dyn-sourced-state-store-fs/main.tf
+++ b/internal/command/e2etest/testdata/full-workflow-with-dyn-sourced-state-store-fs/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    simple6 = {
+      source  = var.provider_source
+      version = var.provider_version
+    }
+  }
+
+  state_store "simple6_fs" {
+    provider "simple6" {}
+
+    workspace_dir = "states"
+  }
+}
+
+variable "provider_source" {
+  default = "invalid source string" // If the default value is used it will cause an error
+  type    = string
+  const   = true
+}
+
+variable "provider_version" {
+  default = "invalid version string" // If the default value is used it will cause an error
+  type    = string
+  const   = true
+}
+
+variable "name" {
+  default = "world"
+}
+
+resource "terraform_data" "my-data" {
+  input = "hello ${var.name}"
+}
+
+output "greeting" {
+  value = resource.terraform_data.my-data.output
+}

--- a/internal/command/init2_test.go
+++ b/internal/command/init2_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/modsdir"
 	"github.com/hashicorp/terraform/internal/terminal"
 )
@@ -956,6 +957,12 @@ func TestPrimaryWorkflow_dynamicProviderSource_pluggableStateStorage(t *testing.
 	t.Chdir(td)
 
 	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	// Make the mock provider have an empty schema body, matching the mock used below for the query command.
+	// Without this, Terraform will detect the change in the provider schema and think the state store configuration has changed.
+	mockProvider.GetProviderSchemaResponse.Provider.Body = &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{},
+		BlockTypes: map[string]*configschema.NestedBlock{},
+	}
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})

--- a/internal/command/init2_test.go
+++ b/internal/command/init2_test.go
@@ -1018,7 +1018,7 @@ func TestPrimaryWorkflow_dynamicProviderSource_pluggableStateStorage(t *testing.
 			AllowExperimentalFeatures: true,
 		},
 	}
-	code = applyCmd.Run(varArgs)
+	code = applyCmd.Run(append([]string{"-auto-approve"}, varArgs...))
 	testOutput = done(t)
 	if code != 0 {
 		t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, testOutput.Stderr(), testOutput.Stdout())

--- a/internal/command/init2_test.go
+++ b/internal/command/init2_test.go
@@ -949,3 +949,116 @@ func TestPlan_dynamicModuleVersionMismatch(t *testing.T) {
 		t.Fatalf("wrong error\ngot:\n%s\n\nwant: containing %q", got, want)
 	}
 }
+
+func TestPrimaryWorkflow_dynamicProviderSource_pluggableStateStorage(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath(filepath.Join("dynamic-provider-sources", "combined-with-pluggable-state-storage")), td)
+	t.Chdir(td)
+
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.0.0"},
+	})
+
+	varArgs := []string{
+		"-var", "provider_source=registry.terraform.io/hashicorp/test",
+		"-var", "provider_version=1.0.0",
+	}
+
+	// INIT
+	ui := testUiWrapped(t)
+	view, done := testView(t)
+	initCmd := &InitCommand{
+		Meta: Meta{
+			testingOverrides:          metaOverridesForProvider(mockProvider),
+			Ui:                        ui,
+			View:                      view,
+			ProviderSource:            providerSource,
+			AllowExperimentalFeatures: true,
+		},
+	}
+
+	code := initCmd.Run(append([]string{"-enable-pluggable-state-storage-experiment"}, varArgs...))
+	testOutput := done(t)
+	if code != 0 {
+		t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, testOutput.Stderr(), testOutput.Stdout())
+	}
+	expectedMsg := `Finding hashicorp/test versions matching "1.0.0"...`
+	if !strings.Contains(testOutput.All(), expectedMsg) {
+		t.Fatalf("expected output to contain %q\n, got:\n%s", expectedMsg, testOutput.All())
+	}
+
+	// PLAN
+	ui = testUiWrapped(t)
+	view, done = testView(t)
+	planCmd := &PlanCommand{
+		Meta: Meta{
+			testingOverrides:          metaOverridesForProvider(mockProvider),
+			Ui:                        ui,
+			View:                      view,
+			ProviderSource:            providerSource,
+			AllowExperimentalFeatures: true,
+		},
+	}
+	code = planCmd.Run(varArgs)
+	testOutput = done(t)
+	if code != 0 {
+		t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, testOutput.Stderr(), testOutput.Stdout())
+	}
+
+	// APPLY
+	ui = testUiWrapped(t)
+	view, done = testView(t)
+	applyCmd := &ApplyCommand{
+		Meta: Meta{
+			testingOverrides:          metaOverridesForProvider(mockProvider),
+			Ui:                        ui,
+			View:                      view,
+			ProviderSource:            providerSource,
+			AllowExperimentalFeatures: true,
+		},
+	}
+	code = applyCmd.Run(varArgs)
+	testOutput = done(t)
+	if code != 0 {
+		t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, testOutput.Stderr(), testOutput.Stdout())
+	}
+
+	// REFRESH
+	ui = testUiWrapped(t)
+	view, done = testView(t)
+	refreshCmd := &RefreshCommand{
+		Meta: Meta{
+			testingOverrides:          metaOverridesForProvider(mockProvider),
+			Ui:                        ui,
+			View:                      view,
+			ProviderSource:            providerSource,
+			AllowExperimentalFeatures: true,
+		},
+	}
+	code = refreshCmd.Run(varArgs)
+	testOutput = done(t)
+	if code != 0 {
+		t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, testOutput.Stderr(), testOutput.Stdout())
+	}
+
+	// QUERY
+	queryMockProvider := queryFixtureProvider()
+	queryMockProvider = addPluggableStateStoreToMockProvider(queryMockProvider, mockSingleStateStoreSchema("test_store")) // Update the query-specific mock to also include a state store.
+	ui = testUiWrapped(t)
+	view, done = testView(t)
+	queryCmd := &QueryCommand{
+		Meta: Meta{
+			testingOverrides:          metaOverridesForProvider(queryMockProvider),
+			Ui:                        ui,
+			View:                      view,
+			ProviderSource:            providerSource,
+			AllowExperimentalFeatures: true,
+		},
+	}
+	code = queryCmd.Run(varArgs)
+	testOutput = done(t)
+	if code != 0 {
+		t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, testOutput.Stderr(), testOutput.Stdout())
+	}
+}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -8590,7 +8590,30 @@ func mockPluggableStateStorageProvider(schemas map[string]providers.Schema) *tes
 	//
 	// This imagines a provider called `test` that contains
 	// a pluggable state store implementation called `store`.
-	mock := testing_provider.MockProvider{}
+	mock := testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"region": {Type: cty.String, Optional: true},
+					},
+				},
+			},
+			DataSources: map[string]providers.Schema{},
+			ResourceTypes: map[string]providers.Schema{
+				"test_instance": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"input": {Type: cty.String, Optional: true},
+							"id":    {Type: cty.String, Computed: true},
+						},
+					},
+				},
+			},
+			ListResourceTypes: map[string]providers.Schema{},
+			StateStores:       schemas,
+		},
+	}
 	return addPluggableStateStoreToMockProvider(&mock, schemas)
 }
 

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -8590,34 +8590,17 @@ func mockPluggableStateStorageProvider(schemas map[string]providers.Schema) *tes
 	//
 	// This imagines a provider called `test` that contains
 	// a pluggable state store implementation called `store`.
-	mock := testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{
-				Body: &configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"region": {Type: cty.String, Optional: true},
-					},
-				},
-			},
-			DataSources: map[string]providers.Schema{},
-			ResourceTypes: map[string]providers.Schema{
-				"test_instance": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"input": {Type: cty.String, Optional: true},
-							"id":    {Type: cty.String, Computed: true},
-						},
-					},
-				},
-			},
-			ListResourceTypes: map[string]providers.Schema{},
-			StateStores:       schemas,
-		},
-	}
+	mock := testing_provider.MockProvider{}
+	return addPluggableStateStoreToMockProvider(&mock, schemas)
+}
+
+func addPluggableStateStoreToMockProvider(p *testing_provider.MockProvider, schemas map[string]providers.Schema) *testing_provider.MockProvider {
+	p.GetProviderSchemaResponse.StateStores = schemas
+
 	typeNames := slices.Sorted(maps.Keys(schemas))
-	mock.MockStates = testing_provider.NewMockStateBytesWithTypes(typeNames)
-	mock.GetStatesFn = func(req providers.GetStatesRequest) (resp providers.GetStatesResponse) {
-		stateIds, err := mock.MockStates.StateIds(req.TypeName)
+	p.MockStates = testing_provider.NewMockStateBytesWithTypes(typeNames)
+	p.GetStatesFn = func(req providers.GetStatesRequest) (resp providers.GetStatesResponse) {
+		stateIds, err := p.MockStates.StateIds(req.TypeName)
 		if err != nil {
 			resp.Diagnostics = resp.Diagnostics.Append(err)
 		}
@@ -8625,24 +8608,24 @@ func mockPluggableStateStorageProvider(schemas map[string]providers.Schema) *tes
 
 		return resp
 	}
-	mock.ConfigureStateStoreFn = func(req providers.ConfigureStateStoreRequest) providers.ConfigureStateStoreResponse {
+	p.ConfigureStateStoreFn = func(req providers.ConfigureStateStoreRequest) providers.ConfigureStateStoreResponse {
 		return providers.ConfigureStateStoreResponse{
 			Capabilities: providers.StateStoreServerCapabilities{
 				ChunkSize: 1234, // arbitrary number that isn't 0
 			},
 		}
 	}
-	mock.WriteStateBytesFn = func(req providers.WriteStateBytesRequest) (resp providers.WriteStateBytesResponse) {
+	p.WriteStateBytesFn = func(req providers.WriteStateBytesRequest) (resp providers.WriteStateBytesResponse) {
 		// Workspaces exist once the artefact representing it is written
-		err := mock.MockStates.Write(req.TypeName, req.StateId, req.Bytes)
+		err := p.MockStates.Write(req.TypeName, req.StateId, req.Bytes)
 		if err != nil {
 			resp.Diagnostics = resp.Diagnostics.Append(err)
 		}
 
 		return resp
 	}
-	mock.ReadStateBytesFn = func(req providers.ReadStateBytesRequest) (resp providers.ReadStateBytesResponse) {
-		b, err := mock.MockStates.Read(req.TypeName, req.StateId)
+	p.ReadStateBytesFn = func(req providers.ReadStateBytesRequest) (resp providers.ReadStateBytesResponse) {
+		b, err := p.MockStates.Read(req.TypeName, req.StateId)
 		if err != nil {
 			if errors.Is(err, testing_provider.StateNotFoundErr{TypeName: req.TypeName, StateId: req.StateId}) {
 				warn := tfdiags.SimpleWarning(err.Error())
@@ -8655,14 +8638,14 @@ func mockPluggableStateStorageProvider(schemas map[string]providers.Schema) *tes
 
 		return resp
 	}
-	mock.DeleteStateFn = func(req providers.DeleteStateRequest) (resp providers.DeleteStateResponse) {
-		err := mock.MockStates.Delete(req.TypeName, req.StateId)
+	p.DeleteStateFn = func(req providers.DeleteStateRequest) (resp providers.DeleteStateResponse) {
+		err := p.MockStates.Delete(req.TypeName, req.StateId)
 		if err != nil {
 			resp.Diagnostics = resp.Diagnostics.Append(err)
 		}
 		return resp
 	}
-	return &mock
+	return p
 }
 
 func assertLockfileContents(t *testing.T, path string, expected string) {

--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -471,6 +471,12 @@ func queryFixtureProvider() *testing_provider.MockProvider {
 		},
 	}
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		Provider: providers.Schema{
+			Body: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{},
+				BlockTypes: map[string]*configschema.NestedBlock{},
+			},
+		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Body: &configschema.Block{

--- a/internal/command/testdata/dynamic-provider-sources/combined-with-pluggable-state-storage/main.tf
+++ b/internal/command/testdata/dynamic-provider-sources/combined-with-pluggable-state-storage/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    test = {
+      source  = var.provider_source
+      version = var.provider_version
+    }
+  }
+
+  state_store "test_store" {
+    provider "test" {}
+
+    value = "foobar"
+  }
+}
+
+variable "provider_source" {
+  default = "invalid source string" // If the default value is used it will cause an error
+  type    = string
+  const   = true
+}
+
+variable "provider_version" {
+  default = "invalid version string" // If the default value is used it will cause an error
+  type    = string
+  const   = true
+}
+
+variable "name" {
+  default = "world"
+}
+
+output "greeting" {
+  value = "hello ${var.name}"
+}

--- a/internal/command/testdata/dynamic-provider-sources/combined-with-pluggable-state-storage/query.tfquery.hcl
+++ b/internal/command/testdata/dynamic-provider-sources/combined-with-pluggable-state-storage/query.tfquery.hcl
@@ -1,0 +1,7 @@
+list "test_instance" "example" {
+  provider = test
+
+  config {
+    ami = "ami-12345"
+  }
+}


### PR DESCRIPTION
Tests that show const variables are resolved in time for PSS to be used. Focusing on commands where Operations are used, as variable resolution used to occur later when OperationRequests were created instead of before when the backend.OperationsBackend instance was initialised.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
