### PR TITLE
fix(terraform): resolve import-only resource provider via required_providers

### DIFF
--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -364,16 +364,21 @@ func (n *NodeAbstractResource) Provider() ProviderRef {
 		// The import targets should either all be defined via config or none
 		// of them should be. They should also all have the same provider, so it
 		// shouldn't matter which we check here, as they'll all give the same.
-		if n.importTargets[0].Config != nil && n.importTargets[0].Config.ProviderConfigRef != nil {
+		if n.importTargets[0].Config != nil {
 			ref := ProviderRef{
 				Addr: addrs.AbsProviderConfig{
 					Provider: n.importTargets[0].Config.Provider,
-					Alias:    n.importTargets[0].Config.ProviderConfigRef.Alias,
 					Module:   n.ModulePath(),
 				},
 			}
 
-			ref.Addr.Alias = n.importTargets[0].Config.ProviderConfigRef.Alias
+			// The import block may explicitly pin a provider configuration,
+			// in which case its alias must be preserved. Otherwise
+			// Config.Provider has already been resolved against the module's
+			// required_providers during decoding.
+			if n.importTargets[0].Config.ProviderConfigRef != nil {
+				ref.Addr.Alias = n.importTargets[0].Config.ProviderConfigRef.Alias
+			}
 			return ref
 		}
 	}

--- a/internal/terraform/node_resource_abstract_test.go
+++ b/internal/terraform/node_resource_abstract_test.go
@@ -115,6 +115,82 @@ func TestNodeAbstractResourceProvider(t *testing.T) {
 	}
 }
 
+// The Provider method must prefer the provider address resolved from an
+// import target's config (via required_providers at decode time) even when
+// the import block has no explicit "provider" argument. This is the
+// -generate-config-out path for import-only resources.
+func TestNodeAbstractResourceProvider_ImportTarget(t *testing.T) {
+	tests := map[string]struct {
+		importTargets []*ImportTarget
+		want          addrs.Provider
+		wantAlias     string
+	}{
+		"import target without explicit provider uses required_providers resolution": {
+			importTargets: []*ImportTarget{
+				{
+					Config: &configs.Import{
+						Provider: addrs.Provider{
+							Hostname:  addrs.DefaultProviderRegistryHost,
+							Namespace: "datahub-project",
+							Type:      "datahub",
+						},
+					},
+				},
+			},
+			want: addrs.Provider{
+				Hostname:  addrs.DefaultProviderRegistryHost,
+				Namespace: "datahub-project",
+				Type:      "datahub",
+			},
+		},
+		"import target with explicit provider preserves the alias": {
+			importTargets: []*ImportTarget{
+				{
+					Config: &configs.Import{
+						Provider: addrs.Provider{
+							Hostname:  addrs.DefaultProviderRegistryHost,
+							Namespace: "datahub-project",
+							Type:      "datahub",
+						},
+						ProviderConfigRef: &configs.ProviderConfigRef{
+							Name:  "datahub",
+							Alias: "west",
+						},
+					},
+				},
+			},
+			want: addrs.Provider{
+				Hostname:  addrs.DefaultProviderRegistryHost,
+				Namespace: "datahub-project",
+				Type:      "datahub",
+			},
+			wantAlias: "west",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			node := &NodeAbstractResource{
+				// Just enough NodeAbstractResource for the Provider function.
+				// (This would not be valid for some other functions.)
+				Addr: addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "datahub_ingestion_source",
+					Name: "rt_source",
+				}.InModule(addrs.RootModule),
+				importTargets: test.importTargets,
+			}
+			got := node.Provider()
+			if got.FQN() != test.want {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", got.FQN(), test.want)
+			}
+			if got.Addr.Alias != test.wantAlias {
+				t.Errorf("wrong alias\ngot:  %q\nwant: %q", got.Addr.Alias, test.wantAlias)
+			}
+		})
+	}
+}
+
 // Make sure ProvideBy returns the final resolved provider
 func TestNodeAbstractResourceSetProvider(t *testing.T) {
 	node := &NodeAbstractResource{


### PR DESCRIPTION
## What

Fixes a regression introduced in `ee47cd37610daaed4edc9ff4083957663b488ca1` ("refactor GraphNodeProviderConsumer") that caused `terraform plan -generate-config-out` to resolve import-only resources against the implied `hashicorp/<type>` provider instead of the provider declared in `required_providers`.

## Why

Before the refactor, `NodeAbstractResource.Provider()` returned the import target's `Config.Provider` whenever the import block had a non-nil `Config`, and `Config.Provider` is resolved against the module's `required_providers` during decoding. After the merge of `ProvidedBy()` and `Provider()`, the import-target branch additionally required `ProviderConfigRef != nil`, which is only true when the import block carries an explicit `provider` argument.

For the `-generate-config-out` case (an import block with no matching `resource` block and no explicit `provider` attribute), `ProviderConfigRef` is `nil`, so the method fell through to `ImpliedProviderForUnqualifiedType`, producing `registry.terraform.io/hashicorp/datahub` and the error:

```
failed to read schema for datahub_ingestion_source.rt_source in registry.terraform.io/hashicorp/datahub
```

instead of resolving to `registry.terraform.io/datahub-project/datahub`.

## How

`Provider()` now returns the import target's `Config.Provider` whenever `Config` is non-nil, and only applies the provider alias when the block explicitly pins a provider configuration (`ProviderConfigRef != nil`). This restores the pre-refactor behavior while preserving explicit aliases.

## Test plan

Added `TestNodeAbstractResourceProvider_ImportTarget`, covering both the import-only case (no explicit `provider`) and the alias-preservation case. The test fails on `main` (returns `hashicorp/datahub`) and passes with this change.

```
go test ./internal/terraform/ -run 'TestNodeAbstractResourceProvider' -count=1
```

## Checklist

- [x] Added a regression test that fails without the fix
- [x] `gofmt` applied
- [x] Signed off (DCO)

Fixes #39144
