### PR TITLE
Add provider meta schema to JSON output

### DIFF
--- a/.changes/v1.17/ENHANCEMENTS-20260909-083437.yaml
+++ b/.changes/v1.17/ENHANCEMENTS-20260909-083437.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: "providers schema: include provider_meta in the JSON output"
+time: 2026-09-09T08:34:47.000000Z
+custom:
+    Issue: "38824"

--- a/internal/command/jsonprovider/provider.go
+++ b/internal/command/jsonprovider/provider.go
@@ -24,6 +24,7 @@ type Providers struct {
 
 type Provider struct {
 	Provider                 *Schema                                    `json:"provider,omitempty"`
+	ProviderMeta             *Schema                                    `json:"provider_meta,omitempty"`
 	ResourceSchemas          map[string]*Schema                         `json:"resource_schemas,omitempty"`
 	DataSourceSchemas        map[string]*Schema                         `json:"data_source_schemas,omitempty"`
 	EphemeralResourceSchemas map[string]*Schema                         `json:"ephemeral_resource_schemas,omitempty"`
@@ -64,6 +65,7 @@ func Marshal(s *terraform.Schemas) ([]byte, error) {
 func marshalProvider(tps providers.ProviderSchema) *Provider {
 	p := &Provider{
 		Provider:                 marshalSchema(tps.Provider),
+		ProviderMeta:             marshalSchema(tps.ProviderMeta),
 		ResourceSchemas:          marshalSchemas(tps.ResourceTypes),
 		DataSourceSchemas:        marshalSchemas(tps.DataSources),
 		EphemeralResourceSchemas: marshalSchemas(tps.EphemeralResourceTypes),

--- a/internal/command/jsonprovider/provider_test.go
+++ b/internal/command/jsonprovider/provider_test.go
@@ -27,6 +27,7 @@ func TestMarshalProvider(t *testing.T) {
 			providers.ProviderSchema{},
 			&Provider{
 				Provider:                 &Schema{},
+				ProviderMeta:             &Schema{},
 				ResourceSchemas:          map[string]*Schema{},
 				DataSourceSchemas:        map[string]*Schema{},
 				EphemeralResourceSchemas: map[string]*Schema{},
@@ -45,6 +46,18 @@ func TestMarshalProvider(t *testing.T) {
 							"region": {
 								AttributeType:   json.RawMessage(`"string"`),
 								Required:        true,
+								DescriptionKind: "plain",
+							},
+						},
+						DescriptionKind: "plain",
+					},
+				},
+				ProviderMeta: &Schema{
+					Block: &Block{
+						Attributes: map[string]*Attribute{
+							"module_name": {
+								AttributeType:   json.RawMessage(`"string"`),
+								Optional:        true,
 								DescriptionKind: "plain",
 							},
 						},
@@ -272,6 +285,13 @@ func testProvider() providers.ProviderSchema {
 			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"region": {Type: cty.String, Required: true},
+				},
+			},
+		},
+		ProviderMeta: providers.Schema{
+			Body: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"module_name": {Type: cty.String, Optional: true},
 				},
 			},
 		},


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Adds `provider_meta` to the JSON output produced by `terraform providers schema -json`.

Provider meta schemas are already available through `providers.ProviderSchema.ProviderMeta`, but were not included in the public JSON representation.

This change:
- adds `provider_meta` to `jsonprovider.Provider`
- marshals `ProviderMeta` using the existing schema marshaling logic
- adds test coverage for provider meta schema serialization

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #38824

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.