### PR TITLE
Add hyphen to diags mentioning the providers-lock sub command

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/provider_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config.go
@@ -89,7 +89,7 @@ func CheckProviderInLockfile(locks depsfile.Locks, providerType *ProviderType, v
 			Severity: hcl.DiagError,
 			Summary:  "Provider missing from lockfile",
 			Detail: fmt.Sprintf(
-				"Provider %q is not in the lockfile. This provider must be in the lockfile to be used in the configuration. Please run `terraform stacks providers lock` to update the lockfile and run this operation again with an updated configuration.",
+				"Provider %q is not in the lockfile. This provider must be in the lockfile to be used in the configuration. Please run `terraform stacks providers-lock` to update the lockfile and run this operation again with an updated configuration.",
 				providerType.Addr(),
 			),
 			Subject: declRange,
@@ -105,7 +105,7 @@ func CheckProviderInLockfile(locks depsfile.Locks, providerType *ProviderType, v
 				Severity: hcl.DiagError,
 				Summary:  "Provider version doesn't match the lockfile",
 				Detail: fmt.Sprintf(
-					"Provider %q is locked at version %s in the dependency lockfile, but the configuration's version constraints (%s) do not allow that version. This usually means the version constraints were changed after the lockfile was generated. Please run `terraform stacks providers lock` to update the lockfile and run this operation again with an updated configuration.",
+					"Provider %q is locked at version %s in the dependency lockfile, but the configuration's version constraints (%s) do not allow that version. This usually means the version constraints were changed after the lockfile was generated. Please run `terraform stacks providers-lock` to update the lockfile and run this operation again with an updated configuration.",
 					providerType.Addr(), selectedVersion.String(),
 					providerreqs.VersionConstraintsString(versionConstraints),
 				),

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -483,7 +483,7 @@ Terraform uses references to decide a suitable order for performing operations, 
 				return diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Provider missing from lockfile",
-					Detail:   "Provider \"registry.terraform.io/hashicorp/testing\" is not in the lockfile. This provider must be in the lockfile to be used in the configuration. Please run `terraform stacks providers lock` to update the lockfile and run this operation again with an updated configuration.",
+					Detail:   "Provider \"registry.terraform.io/hashicorp/testing\" is not in the lockfile. This provider must be in the lockfile to be used in the configuration. Please run `terraform stacks providers-lock` to update the lockfile and run this operation again with an updated configuration.",
 					Subject: &hcl.Range{
 						Filename: "git::https://example.com/test.git//with-single-input/input-from-component/input-from-component.tfcomponent.hcl",
 						Start:    hcl.Pos{Line: 8, Column: 1, Byte: 98},


### PR DESCRIPTION
There are diagnostics that mention `terraform stacks providers lock` but the command is a single word `providers-lock`. Adding the hyphen to the diag messages with this PR.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

https://hashicorp.atlassian.net/browse/TF-40816

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
