### PR TITLE
Handle forget-action when the order is create_before_destroy

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260909-152256.yaml
+++ b/.changes/v1.16/BUG FIXES-20260909-152256.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix handling of destroy=false around create_before_destroy instances
+time: 2026-09-09T15:22:56.069683-04:00
+custom:
+    Issue: "39169"

--- a/internal/command/format/format.go
+++ b/internal/command/format/format.go
@@ -20,6 +20,8 @@ func DiffActionSymbol(action plans.Action) string {
 	switch action {
 	case plans.DeleteThenCreate:
 		return "[red]-[reset]/[green]+[reset]"
+	case plans.ForgetThenCreate:
+		return "[red].[reset]/[green]+[reset]"
 	case plans.CreateThenDelete:
 		return "[green]+[reset]/[red]-[reset]"
 	case plans.Create:

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -220,6 +220,12 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...plans.Q
 		if counts[plans.CreateThenDelete] > 0 {
 			renderer.Streams.Println(renderer.Colorize.Color(actionDescription(plans.CreateThenDelete)))
 		}
+		if counts[plans.ForgetThenCreate] > 0 {
+			renderer.Streams.Println(renderer.Colorize.Color(actionDescription(plans.ForgetThenCreate)))
+		}
+		if counts[plans.CreateThenForget] > 0 {
+			renderer.Streams.Println(renderer.Colorize.Color(actionDescription(plans.CreateThenForget)))
+		}
 		if counts[plans.Read] > 0 {
 			renderer.Streams.Println(renderer.Colorize.Color(actionDescription(plans.Read)))
 		}
@@ -246,7 +252,7 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...plans.Q
 			buf.WriteString(fmt.Sprintf("%d to import, ", importingCount))
 		}
 		buf.WriteString(fmt.Sprintf("%d to add, %d to change, %d to destroy.",
-			counts[plans.Create]+counts[plans.DeleteThenCreate]+counts[plans.CreateThenDelete]+counts[plans.CreateThenForget],
+			counts[plans.Create]+counts[plans.DeleteThenCreate]+counts[plans.CreateThenDelete]+counts[plans.ForgetThenCreate]+counts[plans.CreateThenForget],
 			counts[plans.Update],
 			counts[plans.Delete]+counts[plans.DeleteThenCreate]+counts[plans.CreateThenDelete]),
 		)
@@ -563,7 +569,7 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 		default:
 			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] must be [bold][red]replaced[reset]", dispAddr))
 		}
-	case plans.CreateThenForget:
+	case plans.ForgetThenCreate, plans.CreateThenForget:
 		buf.WriteString(fmt.Sprintf("[bold] # %s[reset] must be replaced, but the existing object will not be destroyed", dispAddr))
 		buf.WriteString("\n # (destroy = false is set in the configuration)")
 	case plans.Forget:
@@ -692,6 +698,10 @@ func actionDescription(action plans.Action) string {
 		return "[green]+[reset]/[red]-[reset] create replacement and then destroy"
 	case plans.DeleteThenCreate:
 		return "[red]-[reset]/[green]+[reset] destroy and then create replacement"
+	case plans.ForgetThenCreate:
+		return "[red].[reset]/[green]+[reset] forget and then create replacement"
+	case plans.CreateThenForget:
+		return "[green]+[reset]/[red].[reset] create replacement and then forget"
 	case plans.Read:
 		return " [cyan]<=[reset] read (data resources)"
 	default:

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -886,6 +886,33 @@ func TestResourceChange_primitiveTypes(t *testing.T) {
       ~ id  = "i-02ae66f368e8518a9" -> "i-02999999999999999"
     }`,
 		},
+		"forget-then-create": {
+			Action: plans.ForgetThenCreate,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02999999999999999"),
+				"ami": cty.StringVal("ami-AFTER"),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":  {Type: cty.String, Computed: true},
+					"ami": {Type: cty.String, Optional: true},
+				},
+			},
+			RequiredReplace: cty.NewPathSet(cty.Path{
+				cty.GetAttrStep{Name: "ami"},
+			}),
+			ExpectedOutput: ` # test_instance.example must be replaced, but the existing object will not be destroyed
+ # (destroy = false is set in the configuration)
+./+ resource "test_instance" "example" {
+      ~ ami = "ami-BEFORE" -> "ami-AFTER" # forces replacement
+      ~ id  = "i-02ae66f368e8518a9" -> "i-02999999999999999"
+    }`,
+		},
 		"string in-place update": {
 			Action: plans.Update,
 			Mode:   addrs.ManagedResourceMode,

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -991,6 +991,8 @@ func actionString(action string) []string {
 		return []string{"delete", "create"}
 	case action == "Forget":
 		return []string{"forget"}
+	case action == "ForgetThenCreate":
+		return []string{"forget", "create"}
 	case action == "CreateThenForget":
 		return []string{"create", "forget"}
 	default:
@@ -1011,6 +1013,10 @@ func UnmarshalActions(actions []string) plans.Action {
 
 		if actions[0] == "create" && actions[1] == "forget" {
 			return plans.CreateThenForget
+		}
+
+		if actions[0] == "forget" && actions[1] == "create" {
+			return plans.ForgetThenCreate
 		}
 	}
 

--- a/internal/command/views/hook_count.go
+++ b/internal/command/views/hook_count.go
@@ -63,6 +63,8 @@ func (h *countHook) PostApply(id terraform.HookResourceIdentity, dk addrs.Depose
 				case plans.CreateThenDelete, plans.DeleteThenCreate:
 					h.Added++
 					h.Removed++
+				case plans.ForgetThenCreate, plans.CreateThenForget:
+					h.Added++
 				case plans.Create:
 					h.Added++
 				case plans.Delete:
@@ -94,6 +96,8 @@ func (h *countHook) PostDiff(id terraform.HookResourceIdentity, dk addrs.Deposed
 	switch action {
 	case plans.CreateThenDelete, plans.DeleteThenCreate:
 		h.ToRemoveAndAdd += 1
+	case plans.ForgetThenCreate, plans.CreateThenForget:
+		h.ToAdd += 1
 	case plans.Create:
 		h.ToAdd += 1
 	case plans.Delete:

--- a/internal/command/views/json/change.go
+++ b/internal/command/views/json/change.go
@@ -134,7 +134,7 @@ func changeAction(action plans.Action) ChangeAction {
 		return ActionRead
 	case plans.Update:
 		return ActionUpdate
-	case plans.DeleteThenCreate, plans.CreateThenDelete, plans.CreateThenForget:
+	case plans.DeleteThenCreate, plans.CreateThenDelete, plans.ForgetThenCreate, plans.CreateThenForget:
 		return ActionReplace
 	case plans.Delete:
 		return ActionDelete

--- a/internal/command/views/json/hook.go
+++ b/internal/command/views/json/hook.go
@@ -549,7 +549,7 @@ func startActionVerb(action plans.Action) string {
 		return "Destroying"
 	case plans.Read:
 		return "Refreshing"
-	case plans.CreateThenDelete, plans.DeleteThenCreate, plans.CreateThenForget:
+	case plans.CreateThenDelete, plans.DeleteThenCreate, plans.ForgetThenCreate, plans.CreateThenForget:
 		// This is not currently possible to reach, as we receive separate
 		// passes for create and delete
 		return "Replacing"
@@ -583,7 +583,7 @@ func progressActionVerb(action plans.Action) string {
 		return "destroying"
 	case plans.Read:
 		return "refreshing"
-	case plans.CreateThenDelete, plans.CreateThenForget, plans.DeleteThenCreate:
+	case plans.CreateThenDelete, plans.CreateThenForget, plans.DeleteThenCreate, plans.ForgetThenCreate:
 		// This is not currently possible to reach, as we receive separate
 		// passes for create and delete
 		return "replacing"
@@ -620,7 +620,7 @@ func actionNoun(action plans.Action) string {
 		return "Destruction"
 	case plans.Read:
 		return "Refresh"
-	case plans.CreateThenDelete, plans.DeleteThenCreate, plans.CreateThenForget:
+	case plans.CreateThenDelete, plans.DeleteThenCreate, plans.ForgetThenCreate, plans.CreateThenForget:
 		// This is not currently possible to reach, as we receive separate
 		// passes for create and delete
 		return "Replacement"

--- a/internal/command/views/operation.go
+++ b/internal/command/views/operation.go
@@ -261,6 +261,8 @@ func (v *OperationJSON) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
 		case plans.CreateThenDelete, plans.DeleteThenCreate:
 			cs.Add++
 			cs.Remove++
+		case plans.ForgetThenCreate, plans.CreateThenForget:
+			cs.Add++
 		}
 
 		if change.Action != plans.NoOp || !change.Addr.Equal(change.PrevRunAddr) || change.Importing != nil {

--- a/internal/plans/action.go
+++ b/internal/plans/action.go
@@ -14,6 +14,7 @@ const (
 	CreateThenDelete Action = '±'
 	Delete           Action = '-'
 	Forget           Action = '.'
+	ForgetThenCreate Action = '∔'
 	CreateThenForget Action = '⨥'
 	Open             Action = '⟃'
 	Renew            Action = '⟳'
@@ -25,5 +26,5 @@ const (
 // IsReplace returns true if the action is one of the actions that
 // represent replacing an existing object with a new object.
 func (a Action) IsReplace() bool {
-	return a == DeleteThenCreate || a == CreateThenDelete || a == CreateThenForget
+	return a == DeleteThenCreate || a == CreateThenDelete || a == ForgetThenCreate || a == CreateThenForget
 }

--- a/internal/plans/action_string.go
+++ b/internal/plans/action_string.go
@@ -16,13 +16,14 @@ func _() {
 	_ = x[CreateThenDelete-177]
 	_ = x[Delete-45]
 	_ = x[Forget-46]
+	_ = x[ForgetThenCreate-8724]
 	_ = x[CreateThenForget-10789]
 	_ = x[Open-10179]
 	_ = x[Renew-10227]
 	_ = x[Close-10959]
 }
 
-const _Action_name = "NoOpCreateDeleteForgetUpdateCreateThenDeleteReadDeleteThenCreateOpenRenewCreateThenForgetClose"
+const _Action_name = "NoOpCreateDeleteForgetUpdateCreateThenDeleteReadDeleteThenCreateForgetThenCreateOpenRenewCreateThenForgetClose"
 
 var _Action_map = map[Action]string{
 	0:     _Action_name[0:4],
@@ -33,10 +34,11 @@ var _Action_map = map[Action]string{
 	177:   _Action_name[28:44],
 	8592:  _Action_name[44:48],
 	8723:  _Action_name[48:64],
-	10179: _Action_name[64:68],
-	10227: _Action_name[68:73],
-	10789: _Action_name[73:89],
-	10959: _Action_name[89:94],
+	8724:  _Action_name[64:80],
+	10179: _Action_name[80:84],
+	10227: _Action_name[84:89],
+	10789: _Action_name[89:105],
+	10959: _Action_name[105:110],
 }
 
 func (i Action) String() string {

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -455,7 +455,7 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 		switch rc.Action {
 		case Delete:
 			// We'll fall out and just return rc verbatim, then.
-		case CreateThenDelete, DeleteThenCreate, CreateThenForget:
+		case CreateThenDelete, DeleteThenCreate, ForgetThenCreate, CreateThenForget:
 			return &ResourceInstanceChange{
 				Addr:         rc.Addr,
 				DeposedKey:   rc.DeposedKey,
@@ -506,7 +506,7 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 					GeneratedConfig: rc.GeneratedConfig,
 				},
 			}
-		case CreateThenDelete, DeleteThenCreate, CreateThenForget:
+		case CreateThenDelete, DeleteThenCreate, ForgetThenCreate, CreateThenForget:
 			return &ResourceInstanceChange{
 				Addr:         rc.Addr,
 				DeposedKey:   rc.DeposedKey,

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -407,6 +407,8 @@ func ActionFromProto(rawAction planproto.Action) (plans.Action, error) {
 		return plans.DeleteThenCreate, nil
 	case planproto.Action_FORGET:
 		return plans.Forget, nil
+	case planproto.Action_FORGET_THEN_CREATE:
+		return plans.ForgetThenCreate, nil
 	case planproto.Action_CREATE_THEN_FORGET:
 		return plans.CreateThenForget, nil
 	default:
@@ -453,7 +455,7 @@ func changeFromTfplan(rawChange *planproto.Change) (*plans.ChangeSrc, error) {
 		afterIdx = 1
 	case plans.Forget:
 		beforeIdx = 0
-	case plans.CreateThenForget:
+	case plans.ForgetThenCreate, plans.CreateThenForget:
 		beforeIdx = 0
 		afterIdx = 1
 	default:
@@ -934,6 +936,8 @@ func ActionToProto(action plans.Action) (planproto.Action, error) {
 		return planproto.Action_CREATE_THEN_DELETE, nil
 	case plans.Forget:
 		return planproto.Action_FORGET, nil
+	case plans.ForgetThenCreate:
+		return planproto.Action_FORGET_THEN_CREATE, nil
 	case plans.CreateThenForget:
 		return planproto.Action_CREATE_THEN_FORGET, nil
 	default:
@@ -1001,7 +1005,7 @@ func changeToTfplan(change *plans.ChangeSrc) (*planproto.Change, error) {
 		ret.Values = []*planproto.DynamicValue{before, after}
 	case planproto.Action_FORGET:
 		ret.Values = []*planproto.DynamicValue{before}
-	case planproto.Action_CREATE_THEN_FORGET:
+	case planproto.Action_FORGET_THEN_CREATE, planproto.Action_CREATE_THEN_FORGET:
 		ret.Values = []*planproto.DynamicValue{before, after}
 	default:
 		return nil, fmt.Errorf("invalid change action %s", change.Action)

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -23,6 +23,39 @@ import (
 	"github.com/hashicorp/terraform/internal/states"
 )
 
+func TestActionProtoRoundTrip_forgetThenCreate(t *testing.T) {
+	before, err := plans.NewDynamicValue(cty.StringVal("before"), cty.String)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := plans.NewDynamicValue(cty.StringVal("after"), cty.String)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := changeToTfplan(&plans.ChangeSrc{
+		Action: plans.ForgetThenCreate,
+		Before: before,
+		After:  after,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := changeFromTfplan(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Action != plans.ForgetThenCreate {
+		t.Fatalf("wrong action after round trip: got %s, want %s", got.Action, plans.ForgetThenCreate)
+	}
+	if !bytes.Equal(got.Before, before) {
+		t.Fatalf("wrong before value after round trip")
+	}
+	if !bytes.Equal(got.After, after) {
+		t.Fatalf("wrong after value after round trip")
+	}
+}
+
 // TestTFPlanRoundTrip writes a plan to a planfile, reads the contents of the planfile,
 // and asserts that the read data matches the written data.
 func TestTFPlanRoundTrip(t *testing.T) {

--- a/internal/plans/planproto/convert.go
+++ b/internal/plans/planproto/convert.go
@@ -77,6 +77,10 @@ func NewAction(action plans.Action) Action {
 		return Action_CREATE_THEN_DELETE
 	case plans.Forget:
 		return Action_FORGET
+	case plans.ForgetThenCreate:
+		return Action_FORGET_THEN_CREATE
+	case plans.CreateThenForget:
+		return Action_CREATE_THEN_FORGET
 	default:
 		// The above should be exhaustive for all possible actions
 		panic(fmt.Sprintf("unsupported change action %s", action))
@@ -101,6 +105,10 @@ func FromAction(protoAction Action) (plans.Action, error) {
 		return plans.CreateThenDelete, nil
 	case Action_FORGET:
 		return plans.Forget, nil
+	case Action_FORGET_THEN_CREATE:
+		return plans.ForgetThenCreate, nil
+	case Action_CREATE_THEN_FORGET:
+		return plans.CreateThenForget, nil
 	default:
 		return plans.NoOp, fmt.Errorf("unsupported action %s", protoAction)
 	}

--- a/internal/plans/planproto/planfile.pb.go
+++ b/internal/plans/planproto/planfile.pb.go
@@ -88,20 +88,22 @@ const (
 	Action_CREATE_THEN_DELETE Action = 7
 	Action_FORGET             Action = 8
 	Action_CREATE_THEN_FORGET Action = 9
+	Action_FORGET_THEN_CREATE Action = 10
 )
 
 // Enum value maps for Action.
 var (
 	Action_name = map[int32]string{
-		0: "NOOP",
-		1: "CREATE",
-		2: "READ",
-		3: "UPDATE",
-		5: "DELETE",
-		6: "DELETE_THEN_CREATE",
-		7: "CREATE_THEN_DELETE",
-		8: "FORGET",
-		9: "CREATE_THEN_FORGET",
+		0:  "NOOP",
+		1:  "CREATE",
+		2:  "READ",
+		3:  "UPDATE",
+		5:  "DELETE",
+		6:  "DELETE_THEN_CREATE",
+		7:  "CREATE_THEN_DELETE",
+		8:  "FORGET",
+		9:  "CREATE_THEN_FORGET",
+		10: "FORGET_THEN_CREATE",
 	}
 	Action_value = map[string]int32{
 		"NOOP":               0,
@@ -113,6 +115,7 @@ var (
 		"CREATE_THEN_DELETE": 7,
 		"FORGET":             8,
 		"CREATE_THEN_FORGET": 9,
+		"FORGET_THEN_CREATE": 10,
 	}
 )
 
@@ -2441,7 +2444,7 @@ const file_planfile_proto_rawDesc = "" +
 	"\n" +
 	"\x06NORMAL\x10\x00\x12\v\n" +
 	"\aDESTROY\x10\x01\x12\x10\n" +
-	"\fREFRESH_ONLY\x10\x02*\x94\x01\n" +
+	"\fREFRESH_ONLY\x10\x02*\xac\x01\n" +
 	"\x06Action\x12\b\n" +
 	"\x04NOOP\x10\x00\x12\n" +
 	"\n" +
@@ -2455,7 +2458,9 @@ const file_planfile_proto_rawDesc = "" +
 	"\x12CREATE_THEN_DELETE\x10\a\x12\n" +
 	"\n" +
 	"\x06FORGET\x10\b\x12\x16\n" +
-	"\x12CREATE_THEN_FORGET\x10\t*\xc8\x03\n" +
+	"\x12CREATE_THEN_FORGET\x10\t\x12\x16\n" +
+	"\x12FORGET_THEN_CREATE\x10\n" +
+	"*\xc8\x03\n" +
 	"\x1cResourceInstanceActionReason\x12\b\n" +
 	"\x04NONE\x10\x00\x12\x1b\n" +
 	"\x17REPLACE_BECAUSE_TAINTED\x10\x01\x12\x16\n" +

--- a/internal/plans/planproto/planfile.proto
+++ b/internal/plans/planproto/planfile.proto
@@ -184,6 +184,7 @@ enum Action {
     CREATE_THEN_DELETE = 7;
     FORGET = 8;
     CREATE_THEN_FORGET = 9;
+    FORGET_THEN_CREATE = 10;
 }
 
 // Change represents a change made to some object, transforming it from an old

--- a/internal/rpcapi/terraform1/stacks/conversion.go
+++ b/internal/rpcapi/terraform1/stacks/conversion.go
@@ -39,6 +39,8 @@ func ChangeTypesForPlanAction(action plans.Action) ([]ChangeType, error) {
 		return []ChangeType{ChangeType_CREATE, ChangeType_DELETE}, nil
 	case plans.Forget:
 		return []ChangeType{ChangeType_FORGET}, nil
+	case plans.ForgetThenCreate:
+		return []ChangeType{ChangeType_FORGET, ChangeType_CREATE}, nil
 	case plans.CreateThenForget:
 		return []ChangeType{ChangeType_CREATE, ChangeType_FORGET}, nil
 	default:

--- a/internal/stacks/stackruntime/hooks/component_instance.go
+++ b/internal/stacks/stackruntime/hooks/component_instance.go
@@ -88,7 +88,7 @@ func (cic *ComponentInstanceChange) CountNewAction(action plans.Action) {
 		cic.Remove++
 	case plans.Forget:
 		cic.Forget++
-	case plans.CreateThenForget:
+	case plans.ForgetThenCreate, plans.CreateThenForget:
 		cic.Add++
 		cic.Forget++
 	}

--- a/internal/stacks/stackruntime/internal/stackeval/applying.go
+++ b/internal/stacks/stackruntime/internal/stackeval/applying.go
@@ -297,6 +297,11 @@ func ApplyComponentPlan(ctx context.Context, main *Main, plan *plans.Plan, requi
 		for _, rioAddr := range applied {
 			action := tfHook.ResourceInstanceObjectAppliedAction(rioAddr)
 			cic.CountNewAction(action)
+			if change, ok := stackPlan.ResourceInstancePlanned.GetOk(rioAddr); ok {
+				if change.Action == plans.ForgetThenCreate || change.Action == plans.CreateThenForget {
+					cic.Forget++
+				}
+			}
 		}
 
 		// The state management actions (move, import, forget) don't emit
@@ -332,7 +337,7 @@ func ApplyComponentPlan(ctx context.Context, main *Main, plan *plans.Plan, requi
 				if change.Moved() {
 					cic.Move++
 				}
-			case plans.Forget:
+			case plans.Forget, plans.ForgetThenCreate:
 				cic.Forget++
 			}
 		}

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -5197,7 +5197,7 @@ resource test_object default {}
 		if !strings.Contains(diags.ErrWithWarnings().Error(), "Some objects will no longer be managed by Terraform") {
 			t.Fatal("missing expected diagnostic")
 		}
-		assertPlan(t, plan, forget, plans.CreateThenForget)
+		assertPlan(t, plan, forget, plans.ForgetThenCreate)
 
 		state, applyDiags := ctx.Apply(plan, m, nil)
 		assertNoDiagnostics(t, applyDiags)
@@ -5402,4 +5402,267 @@ resource "test_object" "r3" {
 		_, applyDiags := ctx.Apply(plan, m, nil)
 		assertNoDiagnostics(t, applyDiags)
 	})
+}
+
+func TestContext2Apply_forget_createBeforeDestroy(t *testing.T) {
+	tests := map[string]string{
+		"explicit": `
+resource "test_object" "forget" {
+	lifecycle {
+		destroy               = false
+		create_before_destroy = true
+	}
+}
+`,
+		"propagated": `
+resource "test_object" "forget" {
+	lifecycle {
+		destroy = false
+	}
+}
+
+resource "test_object" "dependent" {
+	depends_on = [test_object.forget]
+
+	lifecycle {
+		create_before_destroy = true
+	}
+}
+`,
+	}
+
+	for name, config := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := testModuleInline(t, map[string]string{
+				"main.tf": config,
+			})
+
+			p := simpleMockProvider()
+			createCalls := 0
+			p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+				if req.PlannedState.IsNull() {
+					t.Fatal("provider was asked to destroy an object")
+				}
+
+				if req.PriorState.IsNull() {
+					createCalls++
+				}
+				resp.NewState = req.PlannedState
+				return resp
+			}
+			ctx := testContext2(t, &ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+				},
+			})
+
+			forget := mustResourceInstanceAddr("test_object.forget")
+			state := states.NewState()
+			root := state.EnsureModule(addrs.RootModuleInstance)
+			root.SetResourceInstanceCurrent(
+				forget.Resource,
+				&states.ResourceInstanceObjectSrc{
+					Status:    states.ObjectTainted,
+					AttrsJSON: []byte(`{"test_string":"old"}`),
+				},
+				mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+			)
+			if name == "propagated" {
+				root.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test_object.dependent").Resource,
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{}`),
+					},
+					mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+				)
+			}
+
+			plan, diags := ctx.Plan(m, state, nil)
+			tfdiags.AssertNoErrors(t, diags)
+			change := plan.Changes.ResourceInstance(forget)
+			if change == nil {
+				t.Fatal("expected a change")
+			}
+			if got, want := change.Action, plans.CreateThenForget; got != want {
+				t.Fatalf("wrong change type for %s: got %s, want %s", forget, got, want)
+			}
+
+			state, diags = ctx.Apply(plan, m, nil)
+			tfdiags.AssertNoErrors(t, diags)
+			if got, want := createCalls, 1; got != want {
+				t.Fatalf("wrong number of provider create calls: got %d, want %d", got, want)
+			}
+
+			instance := state.ResourceInstance(forget)
+			if instance == nil || instance.Current == nil {
+				t.Fatalf("%s has no current object after replacement", forget)
+			}
+			if got := len(instance.Deposed); got != 0 {
+				t.Fatalf("%s has %d deposed objects after replacement; want none", forget, got)
+			}
+		})
+	}
+}
+
+func TestContext2Apply_forget_createBeforeDestroyInvalidResult(t *testing.T) {
+	initialConfig := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "forget" {
+	test_string = "old"
+
+	lifecycle {
+		destroy               = false
+		create_before_destroy = true
+	}
+}
+`,
+	})
+
+	replacementConfig := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "forget" {
+	test_string = "new"
+
+	lifecycle {
+		destroy               = false
+		create_before_destroy = true
+	}
+}
+`,
+	})
+
+	p := simpleMockProvider()
+	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+		resp.PlannedState = req.ProposedNewState
+		if req.PriorState.IsNull() || req.ProposedNewState.IsNull() {
+			return resp
+		}
+		if !req.PriorState.GetAttr("test_string").RawEquals(req.ProposedNewState.GetAttr("test_string")) {
+			resp.RequiresReplace = []cty.Path{cty.GetAttrPath("test_string")}
+		}
+		return resp
+	}
+	createCalls := 0
+	p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+		if req.PlannedState.IsNull() {
+			t.Fatal("provider was asked to destroy an object")
+		}
+		if req.PriorState.IsNull() {
+			createCalls++
+		}
+		resp.NewState = req.PlannedState
+		return resp
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(initialConfig, states.NewState(), nil)
+	tfdiags.AssertNoErrors(t, diags)
+	state, diags := ctx.Apply(plan, initialConfig, nil)
+	tfdiags.AssertNoErrors(t, diags)
+	if got, want := createCalls, 1; got != want {
+		t.Fatalf("wrong number of provider create calls after initial apply: got %d, want %d", got, want)
+	}
+
+	plan, diags = ctx.Plan(replacementConfig, state, nil)
+	tfdiags.AssertNoErrors(t, diags)
+	_, diags = ctx.Apply(plan, replacementConfig, nil)
+	tfdiags.AssertNoErrors(t, diags)
+	if got, want := createCalls, 2; got != want {
+		t.Fatalf("wrong total number of provider create calls: got %d, want %d", got, want)
+	}
+}
+
+func TestContext2Apply_forget_replace(t *testing.T) {
+	// https://github.com/hashicorp/terraform/issues/39088
+	// we have a resource in state that needs replacing, and forget statement, but we're doing a replace
+	// don't be weird about it
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "forget" {
+	test_string = "hello"
+	lifecycle {
+		destroy = false
+	}
+}
+`})
+
+	p := simpleMockProvider()
+
+	hook := new(MockHook)
+	ctx := testContext2(t, &ContextOpts{
+		Hooks: []Hook{hook},
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	forget := mustResourceInstanceAddr("test_object.forget")
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		forget.Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"test_string":"hi"}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+	)
+
+	// need the provider to return a requires_replace (or otherwise force replace)
+	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+		obj := req.ProposedNewState.AsValueMap()
+
+		if req.Config.IsNull() {
+			t.Fatal("should not plan a destroy")
+		}
+
+		if !req.PriorState.IsNull() {
+			if req.PriorState.GetAttr("test_string").AsString() != "hello" {
+				resp.RequiresReplace = append(resp.RequiresReplace, cty.GetAttrPath("test_string"))
+			}
+		}
+
+		resp.PlannedState = cty.ObjectVal(obj)
+		return resp
+	}
+
+	p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+		if req.PlannedState.IsNull() {
+			t.Fatal("should not be applying a destroy")
+		}
+
+		resp.NewState = req.PlannedState
+		return resp
+	}
+
+	plan, diags := ctx.Plan(m, state, nil)
+	if !diags.HasWarnings() { // forgetting emits a warning, but there should be no errors.
+		t.Errorf("missing expected forget warning")
+	}
+	assertNoDiagnostics(t, diags.ErrorsOnly())
+	change := plan.Changes.ResourceInstance(forget)
+	if change == nil {
+		t.Fatal("expected a change")
+	}
+	if got, want := change.Action, plans.ForgetThenCreate; got != want {
+		t.Fatalf("wrong change type for %s: got %s, want %s", forget, got, want)
+	}
+
+	state, applyDiags := ctx.Apply(plan, m, nil)
+	assertNoDiagnostics(t, applyDiags)
+
+	replaced := state.Resources(forget.ConfigResource())
+	if len(replaced) != 1 {
+		t.Fatal("expected one resource in state")
+	}
+
+	if len(replaced[0].Instances[addrs.NoKey].Deposed) != 0 {
+		t.Fatal("should be no deposed instances")
+	}
 }

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -894,7 +894,7 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 
 	var forgottenResources []string
 	for _, rc := range changes.Resources {
-		if rc.Action == plans.Forget || rc.Action == plans.CreateThenForget {
+		if rc.Action == plans.Forget || rc.Action == plans.ForgetThenCreate || rc.Action == plans.CreateThenForget {
 			// TODO KEM display resource ids
 			forgottenResources = append(forgottenResources, fmt.Sprintf(" - %s", rc.Addr))
 		}

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -427,7 +427,7 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 		for _, c := range changes {
 			switch c.Change.Action {
 			// Only immediate changes to the resource will trigger replacement.
-			case plans.Update, plans.DeleteThenCreate, plans.CreateThenDelete:
+			case plans.Update, plans.DeleteThenCreate, plans.CreateThenDelete, plans.ForgetThenCreate, plans.CreateThenForget:
 				return ref, true, diags
 			}
 		}
@@ -443,7 +443,7 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 	// Make sure the change is actionable. A create or delete action will have
 	// a change in value, but are not valid for our purposes here.
 	switch change.Change.Action {
-	case plans.Update, plans.DeleteThenCreate, plans.CreateThenDelete:
+	case plans.Update, plans.DeleteThenCreate, plans.CreateThenDelete, plans.ForgetThenCreate, plans.CreateThenForget:
 		// OK
 	default:
 		return nil, false, diags

--- a/internal/terraform/node_policy_resource.go
+++ b/internal/terraform/node_policy_resource.go
@@ -126,7 +126,7 @@ func policyNodesFromChange(change *plans.ResourceInstanceChange) []*nodeResource
 				After:        cty.NilVal,
 			},
 		}
-	case plans.CreateThenForget:
+	case plans.ForgetThenCreate, plans.CreateThenForget:
 		return []*nodeResourcePolicy{
 			{
 				ResourceAddr: change.Addr,

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -212,7 +212,7 @@ func (n *NodeAbstractResourceInstance) checkPreventDestroy(change *plans.Resourc
 
 	preventDestroy := n.Config.Managed.PreventDestroy && !n.overridePreventDestroy
 
-	if (change.Action == plans.Delete || change.Action.IsReplace()) && preventDestroy {
+	if (change.Action == plans.Delete || change.Action == plans.DeleteThenCreate || change.Action == plans.CreateThenDelete) && preventDestroy {
 		var diags tfdiags.Diagnostics
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
@@ -880,7 +880,8 @@ func (n *NodeAbstractResourceInstance) plan(
 	var plannedPrivate []byte
 	if plannedChange != nil {
 		// If we already planned the action, we stick to that plan
-		createBeforeDestroy = plannedChange.Action == plans.CreateThenDelete
+		createBeforeDestroy = plannedChange.Action == plans.CreateThenDelete ||
+			plannedChange.Action == plans.CreateThenForget
 
 		plannedPrivate = plannedChange.Private
 	}
@@ -1341,8 +1342,10 @@ func (n *NodeAbstractResourceInstance) plan(
 	forget := resourceLifecycleForget(n.Config)
 	if action == plans.Create && !priorValTainted.IsNull() {
 		switch {
-		case forget:
+		case forget && createBeforeDestroy:
 			action = plans.CreateThenForget
+		case forget:
+			action = plans.ForgetThenCreate
 		case createBeforeDestroy:
 			action = plans.CreateThenDelete
 		default:
@@ -1350,6 +1353,15 @@ func (n *NodeAbstractResourceInstance) plan(
 		}
 		priorVal = priorValTainted
 		actionReason = plans.ResourceInstanceReplaceBecauseTainted
+	}
+
+	if forget {
+		switch action {
+		case plans.CreateThenDelete:
+			action = plans.CreateThenForget
+		case plans.DeleteThenCreate:
+			action = plans.ForgetThenCreate
+		}
 	}
 
 	// If we plan to change the sensitivity on some portion of the value, this

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -193,7 +193,8 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 
 	destroy := (diffApply.Action == plans.Delete || diffApply.Action.IsReplace())
 	// Get the stored action for CBD if we have a plan already
-	createBeforeDestroyEnabled = diffApply.Change.Action == plans.CreateThenDelete
+	createBeforeDestroyEnabled = diffApply.Change.Action == plans.CreateThenDelete ||
+		diffApply.Change.Action == plans.CreateThenForget
 
 	if destroy && n.CreateBeforeDestroy() {
 		createBeforeDestroyEnabled = true

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -287,14 +287,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		return diags
 	}
 
-	var change *plans.ResourceInstanceChange
-	var destroyPlanDiags tfdiags.Diagnostics
-	var deferred *providers.Deferred
-	if resourceLifecycleForget(n.Config) {
-		change, destroyPlanDiags = n.planForget(ctx, state, n.DeposedKey)
-	} else {
-		change, deferred, destroyPlanDiags = n.planDestroy(ctx, state, n.DeposedKey)
-	}
+	change, deferred, destroyPlanDiags := n.planDestroy(ctx, state, n.DeposedKey)
 	diags = diags.Append(destroyPlanDiags)
 	if diags.HasErrors() {
 		return diags
@@ -359,6 +352,7 @@ var (
 	_ GraphNodeDeposedResourceInstanceObject = (*NodeForgetDeposedResourceInstanceObject)(nil)
 	_ GraphNodeConfigResource                = (*NodeForgetDeposedResourceInstanceObject)(nil)
 	_ GraphNodeResourceInstance              = (*NodeForgetDeposedResourceInstanceObject)(nil)
+	_ GraphNodeCreateBeforeDestroy           = (*NodeForgetDeposedResourceInstanceObject)(nil)
 	_ GraphNodeReferenceable                 = (*NodeForgetDeposedResourceInstanceObject)(nil)
 	_ GraphNodeReferencer                    = (*NodeForgetDeposedResourceInstanceObject)(nil)
 	_ GraphNodeExecutable                    = (*NodeForgetDeposedResourceInstanceObject)(nil)
@@ -373,6 +367,16 @@ func (n *NodeForgetDeposedResourceInstanceObject) Name() string {
 
 func (n *NodeForgetDeposedResourceInstanceObject) DestroyAddr() *addrs.AbsResourceInstance {
 	return &n.Addr
+}
+
+func (n *NodeForgetDeposedResourceInstanceObject) CreateBeforeDestroy() bool {
+	// A deposed instance is always CreateBeforeDestroy by definition, since
+	// we use deposed only to handle create-before-destroy.
+	return true
+}
+
+func (n *NodeForgetDeposedResourceInstanceObject) ForceCreateBeforeDestroy() {
+	// noop because deposed instances are always CBD
 }
 
 func (n *NodeForgetDeposedResourceInstanceObject) DeposedInstanceObjectKey() states.DeposedKey {

--- a/internal/terraform/transform_diff.go
+++ b/internal/terraform/transform_diff.go
@@ -112,11 +112,18 @@ func (t *DiffTransformer) Transform(g *Graph) error {
 
 		case plans.Delete:
 			delete = true
-		case plans.DeleteThenCreate, plans.CreateThenDelete:
+		case plans.DeleteThenCreate:
 			update = true
 			delete = true
-			createBeforeDestroy = (rc.Action == plans.CreateThenDelete)
+		case plans.CreateThenDelete:
+			update = true
+			delete = true
+			createBeforeDestroy = true
 		case plans.CreateThenForget:
+			update = true
+			forget = true
+			createBeforeDestroy = true
+		case plans.ForgetThenCreate:
 			update = true
 			forget = true
 		case plans.Forget:
@@ -137,12 +144,11 @@ func (t *DiffTransformer) Transform(g *Graph) error {
 			continue
 		}
 
-		// If we're going to do a create_before_destroy Replace operation then
-		// we need to allocate a DeposedKey to use to retain the
-		// not-yet-destroyed prior object, so that the delete node can destroy
-		// _that_ rather than the newly-created node, which will be current
-		// by the time the delete node is visited.
-		if update && delete && createBeforeDestroy {
+		// If we're going to do a create-before-remove replacement then we need
+		// to allocate a DeposedKey to retain the prior object, so that the
+		// removal node acts on that rather than the newly-created current
+		// object.
+		if update && (delete || forget) && createBeforeDestroy {
 			// In this case, variable dk will be the _pre-assigned_ DeposedKey
 			// that must be used if the update graph node deposes the current
 			// instance, which will then align with the same key we pass


### PR DESCRIPTION
The simple action of forgetting a resource was not interacting smoothly with `CreateBeforeDestroy`. Even though forgetting a resource has no external side effects, we need to treat the forget node like other delete nodes so that the internal bookkeeping is maintained correctly. Terraform relies on the order of state operations to align with the deposed instances, and CBD status needs to be reported correctly to prevent cycles.

We first add a `ForgetThenCreate` action to compliment the existing `CreateThenForget`. This allows us to maintain parity with the non-forget actions, and share codepaths throughout the code. Once that was in place, the main barrier was only that the `NodeForgetDeposedResourceInstanceObject` type did not correctly report itself as `CreateBeforeDestroy`.

This also catches a bug in the handling of `replace_triggered_by` which was not picking up forget actions.

Fixes #39088