### PR TITLE
Ensure stable ordering of marks in cty.Value comparison

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260909-170426.yaml
+++ b/.changes/v1.16/BUG FIXES-20260909-170426.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix function result comparison when there are multiple marks
+time: 2026-09-09T17:04:26.18364-04:00
+custom:
+    Issue: "39170"

--- a/internal/lang/function_results.go
+++ b/internal/lang/function_results.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sort"
 	"sync"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -57,7 +58,7 @@ func (f *FunctionResults) CheckPriorProvider(provider addrs.Provider, name strin
 	// gracefully throughout the evaluation system, whereas invalid data is
 	// harder to trace back to the source since it's usually only visible due to
 	// unexpected side-effects.
-	if !result.IsKnown() {
+	if !result.IsWhollyKnown() {
 		return nil
 	}
 
@@ -69,17 +70,14 @@ func (f *FunctionResults) CheckPriorProvider(provider addrs.Provider, name strin
 	io.WriteString(argSum, name)
 
 	for _, arg := range args {
-		// cty.Values have a Hash method, but it is not collision resistant. We
-		// are going to rely on the GoString formatting instead, which gives
-		// detailed results for all values.
-		io.WriteString(argSum, "|"+arg.GoString())
+		io.WriteString(argSum, "|"+ctyHashString(arg))
 	}
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	argHash := [sha256.Size]byte(argSum.Sum(nil))
-	resHash := sha256.Sum256([]byte(result.GoString()))
+	resHash := sha256.Sum256([]byte(ctyHashString(result)))
 
 	res, ok := f.results[argHash]
 	if !ok {
@@ -141,4 +139,27 @@ func (f *FunctionResults) GetHashes() []FunctionResultHash {
 		res = append(res, FunctionResultHash{Key: k[:], Result: r.hash[:]})
 	}
 	return res
+}
+
+// ctyHashString returns a stable string for hashing a cty value. cty.Values
+// have a Hash method, but it is not collision resistant. We are going to rely
+// on the GoString formatting instead, which gives detailed results for all
+// values. Marks however are iterated over from a map, so we need to account for
+// those separately.
+func ctyHashString(v cty.Value) string {
+	unmarked, pathMarks := v.UnmarkDeepWithPaths()
+	if len(pathMarks) == 0 {
+		return v.GoString()
+	}
+
+	marks := make([]string, 0, len(pathMarks))
+	for _, pathMark := range pathMarks {
+		path := fmt.Sprintf("%#v", pathMark.Path)
+		for mark := range pathMark.Marks {
+			marks = append(marks, fmt.Sprintf("<%s:%#v>", path, mark))
+		}
+	}
+	sort.Strings(marks)
+
+	return fmt.Sprintf("%#v|%#v", unmarked, marks)
 }

--- a/internal/lang/function_results_test.go
+++ b/internal/lang/function_results_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 
 	// set the correct global logger for tests
@@ -16,6 +17,8 @@ import (
 
 func TestFunctionCache(t *testing.T) {
 	testAddr := addrs.NewDefaultProvider("test")
+
+	deprecated := marks.NewDeprecation("test deprecation", "test")
 
 	type testCall struct {
 		provider addrs.Provider
@@ -156,6 +159,37 @@ func TestFunctionCache(t *testing.T) {
 				result: cty.False,
 			},
 			// OK because args changed from unknown to known
+		},
+		{
+			first: testCall{
+				provider: testAddr,
+				name:     "fun",
+				args:     []cty.Value{cty.NumberIntVal(2)},
+				result:   cty.True.Mark(deprecated).Mark(marks.Sensitive),
+			},
+			second: testCall{
+				provider: testAddr,
+				name:     "fun",
+				args:     []cty.Value{cty.NumberIntVal(2)},
+				result:   cty.True.Mark(deprecated).Mark(marks.Sensitive),
+			},
+		},
+
+		{
+			first: testCall{
+				provider: testAddr,
+				name:     "fun",
+				args:     []cty.Value{cty.NumberIntVal(2).Mark(marks.Ephemeral).Mark(marks.Sensitive)},
+				result:   cty.True,
+			},
+			second: testCall{
+				provider: testAddr,
+				name:     "fun",
+				args:     []cty.Value{cty.NumberIntVal(2).Mark(marks.Ephemeral).Mark(marks.Sensitive)},
+				result:   cty.False,
+			},
+			// make sure the arg marks always evaluate as equal
+			expectErr: true,
 		},
 	}
 


### PR DESCRIPTION
When comparing values of function argument and results, the non-deterministic ordering of marks can cause false negatives or positives when comparing only using the native GoString implementation. Create a function to extract stable strings from cty values for comparison, retaining marks and their location within the value.

We also switch to using `IsWhollyKnown` for arguments, since the apply value can't also have nested unknowns, and it's just wasted space in the list of plan function hashes.

Fixes #39137