### PR TITLE
fix chaining of `marks.PathsWithMark`

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260909-190037.yaml
+++ b/.changes/v1.16/BUG FIXES-20260909-190037.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Filter logic for marks could cause values with multiple marks to erroneously fail validations
+time: 2026-09-09T19:00:37.342225-04:00
+custom:
+    Issue: "39171"

--- a/internal/lang/marks/paths.go
+++ b/internal/lang/marks/paths.go
@@ -28,28 +28,31 @@ func PathsWithMark(pvms []cty.PathValueMarks, wantMark any) (withWanted []cty.Pa
 		return nil, nil
 	}
 
+	wanted := func(mark any) bool {
+		switch wantMark.(type) {
+		case valueMark, string:
+			return mark == wantMark
+
+		// For data marks we check if a mark of the type exists
+		case DeprecationMark:
+			_, ok := mark.(DeprecationMark)
+			return ok
+
+		default:
+			panic(fmt.Sprintf("unexpected mark type %T", wantMark))
+		}
+	}
+
 	for _, pvm := range pvms {
 		pathHasMark := false
-		pathHasOtherMarks := false
+		otherMarks := []any{}
 		for mark := range pvm.Marks {
-			switch wantMark.(type) {
-			case valueMark, string:
-				if mark == wantMark {
-					pathHasMark = true
-				} else {
-					pathHasOtherMarks = true
-				}
+			if wanted(mark) {
+				// record the path outside the loop so we don't get multiples
+				pathHasMark = true
 
-			// For data marks we check if a mark of the type exists
-			case DeprecationMark:
-				if _, ok := mark.(DeprecationMark); ok {
-					pathHasMark = true
-				} else {
-					pathHasOtherMarks = true
-				}
-
-			default:
-				panic(fmt.Sprintf("unexpected mark type %T", wantMark))
+			} else {
+				otherMarks = append(otherMarks, mark)
 			}
 		}
 
@@ -57,8 +60,11 @@ func PathsWithMark(pvms []cty.PathValueMarks, wantMark any) (withWanted []cty.Pa
 			withWanted = append(withWanted, pvm.Path)
 		}
 
-		if pathHasOtherMarks {
-			withOthers = append(withOthers, pvm)
+		if len(otherMarks) > 0 {
+			withOthers = append(withOthers, cty.PathValueMarks{
+				Path:  pvm.Path,
+				Marks: cty.NewValueMarks(otherMarks...),
+			})
 		}
 	}
 

--- a/internal/lang/marks/paths_test.go
+++ b/internal/lang/marks/paths_test.go
@@ -57,13 +57,7 @@ func TestPathsWithMark(t *testing.T) {
 		},
 		{
 			Path:  cty.GetAttrPath("both"),
-			Marks: cty.NewValueMarks("sensitive", "other"),
-			// Note that this intentionally preserves the fact that the
-			// attribute was both sensitive _and_ had another mark, since
-			// that gives the caller the most possible information to
-			// potentially handle this combination in a special way in
-			// an error message, or whatever. It also conveniently avoids
-			// allocating a new mark set, which is nice.
+			Marks: cty.NewValueMarks("other"),
 		},
 		{
 			Path:  cty.GetAttrPath("neither"),
@@ -79,7 +73,7 @@ func TestPathsWithMark(t *testing.T) {
 		},
 		{
 			Path:  cty.GetAttrPath("multipleDeprecationsAndSensitive"),
-			Marks: cty.NewValueMarks(NewDeprecation("this is deprecated", ""), NewDeprecation("this is also deprecated", ""), "sensitive"),
+			Marks: cty.NewValueMarks(NewDeprecation("this is deprecated", ""), NewDeprecation("this is also deprecated", "")),
 		},
 	}
 
@@ -90,7 +84,7 @@ func TestPathsWithMark(t *testing.T) {
 		t.Errorf("wrong set of entries with other marks\n%s", diff)
 	}
 
-	gotPaths, gotOthers = PathsWithMark(input, Deprecation)
+	gotPaths, gotOthers = PathsWithMark(gotOthers, Deprecation)
 
 	wantPaths = []cty.Path{
 		cty.GetAttrPath("deprecated"),
@@ -99,24 +93,16 @@ func TestPathsWithMark(t *testing.T) {
 	}
 	wantOthers = []cty.PathValueMarks{
 		{
-			Path:  cty.GetAttrPath("sensitive"),
-			Marks: cty.NewValueMarks("sensitive"),
-		},
-		{
 			Path:  cty.GetAttrPath("other"),
 			Marks: cty.NewValueMarks("other"),
 		},
 		{
 			Path:  cty.GetAttrPath("both"),
-			Marks: cty.NewValueMarks("sensitive", "other"),
+			Marks: cty.NewValueMarks("other"),
 		},
 		{
 			Path:  cty.GetAttrPath("neither"),
 			Marks: cty.NewValueMarks("x", "y"),
-		},
-		{
-			Path:  cty.GetAttrPath("multipleDeprecationsAndSensitive"),
-			Marks: cty.NewValueMarks(NewDeprecation("this is deprecated", ""), NewDeprecation("this is also deprecated", ""), "sensitive"),
 		},
 	}
 


### PR DESCRIPTION
The `PathsWithMark` function was retaining marks that matched the wanted mark in the set of unmatched `PathValueMarks`. This logic breaks when chaining the function to filter out multiple types of marks, since previously filtered marks can show up in the final set.

Fixes #39161