### PR TITLE
Fix import block implicit provider resolution regression (#39144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.18.0 (Unreleased)
 
+BUG FIXES:
+
+- `terraform plan -generate-config-out`: Resources that only exist via an `import` block (no matching `resource` block) once again resolve their provider from `required_providers` when the import block does not set an explicit `provider` argument, fixing a regression introduced in v1.16.0. ([issue #39144](https://github.com/hashicorp/terraform/issues/39144))
 
 EXPERIMENTS:
 

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -376,6 +376,19 @@ func (n *NodeAbstractResource) Provider() ProviderRef {
 			ref.Addr.Alias = n.importTargets[0].Config.ProviderConfigRef.Alias
 			return ref
 		}
+
+		// The import target may not have an explicit provider reference, but
+		// as long as it has config the provider will have already been
+		// resolved (via required_providers, or implied by the resource type)
+		// at decode time, so we can use that directly.
+		if n.importTargets[0].Config != nil {
+			return ProviderRef{
+				Addr: addrs.AbsProviderConfig{
+					Provider: n.importTargets[0].Config.Provider,
+					Module:   n.ModulePath(),
+				},
+			}
+		}
 	}
 
 	// No provider configuration found; return a default address

--- a/internal/terraform/node_resource_abstract_test.go
+++ b/internal/terraform/node_resource_abstract_test.go
@@ -115,6 +115,50 @@ func TestNodeAbstractResourceProvider(t *testing.T) {
 	}
 }
 
+// TestNodeAbstractResourceProvider_ImportTargetImplicitProvider verifies that
+// an import-only resource (no matching config block, i.e. the
+// -generate-config-out case) resolves its provider using the import block's
+// Config.Provider -- which is already correctly resolved via
+// required_providers at decode time -- even when the import block does not
+// set an explicit `provider = x` reference. This is a regression test for
+// https://github.com/hashicorp/terraform/issues/39144.
+func TestNodeAbstractResourceProvider_ImportTargetImplicitProvider(t *testing.T) {
+	addr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "datahub_ingestion_source",
+		Name: "rt_source",
+	}.InModule(addrs.RootModule)
+
+	want := addrs.Provider{
+		Hostname:  addrs.DefaultProviderRegistryHost,
+		Namespace: "datahub-project",
+		Type:      "datahub",
+	}
+
+	node := &NodeAbstractResource{
+		// Just enough NodeAbstractResource for the Provider function.
+		// (This would not be valid for some other functions.)
+		Addr: addr,
+		// No n.Config, since this resource only exists via an import block
+		// (the config-generation case).
+		importTargets: []*ImportTarget{
+			{
+				Config: &configs.Import{
+					// No ProviderConfigRef: the import block does not set an
+					// explicit `provider = x` attribute, but Provider is
+					// still resolved correctly via required_providers.
+					Provider: want,
+				},
+			},
+		},
+	}
+
+	got := node.Provider()
+	if got.FQN() != want {
+		t.Errorf("wrong result\naddr:  %s\ngot:   %s\nwant:  %s", addr, got.FQN(), want)
+	}
+}
+
 // Make sure ProvideBy returns the final resolved provider
 func TestNodeAbstractResourceSetProvider(t *testing.T) {
 	node := &NodeAbstractResource{


### PR DESCRIPTION
## Description

Fixes a regression from `ee47cd376` ("refactor GraphNodeProviderConsumer") that broke `-generate-config-out` provider resolution for `import` blocks that don't set an explicit `provider = x` attribute.

Before the refactor, `NodeAbstractResource.Provider()`-equivalent logic had an unconditional fallback for import-only resources (resources with no matching `resource` config block, i.e. the config-generation case):

```go
if len(n.importTargets) > 0 {
    if n.importTargets[0].Config != nil {
        return n.importTargets[0].Config.Provider   // resolved via required_providers at decode time
    }
}
```

The merge into a single `Provider()` method kept only the narrower branch that fires solely when the import block sets an **explicit** `provider = x` reference, dropping the implicit case entirely. As a result, an ordinary/idiomatic import block like:

```hcl
import {
  to = datahub_ingestion_source.rt_source
  id = "rt-source"
}
```

fell through to `ImpliedProviderForUnqualifiedType`, ignoring `required_providers`, causing `terraform plan -generate-config-out` to fail with `unavailable provider "registry.terraform.io/hashicorp/datahub"` instead of resolving via the `datahub-project/datahub` source declared in `required_providers`.

## Fix

Restores the dropped fallback: when an import target has config but no explicit provider reference, use `importTargets[0].Config.Provider`, which is already resolved correctly via `required_providers` (or the implied default) at config-decode time (`configs.Module.ImpliedProviderForUnqualifiedType` / `assignImportProviders` in `internal/configs/config.go`).

## Testing

- Added `TestNodeAbstractResourceProvider_ImportTargetImplicitProvider` regression test in `internal/terraform/node_resource_abstract_test.go`, which fails without the fix and passes with it.
- Ran the full `internal/terraform` test suite before and after the change; the same set of pre-existing failures (Windows path-separator/tempfile flakiness) occur in both cases — no new failures introduced.

Fixes #39144

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>