### PR TITLE
Prefer dependent updates before orphan deletion 🤖🤖🤖

### DIFF
--- a/.changes/v1.18/20260910_update_before_dependency_deletion.yaml
+++ b/.changes/v1.18/20260910_update_before_dependency_deletion.yaml
@@ -1,0 +1,3 @@
+kind: ENHANCEMENTS
+body: Prefer in-place updates before deleting their former dependencies within the same provider configuration when the ordering does not introduce a graph cycle. Replacement and explicit create-before-destroy ordering are unchanged.
+time: 2026-09-10T00:00:00Z

--- a/docs/destroying.md
+++ b/docs/destroying.md
@@ -181,6 +181,36 @@ digraph destroy_then_update {
     a -> b_d;
 }
 -->
+## Updating Former Dependents Before Deletion
+
+When an object is deleted without replacement, Terraform can update its former
+dependents before deleting it. For example, if a distribution stops referencing
+a policy and that policy is removed in the same plan, the distribution update
+can detach the policy before the provider attempts to delete it. No additional
+lifecycle setting is needed for this ordering.
+
+`OrphanDestroyEdgeTransformer` runs after the existing destroy and
+create-before-destroy transformers. It considers an incoming resource edge only
+when the source is an in-place update, its stored dependencies include the
+resource being deleted, and both changes use the same provider configuration.
+This distinction preserves the opposite case: an object being deleted must
+still be destroyed before updating an object on which it depended.
+
+For each deletion, the transformer removes the eligible incoming edges and
+checks whether reversing them would introduce a cycle through other graph
+edges. If so, it restores all of those edges for that deletion. Otherwise, the
+deletion waits for all eligible updates to complete successfully. Deletions are
+considered in a stable order so interacting candidates produce a deterministic
+result.
+
+This is a limited ordering preference, not a general solution for registration
+relationships. It does not change replacement actions, deposed-object cleanup,
+explicit create-before-destroy behavior, or directly reverse edges across
+provider configurations. Existing ordering also remains when a cycle prevents
+the reversal. Those cases can still require explicit lifecycle configuration.
+Dependencies stored in state are resource-level, so the ordering is conservative
+when only some instances of a resource are deleted.
+
 ## Create Before Destroy
 
 Currently, the only user-controllable method for changing the ordering of

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -1050,6 +1050,89 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_removeDependencyBeforeDestroy(t *testing.T) {
+	for _, parallelism := range []int{1, 10} {
+		for _, failUpdate := range []bool{false, true} {
+			t.Run(fmt.Sprintf("parallelism=%d/failUpdate=%t", parallelism, failUpdate), func(t *testing.T) {
+				m := testModuleInline(t, map[string]string{
+					"main.tf": `
+resource "aws_instance" "distribution" {
+  foo = "detached"
+}
+`,
+				})
+				p := testProvider("aws")
+				p.PlanResourceChangeFn = testDiffFn
+				var detached, deleted atomic.Bool
+				p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+					if req.PlannedState.IsNull() {
+						deleted.Store(true)
+					}
+					if req.PlannedState.IsNull() && !detached.Load() {
+						return providers.ApplyResourceChangeResponse{
+							NewState:    req.PriorState,
+							Diagnostics: tfdiags.Diagnostics{}.Append(errors.New("policy is still attached to the distribution")),
+						}
+					}
+					if !req.PlannedState.IsNull() && failUpdate {
+						return providers.ApplyResourceChangeResponse{
+							NewState:    req.PriorState,
+							Diagnostics: tfdiags.Diagnostics{}.Append(errors.New("distribution update failed")),
+						}
+					}
+					resp := testApplyFn(req)
+					if !req.PlannedState.IsNull() && !resp.Diagnostics.HasErrors() {
+						detached.Store(true)
+					}
+					return resp
+				}
+				policyAddr := mustResourceInstanceAddr("aws_instance.policy")
+				distributionAddr := mustResourceInstanceAddr("aws_instance.distribution")
+				providerAddr := mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`)
+				state := states.BuildState(func(s *states.SyncState) {
+					s.SetResourceInstanceCurrent(policyAddr, &states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{"id":"policy","foo":"policy"}`),
+					}, providerAddr)
+					s.SetResourceInstanceCurrent(distributionAddr, &states.ResourceInstanceObjectSrc{
+						Status:       states.ObjectReady,
+						AttrsJSON:    []byte(`{"id":"distribution","foo":"policy"}`),
+						Dependencies: []addrs.ConfigResource{policyAddr.ContainingResource().Config()},
+					}, providerAddr)
+				})
+				ctx := testContext2(t, &ContextOpts{
+					Parallelism: parallelism,
+					Providers: map[addrs.Provider]providers.Factory{
+						addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+					},
+				})
+				plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+				tfdiags.AssertNoErrors(t, diags)
+				if got := plan.Changes.ResourceInstance(policyAddr).Action; got != plans.Delete {
+					t.Fatalf("policy action = %s; want Delete", got)
+				}
+				if got := plan.Changes.ResourceInstance(distributionAddr).Action; got != plans.Update {
+					t.Fatalf("distribution action = %s; want Update", got)
+				}
+				state, diags = ctx.Apply(plan, m, nil)
+				if failUpdate {
+					if !diags.HasErrors() || !strings.Contains(diags.Err().Error(), "distribution update failed") {
+						t.Fatalf("expected update failure; got %s", diags.Err())
+					}
+					if deleted.Load() || state.ResourceInstance(policyAddr) == nil {
+						t.Fatal("policy deleted after failed distribution update")
+					}
+					return
+				}
+				tfdiags.AssertNoErrors(t, diags)
+				if state.ResourceInstance(policyAddr) != nil {
+					t.Fatal("policy remains in state after deletion")
+				}
+			})
+		}
+	}
+}
+
 // This tests that when a CBD resource depends on a non-CBD resource,
 // we can still properly apply changes that require new for both.
 func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
@@ -3977,8 +4060,9 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 					// Sleep to allow parallel execution
 					time.Sleep(50 * time.Millisecond)
 
-					// Verify that called is 0 (dep not called)
-					if atomic.LoadInt32(&called) != 1 {
+					// The update must remove the reference before the old
+					// instance is destroyed.
+					if atomic.LoadInt32(&called) != 0 {
 						resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("nothing else should be called"))
 						return
 					}

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -243,6 +243,8 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 			State:  b.State,
 		},
 
+		&OrphanDestroyEdgeTransformer{Changes: b.Changes},
+
 		// In a destroy, we need to remove configuration nodes that are not used
 		// at all, as they may not be able to evaluate. These include variables,
 		// locals, and instance expanders.

--- a/internal/terraform/graph_builder_apply_test.go
+++ b/internal/terraform/graph_builder_apply_test.go
@@ -611,8 +611,8 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 
 	expected := strings.TrimSpace(`
 test_object.a (destroy)
+  test_object.b
 test_object.b
-  test_object.a (destroy)
 `)
 
 	instanceGraph := filterInstances(g)
@@ -881,15 +881,14 @@ test_object.other (expand)
 const testApplyGraphBuilderDestroyCountStr = `
 provider["registry.terraform.io/hashicorp/test"]
 provider["registry.terraform.io/hashicorp/test"] (close)
-  test_object.B
+  test_object.A[1] (destroy)
 root
   provider["registry.terraform.io/hashicorp/test"] (close)
 test_object.A (expand)
   provider["registry.terraform.io/hashicorp/test"]
 test_object.A[1] (destroy)
-  provider["registry.terraform.io/hashicorp/test"]
+  test_object.B
 test_object.B
-  test_object.A[1] (destroy)
   test_object.B (expand)
 test_object.B (expand)
   test_object.A (expand)

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -5,6 +5,8 @@ package terraform
 
 import (
 	"log"
+	"slices"
+	"strings"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/dag"
@@ -252,6 +254,80 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 		}
 	}
 
+	return nil
+}
+
+// OrphanDestroyEdgeTransformer orders in-place updates before deletion of their
+// former dependencies when this does not conflict with other graph edges.
+// Replacement and create_before_destroy ordering are left unchanged.
+type OrphanDestroyEdgeTransformer struct {
+	Changes *plans.ChangesSrc
+}
+
+func (t *OrphanDestroyEdgeTransformer) Transform(g *Graph) error {
+	if t.Changes == nil {
+		return nil
+	}
+
+	// A stable order makes the result deterministic when candidate reversals
+	// interact through other nodes in the graph.
+	vertices := g.VerticesSeq().Collect()
+	slices.SortFunc(vertices, func(a, b dag.Vertex) int {
+		return strings.Compare(a.Name(), b.Name())
+	})
+	for _, v := range vertices {
+		d, ok := v.(GraphNodeDestroyer)
+		if !ok || d.DestroyAddr() == nil {
+			continue
+		}
+		if _, ok := v.(GraphNodeDeposedResourceInstanceObject); ok {
+			continue
+		}
+		change := t.Changes.ResourceInstance(*d.DestroyAddr())
+		if change == nil || change.Action != plans.Delete {
+			continue
+		}
+		if cbd, ok := v.(GraphNodeCreateBeforeDestroy); ok && cbd.CreateBeforeDestroy() {
+			continue
+		}
+
+		var updates []dag.Vertex
+		for src := range g.EdgesTo(v).All() {
+			c, ok := src.(GraphNodeCreator)
+			if !ok || c.CreateAddr() == nil {
+				continue
+			}
+			update := t.Changes.ResourceInstance(*c.CreateAddr())
+			if update == nil || update.Action != plans.Update || !update.ProviderAddr.Equal(change.ProviderAddr) {
+				continue
+			}
+			ri, ok := src.(GraphNodeResourceInstance)
+			if !ok || !slices.ContainsFunc(ri.StateDependencies(), func(dep addrs.ConfigResource) bool {
+				return dep.Equal(d.DestroyAddr().ConfigResource())
+			}) {
+				continue
+			}
+			updates = append(updates, src)
+		}
+		for _, src := range updates {
+			g.RemoveEdge(src, v)
+		}
+
+		cycle := false
+		for _, src := range updates {
+			if g.Ancestors(src).Contains(v) {
+				cycle = true
+				break
+			}
+		}
+		for _, src := range updates {
+			if cycle {
+				g.Connect(src, v)
+			} else {
+				g.Connect(v, src)
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/terraform/transform_destroy_edge_test.go
+++ b/internal/terraform/transform_destroy_edge_test.go
@@ -561,6 +561,90 @@ test_object.B
 	}
 }
 
+func TestOrphanDestroyEdgeTransformer(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		action            plans.Action
+		updateAction      plans.Action
+		crossProvider     bool
+		cycle             bool
+		cbd               bool
+		deposed           bool
+		reverseDependency bool
+		wantUpdateFirst   bool
+	}{
+		{name: "delete", action: plans.Delete, updateAction: plans.Update, wantUpdateFirst: true},
+		{name: "replace", action: plans.DeleteThenCreate, updateAction: plans.Update},
+		{name: "create before destroy replacement", action: plans.CreateThenDelete, updateAction: plans.Update},
+		{name: "forget", action: plans.Forget, updateAction: plans.Update},
+		{name: "unchanged dependent", action: plans.Delete, updateAction: plans.NoOp},
+		{name: "replaced dependent", action: plans.Delete, updateAction: plans.DeleteThenCreate},
+		{name: "cross provider", action: plans.Delete, updateAction: plans.Update, crossProvider: true},
+		{name: "cycle", action: plans.Delete, updateAction: plans.Update, cycle: true},
+		{name: "explicit lifecycle", action: plans.Delete, updateAction: plans.Update, cbd: true},
+		{name: "deposed", action: plans.Delete, updateAction: plans.Update, deposed: true},
+		{name: "destroy dependent before updating dependency", action: plans.Delete, updateAction: plans.Update, reverseDependency: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			policyAddr := mustResourceInstanceAddr("test_object.policy")
+			distributionAddr := mustResourceInstanceAddr("test_object.distribution")
+			providerAddr := mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`)
+			updateProviderAddr := providerAddr
+			if tc.crossProvider {
+				updateProviderAddr.Alias = "other"
+			}
+			var policy GraphNodeDestroyer = testDestroyNode(policyAddr.String())
+			if tc.deposed {
+				policy = &NodeDestroyDeposedResourceInstanceObject{
+					NodeAbstractResourceInstance: NewNodeAbstractResourceInstance(policyAddr),
+					DeposedKey:                   states.DeposedKey("12345678"),
+				}
+			}
+			if tc.cbd {
+				policy.(GraphNodeCreateBeforeDestroy).ForceCreateBeforeDestroy()
+			}
+			distribution := testUpdateNode(distributionAddr.String())
+			state := states.BuildState(func(s *states.SyncState) {
+				var deps []addrs.ConfigResource
+				if !tc.reverseDependency {
+					deps = []addrs.ConfigResource{policyAddr.ConfigResource()}
+				}
+				s.SetResourceInstanceCurrent(distributionAddr, &states.ResourceInstanceObjectSrc{
+					Status:       states.ObjectReady,
+					AttrsJSON:    []byte(`{"id":"distribution"}`),
+					Dependencies: deps,
+				}, updateProviderAddr)
+			})
+			g := &Graph{}
+			g.Add(policy)
+			g.Add(distribution)
+			g.Connect(distribution, policy)
+			if tc.cycle {
+				intermediate := testUpdateNode("test_object.intermediate")
+				g.Add(intermediate)
+				g.Connect(distribution, intermediate)
+				g.Connect(intermediate, policy)
+			}
+			if err := (&AttachStateTransformer{State: state}).Transform(g); err != nil {
+				t.Fatal(err)
+			}
+			changes := &plans.ChangesSrc{Resources: []*plans.ResourceInstanceChangeSrc{
+				{Addr: policyAddr, ProviderAddr: providerAddr, ChangeSrc: plans.ChangeSrc{Action: tc.action}},
+				{Addr: distributionAddr, ProviderAddr: updateProviderAddr, ChangeSrc: plans.ChangeSrc{Action: tc.updateAction}},
+			}}
+			if err := (&OrphanDestroyEdgeTransformer{Changes: changes}).Transform(g); err != nil {
+				t.Fatal(err)
+			}
+			if got := g.Ancestors(policy).Contains(distribution); got != tc.wantUpdateFirst {
+				t.Fatalf("update before delete = %t; want %t\n%s", got, tc.wantUpdateFirst, g.String())
+			}
+			if got := g.Ancestors(distribution).Contains(policy); got == tc.wantUpdateFirst {
+				t.Fatalf("delete before update = %t; want %t\n%s", got, !tc.wantUpdateFirst, g.String())
+			}
+		})
+	}
+}
+
 func testDestroyNode(addrString string) GraphNodeDestroyer {
 	instAddr := mustResourceInstanceAddr(addrString)
 	inst := NewNodeAbstractResourceInstance(instAddr)


### PR DESCRIPTION
When a resource is updated to remove a reference and the referenced object is deleted in the same plan, Terraform currently schedules deletion first. APIs with attachment constraints reject that deletion. CloudFront policy removal in hashicorp/terraform-provider-aws#33047 is one example.

This draft proposes a limited automatic ordering preference for deletion without replacement. After the existing destroy/CBD transformations, reverse eligible edges so in-place updates of former dependents complete before deletion. Eligibility requires a stored dependency and the same provider configuration. If reversing the eligible edges for a deletion would introduce a cycle, retain its existing ordering. Process deletions in a stable order.

The mock-provider regression reproduces an attached policy rejecting deletion before the change and succeeds afterward without `create_before_destroy`, including with parallelism 1. A failed detachment prevents even attempting deletion and preserves the policy in state.

Related: #31309; hashicorp/terraform-provider-aws#33047. This does not close the general registration-pattern enhancement.

### Scope and review questions

- This changes default update/delete ordering within one provider configuration. Is that compatibility tradeoff acceptable for deletion-only changes, or should this require a future provider capability instead?
- Replacement actions, deposed objects, and existing create-before-destroy handling are excluded. This does not solve replacement under unique-name constraints or infer Terraform resource-address renames.
- Direct cross-provider-configuration edges are excluded. Indirect scheduling can still be affected; this is not a claim that resources outside the pair are unaffected.
- When another dependency path prevents reversal, the old ordering remains and an attachment-constrained API can still reject deletion. A more general solution would need additional design.
- Stored dependencies are resource-level, so instance ordering remains conservative.
- Providers must still wait for their updates to become effective where required. No CloudFront acceptance test or other real infrastructure operation was run.

### Validation

- Before the implementation, the new apply regression failed with `policy is still attached to the distribution`.
- `go test ./internal/terraform -count=1` passed.
- `go test -race ./internal/terraform -count=1` passed.
- Boundary tests cover replacements, unchanged/replaced dependents, provider aliases, cycles, explicit CBD, deposed objects, and the opposite dependency direction.
- Two graph expectations and the count-decrement operation-order assertion were updated for the intentional default-order change. The test requiring destruction of a dependent before updating its dependency remains unchanged and passes.

## Target Release

1.18.x, subject to maintainer agreement on the behavior change.

## Rollback Plan

Revert the ordering transformer and its registration to restore prior ordering. No state or plan format migration is introduced.

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No access-control, encryption, or logging controls are changed. The proposal changes execution ordering only; it does not add provider API operations outside the plan.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.

### AI assistance

Codex inspected the AWS provider and Terraform Core implementations, authored the candidate change and tests, and ran local validation. Submitted as a draft for human review, especially of graph-ordering compatibility and the limitations above.
