### PR TITLE
refactor: Replace `initializing_state_store_message` `init_output` JSON message with new `state_store_initialization_start` message.

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -176,7 +176,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ini
 	defer span.End()
 
 	if root.StateStore != nil {
-		view.Output(views.InitializingStateStoreMessage, root.StateStore.Type)
+		view.LogInitializingStateStoreStart(root.StateStore.Type)
 	} else {
 		view.Output(views.InitializingBackendMessage)
 	}

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -26,9 +26,12 @@ type Init interface {
 	// LogConfigurationCopyingStart describes the start of copying a module to create the root module in an empty directory.
 	LogConfigurationCopyingStart(moduleSource string)
 
-	// LogInitializingStateStoreProviderStart indicates progress during installation of a state store provider.
+	// LogInstallStateStoreProviderStart indicates progress during installation of a state store provider.
 	// This is signposted as distinct from general provider download, which may happen later in init.
 	LogInstallStateStoreProviderStart(providerAddr addrs.Provider, cons getproviders.VersionConstraints, storeType string)
+
+	// LogInitializingStateStoreStart indicates progress during initialization of a state store.
+	LogInitializingStateStoreStart(storeType string)
 
 	ModuleInstallationLogger
 	ProviderInstallationLogger
@@ -103,6 +106,12 @@ func (v *InitHuman) LogInstallStateStoreProviderStart(pAddr tfaddr.Provider, con
 	}
 	params := []any{pAddr.ForDisplay(), consSuffix, storeType}
 	msg := fmt.Sprintf(logInstallStateStoreProviderStartMessageHuman, params...)
+	v.print(msg)
+}
+
+func (v *InitHuman) LogInitializingStateStoreStart(storeType string) {
+	template := "\n[reset][bold]Initializing the state store %q..."
+	msg := fmt.Sprintf(template, storeType)
 	v.print(msg)
 }
 
@@ -334,6 +343,15 @@ func (v *InitJSON) LogInstallStateStoreProviderStart(pAddr tfaddr.Provider, cons
 	)
 }
 
+func (v *InitJSON) LogInitializingStateStoreStart(storeType string) {
+	template := "Initializing the state store %q..."
+	msg := fmt.Sprintf(template, storeType)
+	v.view.log.Info(
+		msg,
+		"type", json.MessageStateStoreInitializationStart,
+	)
+}
+
 // Implements StateStoreProviderTrustLogger interface.
 func (v *InitJSON) LogInteractiveApproval() {
 	v.view.log.Info(
@@ -552,10 +570,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]Initializing provider plugins...",
 		JSONValue:  "Initializing provider plugins...",
 	},
-	"initializing_state_store_message": {
-		HumanValue: "\n[reset][bold]Initializing the state store %q...",
-		JSONValue:  "Initializing the state store %q...",
-	},
 	"dependencies_lock_changes_info": {
 		HumanValue: dependenciesLockChangesInfo,
 		JSONValue:  dependenciesLockChangesInfo,
@@ -662,7 +676,6 @@ const (
 	InitializingTerraformCloudMessage InitMessageCode = "initializing_terraform_cloud_message"
 	InitializingModulesMessage        InitMessageCode = "initializing_modules_message"
 	InitializingBackendMessage        InitMessageCode = "initializing_backend_message"
-	InitializingStateStoreMessage     InitMessageCode = "initializing_state_store_message"
 	InitializingProviderPluginMessage InitMessageCode = "initializing_provider_plugin_message"
 	LockInfo                          InitMessageCode = "lock_info"
 	DependenciesLockChangesInfo       InitMessageCode = "dependencies_lock_changes_info"

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -89,6 +89,9 @@ const (
 	MessageProviderInteractiveRejection MessageType = "provider_interactive_rejection"
 	MessageProviderAutomaticApproval    MessageType = "provider_automatic_approval"
 
+	// Backend/state store initialization messages
+	MessageStateStoreInitializationStart MessageType = "state_store_initialization_start"
+
 	// State migration-related messages
 	MessageMigrationStart                             MessageType = "migration_start"
 	MessageMigrationComplete                          MessageType = "migration_complete"


### PR DESCRIPTION
This PR is related to [this comment](https://github.com/hashicorp/terraform-json/pull/212#discussion_r3970656133).

The log message edited in this PR is equivalent to the existing "Initializing the backend..." message that looks like this in JSON output:

```
{"@level":"info","@message":"Initializing the backend...","@module":"terraform.ui","@timestamp":"2026-09-09T11:07:54.780327Z","message_code":"initializing_backend_message","type":"init_output"}
```

When I added the "Initializing the state store "<type>"..." equivalent for when PSS is in use I followed the existing JSON message design. Since then I've realised how `init`'s output does not follow the conventions elsewhere in the codebase (for more info see https://github.com/hashicorp/terraform/issues/38763).

Therefore, this PR makes this event's JSON log have its own distinct `"type"` value of `"state_store_initialization_start"`

This isn't breaking as the original message is experimental.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.18.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
