### PR TITLE
fix: properly resolve required provider for imports

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260910-121207.yaml
+++ b/.changes/v1.16/BUG FIXES-20260910-121207.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix issue with import provider resolution
+time: 2026-09-10T12:12:07.068649-04:00
+custom:
+    Issue: "39185"

--- a/internal/terraform/context_plan_import_test.go
+++ b/internal/terraform/context_plan_import_test.go
@@ -2465,6 +2465,86 @@ import {
 	})
 }
 
+func TestContext2Plan_importResourceConfigGenWithProviderLocalName_implicit(t *testing.T) {
+	// regression reported in https://github.com/hashicorp/terraform/issues/39144
+	addr := mustResourceInstanceAddr("test_object.a")
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+terraform {
+  required_providers {
+    test = {
+      source  = "example.com/foo/test"
+    }
+  }
+}
+
+provider "test" {}
+
+import {
+  to = test_object.a
+  id = "123"
+}
+`,
+	})
+
+	p := simpleMockProvider()
+	providerAddr := addrs.MustParseProviderSourceString("example.com/foo/test")
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			providerAddr: testProviderFuncFixed(p),
+		},
+	})
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
+		NewState: cty.ObjectVal(map[string]cty.Value{
+			"test_string": cty.StringVal("foo"),
+		}),
+	}
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "test_object",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"test_string": cty.StringVal("foo"),
+				}),
+			},
+		},
+	}
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode:               plans.NormalMode,
+		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
+	})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	t.Run(addr.String(), func(t *testing.T) {
+		instPlan := plan.Changes.ResourceInstance(addr)
+		if instPlan == nil {
+			t.Fatalf("no plan for %s at all", addr)
+		}
+		if got := instPlan.ProviderAddr.Provider; got != providerAddr {
+			t.Errorf("wrong provider\ngot:  %s\nwant: %s", got, providerAddr)
+		}
+		want := `resource "test_object" "a" {
+  test_bool   = null
+  test_list   = null
+  test_map    = null
+  test_number = null
+  test_string = "foo"
+}`
+		got := instPlan.GeneratedConfig
+		if diff := cmp.Diff(want, got); len(diff) > 0 {
+			t.Errorf("got:\n%s\nwant:\n%s\ndiff:\n%s", got, want, diff)
+		}
+	})
+}
+
 func TestContext2Plan_importDeferredResource(t *testing.T) {
 	addr := mustResourceInstanceAddr("test_object.a")
 	m := testModuleInline(t, map[string]string{

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
@@ -16,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // ConcreteResourceNodeFunc is a callback type used to convert an
@@ -364,16 +365,18 @@ func (n *NodeAbstractResource) Provider() ProviderRef {
 		// The import targets should either all be defined via config or none
 		// of them should be. They should also all have the same provider, so it
 		// shouldn't matter which we check here, as they'll all give the same.
-		if n.importTargets[0].Config != nil && n.importTargets[0].Config.ProviderConfigRef != nil {
+		if n.importTargets[0].Config != nil {
+			imp := n.importTargets[0].Config
 			ref := ProviderRef{
 				Addr: addrs.AbsProviderConfig{
-					Provider: n.importTargets[0].Config.Provider,
-					Alias:    n.importTargets[0].Config.ProviderConfigRef.Alias,
+					Provider: imp.Provider,
 					Module:   n.ModulePath(),
 				},
 			}
 
-			ref.Addr.Alias = n.importTargets[0].Config.ProviderConfigRef.Alias
+			if imp.ProviderConfigRef != nil {
+				ref.Addr.Alias = imp.ProviderConfigRef.Alias
+			}
 			return ref
 		}
 	}


### PR DESCRIPTION
Addresses a regression introduced in https://github.com/hashicorp/terraform/commit/ee47cd37610daaed4edc9ff4083957663b488ca1 - import blocks were not using the provider defined in required_providers.


<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #39144

## Target Release
1.16 onwards
<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.18.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
