### PR TITLE
rpcapi: release the handle table mutex on newHandleWithDependency's error paths

### DIFF
--- a/.changes/v1.18/BUG FIXES-20260910-203656.yaml
+++ b/.changes/v1.18/BUG FIXES-20260910-203656.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix a potential deadlock in the RPC API where a failed handle creation left the handle table locked
+time: 2026-09-10T20:36:56.889009-05:00
+custom:
+    Issue: "39186"

--- a/internal/rpcapi/handles.go
+++ b/internal/rpcapi/handles.go
@@ -219,6 +219,7 @@ func newHandle[ObjT any](t *handleTable, obj ObjT) handle[ObjT] {
 // returned error will be [newHandleErrorNoParent].
 func newHandleWithDependency[ObjT, DepT any](t *handleTable, obj ObjT, dep handle[DepT]) (handle[ObjT], error) {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	if depObjectI, exists := t.handleObjs[int64(dep)]; !exists {
 		return handle[ObjT](0), newHandleErrorNoParent
 	} else if depObject, ok := depObjectI.(DepT); !ok {
@@ -233,7 +234,6 @@ func newHandleWithDependency[ObjT, DepT any](t *handleTable, obj ObjT, dep handl
 		t.handleDeps[int64(dep)] = make(map[int64]struct{})
 	}
 	t.handleDeps[int64(dep)][hnd] = struct{}{}
-	t.mu.Unlock()
 	return handle[ObjT](hnd), nil
 }
 

--- a/internal/rpcapi/handles_test.go
+++ b/internal/rpcapi/handles_test.go
@@ -1,0 +1,75 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package rpcapi
+
+import (
+	"testing"
+)
+
+// assertTableUnlocked fails the test if the handle table's mutex is still held.
+//
+// TryLock is used rather than racing a goroutine against a timeout so that the
+// assertion is deterministic: a held mutex fails immediately instead of after a
+// wait, and a released one costs nothing.
+func assertTableUnlocked(t *testing.T, tbl *handleTable) {
+	t.Helper()
+	if !tbl.mu.TryLock() {
+		t.Fatal("handleTable.mu is still held; subsequent handle operations would block forever")
+	}
+	tbl.mu.Unlock()
+}
+
+func TestNewHandleWithDependencyNoParentReleasesLock(t *testing.T) {
+	tbl := newHandleTable()
+
+	// Close the dependency first, so that creating a handle against it takes
+	// the same path as an OpenStackConfiguration racing a CloseSourceBundle.
+	depHnd := newHandle(tbl, "dependency-obj")
+	if err := closeHandle(tbl, depHnd); err != nil {
+		t.Fatalf("closing the dependency handle: %s", err)
+	}
+
+	if _, err := newHandleWithDependency(tbl, "obj", depHnd); err != newHandleErrorNoParent {
+		t.Fatalf("wrong error for a missing parent\ngot:  %v\nwant: %v", err, newHandleErrorNoParent)
+	}
+
+	assertTableUnlocked(t, tbl)
+}
+
+func TestNewHandleWithDependencyWrongTypeReleasesLock(t *testing.T) {
+	tbl := newHandleTable()
+
+	// The dependency is alive but holds a string, while the lookup below asks
+	// for an int, so the type assertion panics. That panic is the caller's
+	// fault and is meant to be fatal, but it must not leave the table locked:
+	// anything recovering from it would otherwise deadlock every later call.
+	depHnd := newHandle(tbl, "dependency-obj")
+	wrongType := handle[int](depHnd)
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected a panic for a dependency handle of the wrong type")
+			}
+		}()
+		newHandleWithDependency(tbl, "obj", wrongType)
+	}()
+
+	assertTableUnlocked(t, tbl)
+}
+
+func TestNewHandleWithDependencySuccessReleasesLock(t *testing.T) {
+	tbl := newHandleTable()
+
+	depHnd := newHandle(tbl, "dependency-obj")
+	hnd, err := newHandleWithDependency(tbl, "obj", depHnd)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got, ok := readHandle(tbl, hnd); !ok || got != "obj" {
+		t.Fatalf("new handle did not read back\ngot:  %q, %t\nwant: %q, true", got, ok, "obj")
+	}
+
+	assertTableUnlocked(t, tbl)
+}


### PR DESCRIPTION
`newHandleWithDependency` takes `t.mu` and unlocks it only on the success path. When it returns `newHandleErrorNoParent` the handle table stays locked for the remaining life of the process, and every subsequent handle operation blocks forever.

The same gap covers the type-assertion `panic` immediately below it. The panic is the caller's fault and is meant to be fatal, but anything that recovers from it inherits a permanently locked table.

`defer t.mu.Unlock()` closes both paths and brings the function into line with `readHandle` and `closeHandle`, which already lock and defer. `newHandle` unlocks explicitly but has no early return, so it was never exposed — this function was the only outlier.

Fixes #39053

## Target Release

1.18.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No. This changes lock lifetime within an existing critical section; it does not touch access control, encryption or logging.

## Testing

`internal/rpcapi/handles_test.go` is new and covers both error paths plus the success path. Each asserts with `mu.TryLock()` rather than racing a goroutine against a timeout, so a held mutex fails immediately and deterministically instead of after a wait.

Against `main` the two error-path tests fail:

```
--- FAIL: TestNewHandleWithDependencyNoParentReleasesLock (0.00s)
    handles_test.go:37: handleTable.mu is still held; subsequent handle operations would block forever
--- FAIL: TestNewHandleWithDependencyWrongTypeReleasesLock (0.00s)
    handles_test.go:59: handleTable.mu is still held; subsequent handle operations would block forever
```

With the fix:

```
ok  	github.com/hashicorp/terraform/internal/rpcapi
```

Six tests in `./internal/rpcapi/` fail for me both with and without this change — `TestDependenciesProviderCache`, `TestPackagesServer_FetchProviderPackage`, `TestStacksPlanStackChanges_withPolicies`, `TestStacksApplyStackChanges_withPolicies`, `TestStacksOpenTerraformState_ConfigPath` and `TestStacksMigrateTerraformState`. I confirmed they fail identically on a clean checkout of `main`, so they look environmental on my side rather than related to this change.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.

I first marked this as not user-facing on the grounds that `rpcapi` is an internal RPC surface, but the changelog check disagreed and it is right: a deadlock is visible to whoever hits it. Added `.changes/v1.18/BUG FIXES-20260910-203656.yaml`. Happy to drop it again if you would rather this stayed out of the changelog.