### PR TITLE
refactor: Make `workspace new` use the `views` package for producing terminal output

### DIFF
--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -3020,14 +3020,14 @@ func TestApply_terraformEnvNonDefault(t *testing.T) {
 
 	// Create new env
 	{
-		ui := testUiWrapped(t)
+		view, done := testView(t)
 		newCmd := &WorkspaceNewCommand{
 			Meta: Meta{
-				Ui: ui,
+				View: view,
 			},
 		}
 		if code := newCmd.Run([]string{"test"}); code != 0 {
-			t.Fatal("error creating workspace")
+			t.Fatalf("error creating workspace: %s", done(t).All())
 		}
 	}
 

--- a/internal/command/views/workspace.go
+++ b/internal/command/views/workspace.go
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+const EnvCreated = `
+[reset][green][bold]Created and switched to workspace %q![reset][green]
+
+You're now on a new, empty workspace. Workspaces isolate their state,
+so if you run "terraform plan" Terraform will not see any existing state
+for this configuration.
+`

--- a/internal/command/views/workspace_new.go
+++ b/internal/command/views/workspace_new.go
@@ -1,0 +1,59 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// The WorkspaceNew view is used for the `workspace new` subcommand.
+type WorkspaceNew interface {
+	// LogWorkspaceCreationSuccess is called when a new workspace has been successfully created
+	LogWorkspaceCreationSuccess(workspaceName string, diags tfdiags.Diagnostics)
+
+	Diagnostics(diags tfdiags.Diagnostics)
+}
+
+func NewWorkspaceNew(viewType arguments.ViewType, view *View) WorkspaceNew {
+	switch viewType {
+	case arguments.ViewHuman:
+		return &WorkspaceNewHuman{
+			view: view,
+		}
+	default:
+		panic(fmt.Sprintf("unsupported view type: %s", viewType))
+	}
+}
+
+// The WorkspaceNewHuman implementation renders human-readable logs, suitable for direct consumption by a human user.
+type WorkspaceNewHuman struct {
+	view *View
+}
+
+var _ WorkspaceNew = (*WorkspaceNewHuman)(nil)
+
+func (v *WorkspaceNewHuman) LogWorkspaceCreationSuccess(workspaceName string, diags tfdiags.Diagnostics) {
+	// Print diags above output
+	v.view.Diagnostics(diags)
+
+	msg := fmt.Sprintf(
+		strings.TrimSpace(EnvCreated), workspaceName)
+
+	v.log(msg)
+}
+
+// Diagnostics is used to display diagnostic messages, but should only be used when the command
+// is unsuccessful and returns early.
+func (v *WorkspaceNewHuman) Diagnostics(diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
+}
+
+func (s *WorkspaceNewHuman) log(preparedMessage string) {
+	msg := s.view.colorize.Color(strings.TrimSpace(preparedMessage))
+	s.view.streams.Println(msg)
+}

--- a/internal/command/views/workspace_new_test.go
+++ b/internal/command/views/workspace_new_test.go
@@ -1,0 +1,122 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/terminal"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestWorkspaceNewHuman_LogWorkspaceCreationSuccess(t *testing.T) {
+	workspaceName := "my-workspace"
+	successMsg := fmt.Sprintf(`Created and switched to workspace "%s"!
+
+You're now on a new, empty workspace. Workspaces isolate their state,
+so if you run "terraform plan" Terraform will not see any existing state
+for this configuration.`, workspaceName)
+
+	testCases := map[string]struct {
+		workspace  string
+		diags      tfdiags.Diagnostics
+		wantStdout string
+		wantStderr string
+	}{
+		"success": {
+			workspaceName,
+			nil,
+			successMsg,
+			"",
+		},
+		"success with warning": {
+			workspaceName,
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Warning,
+					"Example warning",
+					"This is an example warning message.",
+				),
+			},
+			fmt.Sprintf("Warning: Example warning\n\nThis is an example warning message.\n%s", successMsg),
+			"",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			view := NewView(streams)
+			view.Configure(&arguments.View{NoColor: true})
+			v := NewWorkspaceNew(arguments.ViewHuman, view)
+
+			v.LogWorkspaceCreationSuccess(tc.workspace, tc.diags)
+
+			output := done(t)
+
+			// Assert contents
+			// This must be done separately for stdout and stderr due to
+			// the interleaving of output caused in tests by (TestOutput).All()
+			gotStdout := strings.TrimSpace(output.Stdout())
+			wantStdout := strings.TrimSpace(tc.wantStdout)
+			if diff := cmp.Diff(wantStdout, gotStdout); diff != "" {
+				t.Fatalf("unexpected diff in human output:\n%s", diff)
+			}
+			gotStderr := strings.TrimSpace(output.Stderr())
+			wantStderr := strings.TrimSpace(tc.wantStderr)
+			if diff := cmp.Diff(wantStderr, gotStderr); diff != "" {
+				t.Fatalf("unexpected diff in human output:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkspaceNewHuman_Diagnostics(t *testing.T) {
+	testCases := map[string]struct {
+		diags      tfdiags.Diagnostics
+		wantStdout string
+		wantStderr string
+	}{
+		"error": {
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Example error",
+					"This is an example error message.",
+				),
+			},
+			"",
+			"Error: Example error\n\nThis is an example error message.\n\n",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			view := NewView(streams)
+			view.Configure(&arguments.View{NoColor: true})
+			v := NewWorkspaceNew(arguments.ViewHuman, view)
+
+			v.Diagnostics(tc.diags)
+
+			output := done(t)
+
+			// Assert contents
+			// This must be done separately for stdout and stderr due to
+			// the interleaving of output caused in tests by (TestOutput).All()
+			gotStdout := strings.TrimSpace(output.Stdout())
+			wantStdout := strings.TrimSpace(tc.wantStdout)
+			if diff := cmp.Diff(wantStdout, gotStdout); diff != "" {
+				t.Fatalf("unexpected diff in human output:\n%s", diff)
+			}
+			gotStderr := strings.TrimSpace(output.Stderr())
+			wantStderr := strings.TrimSpace(tc.wantStderr)
+			if diff := cmp.Diff(wantStderr, gotStderr); diff != "" {
+				t.Fatalf("unexpected diff in human output:\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -103,14 +103,6 @@ or include the "-or-create" flag with the "select" subcommand.`
 
 	envChanged = `[reset][green]Switched to workspace %q.`
 
-	envCreated = `
-[reset][green][bold]Created and switched to workspace %q![reset][green]
-
-You're now on a new, empty workspace. Workspaces isolate their state,
-so if you run "terraform plan" Terraform will not see any existing state
-for this configuration.
-`
-
 	envDeleted = `[reset][green]Deleted workspace %q!`
 
 	envWarnNotEmpty = `[reset][yellow]WARNING: %q was non-empty.

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -352,10 +352,8 @@ func TestWorkspace_cannotCreateOrSelectEmptyStringWorkspace(t *testing.T) {
 	}
 
 	args := []string{""}
-	ui := testUiWrapped(t)
 	view, done := testView(t)
 	newCmd.Meta = Meta{
-		Ui:         ui,
 		View:       view,
 		WorkingDir: workdir.NewDir("."),
 	}
@@ -368,7 +366,7 @@ func TestWorkspace_cannotCreateOrSelectEmptyStringWorkspace(t *testing.T) {
 		t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, got)
 	}
 
-	ui = testUiWrapped(t)
+	ui := testUiWrapped(t)
 	view, _ = testView(t)
 	selectCmd := &WorkspaceSelectCommand{
 		Meta: Meta{
@@ -409,11 +407,9 @@ func TestWorkspace_createAndList(t *testing.T) {
 
 	// create multiple workspaces
 	for _, env := range envs {
-		ui := testUiWrapped(t)
 		view, done := testView(t)
 		newCmd := &WorkspaceNewCommand{
 			Meta: Meta{
-				Ui:         ui,
 				View:       view,
 				WorkingDir: workdir.NewDir("."),
 			},
@@ -424,10 +420,8 @@ func TestWorkspace_createAndList(t *testing.T) {
 	}
 
 	listCmd := &WorkspaceListCommand{}
-	ui := testUiWrapped(t)
 	view, done := testView(t)
 	listCmd.Meta = Meta{
-		Ui:         ui,
 		View:       view,
 		WorkingDir: workdir.NewDir("."),
 	}
@@ -488,9 +482,8 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	env := []string{"test_a"}
 
 	// create test_a workspace
-	ui = testUiWrapped(t)
+	view, _ = testView(t)
 	newCmd.Meta = Meta{
-		Ui:         ui,
 		View:       view,
 		WorkingDir: workdir.NewDir("."),
 	}
@@ -537,11 +530,9 @@ func TestWorkspace_createInvalid(t *testing.T) {
 
 	// create multiple workspaces
 	for _, env := range envs {
-		ui := testUiWrapped(t)
 		view, done := testView(t)
 		newCmd := &WorkspaceNewCommand{
 			Meta: Meta{
-				Ui:         ui,
 				View:       view,
 				WorkingDir: workdir.NewDir("."),
 			},
@@ -553,10 +544,8 @@ func TestWorkspace_createInvalid(t *testing.T) {
 
 	// list workspaces to make sure none were created
 	listCmd := &WorkspaceListCommand{}
-	ui := testUiWrapped(t)
 	view, done := testView(t)
 	listCmd.Meta = Meta{
-		Ui:         ui,
 		View:       view,
 		WorkingDir: workdir.NewDir("."),
 	}
@@ -620,11 +609,9 @@ func TestWorkspace_createWithState(t *testing.T) {
 	workspace := "test_workspace"
 
 	args := []string{"-state", "test.tfstate", workspace}
-	ui = testUiWrapped(t)
 	view, done = testView(t)
 	newCmd := &WorkspaceNewCommand{
 		Meta: Meta{
-			Ui:         ui,
 			View:       view,
 			WorkingDir: workdir.NewDir("."),
 		},
@@ -1023,11 +1010,9 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	}
 
 	// Assert `terraform env new "foobar"` returns expected deprecation warning
-	ui := testUiWrapped(t)
 	view, done := testView(t)
 	newCmd = &WorkspaceNewCommand{
 		Meta: Meta{
-			Ui:         ui,
 			View:       view,
 			WorkingDir: workdir.NewDir("."),
 		},
@@ -1047,7 +1032,7 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	}
 
 	// Assert `terraform env select "default"` returns expected deprecation warning
-	ui = testUiWrapped(t)
+	ui := testUiWrapped(t)
 	view, _ = testView(t)
 	selectCmd := &WorkspaceSelectCommand{
 		Meta: Meta{
@@ -1070,11 +1055,9 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	}
 
 	// Assert `terraform env list` returns expected deprecation warning
-	ui = testUiWrapped(t)
 	view, done = testView(t)
 	listCmd := &WorkspaceListCommand{
 		Meta: Meta{
-			Ui:         ui,
 			View:       view,
 			WorkingDir: workdir.NewDir("."),
 		},

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -88,8 +88,8 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 
 	//// Create Workspace
 	newWorkspace := "foobar"
-	ui = testUiWrapped(t)
-	meta.Ui = ui
+	view, done := testView(t)
+	meta.View = view
 	newCmd := &WorkspaceNewCommand{
 		Meta: meta,
 	}
@@ -105,11 +105,13 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 	args = []string{newWorkspace}
 	code = newCmd.Run(args)
 	if code != 0 {
-		t.Fatalf("bad: %d\n\n%s\n%s", code, ui.ErrorWriter, ui.OutputWriter)
+		output := done(t)
+		t.Fatalf("bad: %d\n\n%s\n%s", code, output.Stderr(), output.Stdout())
 	}
 	expectedMsg := fmt.Sprintf("Created and switched to workspace %q!", newWorkspace)
-	if !strings.Contains(ui.OutputWriter.String(), expectedMsg) {
-		t.Errorf("unexpected output, expected %q, but got:\n%s", expectedMsg, ui.OutputWriter)
+	gotOutput := done(t).Stdout()
+	if !strings.Contains(gotOutput, expectedMsg) {
+		t.Errorf("unexpected output, expected %q, but got:\n%s", expectedMsg, gotOutput)
 	}
 	// We expect a state to have been created for the new custom workspace
 	ok, err = mock.MockStates.StateIdExists("test_store", newWorkspace)
@@ -126,7 +128,7 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 
 	//// List Workspaces
 	ui = testUiWrapped(t)
-	view, done := testView(t)
+	view, done = testView(t)
 	meta.Ui = ui
 	meta.View = view
 	meta.WorkingDir = workdir.NewDir(".")
@@ -351,22 +353,23 @@ func TestWorkspace_cannotCreateOrSelectEmptyStringWorkspace(t *testing.T) {
 
 	args := []string{""}
 	ui := testUiWrapped(t)
-	view, _ := testView(t)
+	view, done := testView(t)
 	newCmd.Meta = Meta{
 		Ui:         ui,
 		View:       view,
 		WorkingDir: workdir.NewDir("."),
 	}
 	if code := newCmd.Run(args); code == 0 {
-		t.Fatalf("expected failure when trying to create the \"\" workspace.\noutput: %s", ui.OutputWriter)
+		t.Fatalf("expected failure when trying to create the \"\" workspace.\noutput: %s", done(t).All())
 	}
 
-	gotStderr := ui.ErrorWriter.String()
+	gotStderr := done(t).Stderr()
 	if want, got := `The workspace name "" is not allowed`, gotStderr; !strings.Contains(got, want) {
 		t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, got)
 	}
 
 	ui = testUiWrapped(t)
+	view, _ = testView(t)
 	selectCmd := &WorkspaceSelectCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -407,14 +410,16 @@ func TestWorkspace_createAndList(t *testing.T) {
 	// create multiple workspaces
 	for _, env := range envs {
 		ui := testUiWrapped(t)
+		view, done := testView(t)
 		newCmd := &WorkspaceNewCommand{
 			Meta: Meta{
 				Ui:         ui,
+				View:       view,
 				WorkingDir: workdir.NewDir("."),
 			},
 		}
 		if code := newCmd.Run([]string{env}); code != 0 {
-			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+			t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 		}
 	}
 
@@ -428,7 +433,7 @@ func TestWorkspace_createAndList(t *testing.T) {
 	}
 
 	if code := listCmd.Run(nil); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
 
 	output := done(t)
@@ -533,7 +538,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 	// create multiple workspaces
 	for _, env := range envs {
 		ui := testUiWrapped(t)
-		view, _ := testView(t)
+		view, done := testView(t)
 		newCmd := &WorkspaceNewCommand{
 			Meta: Meta{
 				Ui:         ui,
@@ -542,7 +547,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 			},
 		}
 		if code := newCmd.Run([]string{env}); code == 0 {
-			t.Fatalf("expected failure: \n%s", ui.OutputWriter)
+			t.Fatalf("expected failure: \n%s", done(t).All())
 		}
 	}
 
@@ -557,7 +562,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 	}
 
 	if code := listCmd.Run(nil); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
 
 	output := done(t)
@@ -616,6 +621,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 
 	args := []string{"-state", "test.tfstate", workspace}
 	ui = testUiWrapped(t)
+	view, done = testView(t)
 	newCmd := &WorkspaceNewCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -624,7 +630,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 		},
 	}
 	if code := newCmd.Run(args); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
 
 	newPath := filepath.Join(local.DefaultWorkspaceDir, "test", DefaultStateFilename)
@@ -1018,7 +1024,7 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 
 	// Assert `terraform env new "foobar"` returns expected deprecation warning
 	ui := testUiWrapped(t)
-	view, _ := testView(t)
+	view, done := testView(t)
 	newCmd = &WorkspaceNewCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -1030,12 +1036,13 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	newWorkspace := "foobar"
 	args := []string{newWorkspace}
 	if code := newCmd.Run(args); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).Stderr())
 	}
-	if !strings.Contains(ui.OutputWriter.String(), expectedWarning) {
+	gotOutput := done(t).Stdout()
+	if !strings.Contains(gotOutput, expectedWarning) {
 		t.Fatalf("expected the command to return a warning, but it was missing.\nwanted: %s\ngot: %s",
 			expectedWarning,
-			ui.OutputWriter.String(),
+			gotOutput,
 		)
 	}
 
@@ -1064,7 +1071,7 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 
 	// Assert `terraform env list` returns expected deprecation warning
 	ui = testUiWrapped(t)
-	view, done := testView(t)
+	view, done = testView(t)
 	listCmd := &WorkspaceListCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -1150,21 +1157,25 @@ func TestWorkspace_extraArgError(t *testing.T) {
 	}
 
 	// New
-	meta, ui, _, _ := newMeta(false)
+	meta, _, _, done := newMeta(false)
 	newCmd := &WorkspaceNewCommand{
 		Meta: meta,
 	}
-	args := []string{"foobar", "extra-arg"} // The new subcommand only accepts a single argument, so this should error
-	if code := newCmd.Run(args); code != cli.RunResultHelp {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+	args := []string{
+		"-no-color",
+		"foobar",
+		"extra-arg", // The new subcommand only accepts a single argument, so this should error
 	}
-	expectedError := "\nError: Expected a single argument: NAME.\n\n\n"
-	if ui.ErrorWriter.String() != expectedError {
-		t.Fatalf("expected error to include %s but was missing, got: %s", expectedError, ui.ErrorWriter.String())
+	if code := newCmd.Run(args); code != cli.RunResultHelp {
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
+	}
+	expectedError := "\nError: Expected a single argument: NAME.\n\n"
+	if done(t).Stderr() != expectedError {
+		t.Fatalf("expected error to include %s but was missing, got: %s", expectedError, done(t).Stderr())
 	}
 
 	// List
-	meta, _, _, done := newMeta(false)
+	meta, _, _, done = newMeta(false)
 	listCmd := &WorkspaceListCommand{
 		Meta: meta,
 	}
@@ -1181,7 +1192,7 @@ func TestWorkspace_extraArgError(t *testing.T) {
 	}
 
 	// Show
-	meta, ui, _, _ = newMeta(false)
+	meta, ui, _, _ := newMeta(false)
 	showCmd := &WorkspaceShowCommand{
 		Meta: meta,
 	}
@@ -1242,34 +1253,39 @@ func TestWorkspace_humanOutput(t *testing.T) {
 	// Assert output from creating a workspace with color enabled
 	for _, env := range envsSet1 {
 		useColor := true
-		meta, ui, _, _ := newMeta(useColor)
+		meta, _, _, done := newMeta(useColor)
 		newCmd := &WorkspaceNewCommand{
 			Meta: meta,
 		}
 		if code := newCmd.Run([]string{env}); code != 0 {
-			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+			t.Fatalf("bad: %d\n\n%s", code, done(t).Stderr())
 		}
 
 		expectedOutput := fmt.Sprintf("\x1b[0m\x1b[32m\x1b[1mCreated and switched to workspace \"%s\"!\x1b[0m\x1b[32m\n\nYou're now on a new, empty workspace. Workspaces isolate their state,\nso if you run \"terraform plan\" Terraform will not see any existing state\nfor this configuration.\x1b[0m\n", env)
-		if ui.OutputWriter.String() != expectedOutput {
-			t.Fatalf("want: %s\ngot: %s", expectedOutput, ui.OutputWriter.String())
+		if done(t).Stdout() != expectedOutput {
+			t.Fatalf("want: %s\ngot: %s", expectedOutput, done(t).Stdout())
 		}
 	}
 
 	// Assert output from creating a workspace with color disabled
 	for _, env := range envsSet2 {
 		useColor := false
-		meta, ui, _, _ := newMeta(useColor)
+		meta, _, _, done := newMeta(useColor)
 		newCmd := &WorkspaceNewCommand{
 			Meta: meta,
 		}
-		if code := newCmd.Run([]string{env}); code != 0 {
-			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		args := []string{
+			"-no-color",
+			env,
+		}
+		if code := newCmd.Run(args); code != 0 {
+			t.Fatalf("bad: %d\n\n%s", code, done(t).Stderr())
 		}
 
 		expectedOutput := fmt.Sprintf("Created and switched to workspace \"%s\"!\n\nYou're now on a new, empty workspace. Workspaces isolate their state,\nso if you run \"terraform plan\" Terraform will not see any existing state\nfor this configuration.\n", env)
-		if ui.OutputWriter.String() != expectedOutput {
-			t.Fatalf("want: %s\ngot: %s", expectedOutput, ui.OutputWriter.String())
+		gotOutput := done(t).Stdout()
+		if gotOutput != expectedOutput {
+			t.Fatalf("want: %s\ngot: %s", expectedOutput, gotOutput)
 		}
 	}
 

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -582,7 +582,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 
 	// init the backend
 	ui := testUiWrapped(t)
-	view, _ := testView(t)
+	view, done := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -591,7 +591,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 		},
 	}
 	if code := initCmd.Run([]string{}); code != 0 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+		t.Fatalf("bad: \n%s", done(t).All())
 	}
 
 	originalState := states.BuildState(func(s *states.SyncState) {

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -28,15 +29,24 @@ type WorkspaceNewCommand struct {
 func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 	var diags tfdiags.Diagnostics
 
-	// Process global flags and configure the view/UI.
-	rawArgs = c.Meta.process(rawArgs)
-	envCommandShowWarning(c.Ui, c.LegacyName)
+	// Parse and apply global view arguments
+	common, rawArgs := arguments.ParseView(rawArgs)
+	c.View.Configure(common)
 
 	// Process command-specific arguments.
 	// Currently there are no arguments for this command, so ignore the returned value for now.
-	args, diags := arguments.ParseWorkspaceNew(rawArgs)
+	args, argDiags := arguments.ParseWorkspaceNew(rawArgs)
+	diags = diags.Append(argDiags)
+
+	// Prepare the view
+	view := views.NewWorkspaceNew(args.ViewType, c.View)
+
+	// Warn against using `terraform env` commands, if needed
+	diags = diags.Append(envCommandWarningDiag(c.LegacyName))
+
+	// Now the view is ready, process any error diagnostics from parsing arguments.
 	if diags.HasErrors() {
-		c.showDiagnostics(diags)
+		view.Diagnostics(diags)
 		return cli.RunResultHelp
 	}
 
@@ -49,15 +59,18 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 	// already due to it being set.
 	current, isOverridden, _ := c.WorkspaceOverridden()
 	if current != workspace && isOverridden {
-		c.Ui.Error(envIsOverriddenNewError)
+		err := errors.New(envIsOverriddenNewError)
+		diags = diags.Append(err)
+		view.Diagnostics(diags)
 		return 1
 	}
 
 	// Load the backend
 	configPath := c.WorkingDir.RootModuleDir()
-	b, diags := c.backend(configPath, args.ViewType)
-	if diags.HasErrors() {
-		c.showDiagnostics(diags)
+	b, bDiags := c.backend(configPath, args.ViewType)
+	diags = diags.Append(bDiags)
+	if bDiags.HasErrors() {
+		view.Diagnostics(diags)
 		return 1
 	}
 
@@ -65,15 +78,17 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 	c.ignoreRemoteVersionConflict(b)
 
 	workspaces, wDiags := b.Workspaces()
+	diags = diags.Append(wDiags)
 	if wDiags.HasErrors() {
-		c.Ui.Error(fmt.Sprintf("Failed to get configured named states: %s", wDiags.Err()))
+		view.Diagnostics(diags)
 		return 1
 	}
-	c.showDiagnostics(diags) // output warnings, if any
 
 	for _, ws := range workspaces {
 		if workspace == ws {
-			c.Ui.Error(fmt.Sprintf(envExists, workspace))
+			err := fmt.Errorf(envExists, workspace)
+			diags = diags.Append(err)
+			view.Diagnostics(diags)
 			return 1
 		}
 	}
@@ -86,8 +101,9 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 	// The cloud backend also has logic in StateMgr for creating projects and
 	// workspaces if they don't already exist.
 	sMgr, sDiags := b.StateMgr(workspace)
+	diags = diags.Append(sDiags)
 	if sDiags.HasErrors() {
-		c.Ui.Error(sDiags.Err().Error())
+		view.Diagnostics(diags)
 		return 1
 	}
 
@@ -100,11 +116,13 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 			// We only do this when the backend in use is pluggable, to avoid impacting users
 			// of remote-state backends.
 			if err := sMgr.WriteState(states.NewState()); err != nil {
-				c.Ui.Error(err.Error())
+				diags = diags.Append(err)
+				view.Diagnostics(diags)
 				return 1
 			}
 			if err := sMgr.PersistState(nil); err != nil {
-				c.Ui.Error(err.Error())
+				diags = diags.Append(err)
+				view.Diagnostics(diags)
 				return 1
 			}
 		}
@@ -112,12 +130,12 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 
 	// now set the current workspace locally
 	if err := c.SetWorkspace(workspace); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error selecting new workspace: %s", err))
+		diags = diags.Append(err)
+		view.Diagnostics(diags)
 		return 1
 	}
 
-	c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
-		strings.TrimSpace(views.EnvCreated), workspace)))
+	view.LogWorkspaceCreationSuccess(workspace, diags)
 
 	if args.StatePath == "" {
 		// if we're not loading a state, then we're done
@@ -126,20 +144,21 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 
 	// load the new Backend state
 	stateMgr, sDiags := b.StateMgr(workspace)
+	diags = diags.Append(sDiags)
 	if sDiags.HasErrors() {
-		c.Ui.Error(sDiags.Err().Error())
+		view.Diagnostics(diags)
 		return 1
 	}
 
 	if args.Lock {
 		stateLocker := clistate.NewLocker(args.LockTimeout, views.NewStateLocker(arguments.ViewHuman, c.View))
 		if diags := stateLocker.Lock(stateMgr, "workspace-new"); diags.HasErrors() {
-			c.showDiagnostics(diags)
+			view.Diagnostics(diags)
 			return 1
 		}
 		defer func() {
 			if diags := stateLocker.Unlock(); diags.HasErrors() {
-				c.showDiagnostics(diags)
+				view.Diagnostics(diags)
 			}
 		}()
 	}
@@ -147,26 +166,30 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 	// read the existing state file
 	f, err := os.Open(args.StatePath)
 	if err != nil {
-		c.Ui.Error(err.Error())
+		diags = diags.Append(err)
+		view.Diagnostics(diags)
 		return 1
 	}
 	defer f.Close()
 
 	stateFile, err := statefile.Read(f)
 	if err != nil {
-		c.Ui.Error(err.Error())
+		diags = diags.Append(err)
+		view.Diagnostics(diags)
 		return 1
 	}
 
 	// save the existing state in the new Backend.
 	err = stateMgr.WriteState(stateFile.State)
 	if err != nil {
-		c.Ui.Error(err.Error())
+		diags = diags.Append(err)
+		view.Diagnostics(diags)
 		return 1
 	}
 	err = stateMgr.PersistState(nil)
 	if err != nil {
-		c.Ui.Error(err.Error())
+		diags = diags.Append(err)
+		view.Diagnostics(diags)
 		return 1
 	}
 

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -117,7 +117,7 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 	}
 
 	c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
-		strings.TrimSpace(envCreated), workspace)))
+		strings.TrimSpace(views.EnvCreated), workspace)))
 
 	if args.StatePath == "" {
 		// if we're not loading a state, then we're done

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/posener/complete"
 )
@@ -100,7 +101,7 @@ func (c *WorkspaceSelectCommand) Run(rawArgs []string) int {
 
 	if newState {
 		c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
-			strings.TrimSpace(envCreated), name)))
+			strings.TrimSpace(views.EnvCreated), name)))
 	} else {
 		c.Ui.Output(
 			c.Colorize().Color(


### PR DESCRIPTION
This PR refactors `workspace new` use the `views` package for human output.

There are some future changes I want to make in a separate PR that will ensure that all paths through the command result in only a single invocation of a view method, as this is necessary if JSON output will be added to this command in future. But this PR for now maintains the commands structure as-is.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.18.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
