### PR TITLE
refactor: Update `workspace new` to produce logs describing when a workspace has been created but failed to populate its state

### DIFF
--- a/internal/command/views/workspace.go
+++ b/internal/command/views/workspace.go
@@ -10,3 +10,12 @@ You're now on a new, empty workspace. Workspaces isolate their state,
 so if you run "terraform plan" Terraform will not see any existing state
 for this configuration.
 `
+
+const envCreatedWithoutStatePopulation = `
+[reset][yellow][bold]Created and switched to workspace %q, but failed to initialize the state.[reset][yellow]
+
+You're now on a new, empty workspace. However, errors prevented Terraform from initializing the new workspace's state
+using the provided '-state' flag. You will need to address these errors before the workspace's state can be properly
+initialized. Once they're addressed, you can use "terraform workspace delete %s" to delete the newly created
+workspace and then reattempt this operation.
+`

--- a/internal/command/views/workspace_new.go
+++ b/internal/command/views/workspace_new.go
@@ -16,6 +16,10 @@ type WorkspaceNew interface {
 	// LogWorkspaceCreationSuccess is called when a new workspace has been successfully created
 	LogWorkspaceCreationSuccess(workspaceName string, diags tfdiags.Diagnostics)
 
+	// LogWorkspaceCreationFromStateFailure is called when creating a new workspace from an existing state file fails.
+	// The user needs to be notified about the side effects from the failed operation.
+	LogWorkspaceCreationFromStateFailure(workspaceName string, diags tfdiags.Diagnostics)
+
 	Diagnostics(diags tfdiags.Diagnostics)
 }
 
@@ -43,6 +47,15 @@ func (v *WorkspaceNewHuman) LogWorkspaceCreationSuccess(workspaceName string, di
 
 	msg := fmt.Sprintf(
 		strings.TrimSpace(EnvCreated), workspaceName)
+
+	v.log(msg)
+}
+
+func (v *WorkspaceNewHuman) LogWorkspaceCreationFromStateFailure(workspaceName string, diags tfdiags.Diagnostics) {
+	// Print diags above output
+	v.view.Diagnostics(diags)
+
+	msg := fmt.Sprintf(envCreatedWithoutStatePopulation, workspaceName, workspaceName)
 
 	v.log(msg)
 }

--- a/internal/command/views/workspace_new_test.go
+++ b/internal/command/views/workspace_new_test.go
@@ -75,6 +75,56 @@ for this configuration.`, workspaceName)
 	}
 }
 
+func TestWorkspaceNewHuman_LogWorkspaceCreationFromStateFailure(t *testing.T) {
+	workspaceName := "my-workspace"
+
+	testCases := map[string]struct {
+		workspace         string
+		diags             tfdiags.Diagnostics
+		wantStdoutSnippet string
+		wantStderr        string
+	}{
+		"error": {
+			workspaceName,
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Example error",
+					"This is an example error message.",
+				),
+			},
+			fmt.Sprintf("Created and switched to workspace %q, but failed to initialize the state.", workspaceName),
+			"Error: Example error\n\nThis is an example error message.\n\n",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			view := NewView(streams)
+			view.Configure(&arguments.View{NoColor: true})
+			v := NewWorkspaceNew(arguments.ViewHuman, view)
+
+			v.LogWorkspaceCreationFromStateFailure(tc.workspace, tc.diags)
+
+			output := done(t)
+
+			// Assert contents
+			// This must be done separately for stdout and stderr due to
+			// the interleaving of output caused in tests by (TestOutput).All()
+			gotStdout := strings.TrimSpace(output.Stdout())
+			wantStdoutSnippet := strings.TrimSpace(tc.wantStdoutSnippet)
+			if !strings.Contains(gotStdout, wantStdoutSnippet) {
+				t.Fatalf("expected stdout to contain:\n%s\nbut got:\n%s", wantStdoutSnippet, gotStdout)
+			}
+			gotStderr := strings.TrimSpace(output.Stderr())
+			wantStderr := strings.TrimSpace(tc.wantStderr)
+			if diff := cmp.Diff(wantStderr, gotStderr); diff != "" {
+				t.Fatalf("unexpected diff in human output:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestWorkspaceNewHuman_Diagnostics(t *testing.T) {
 	testCases := map[string]struct {
 		diags      tfdiags.Diagnostics

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -564,80 +564,125 @@ func TestWorkspace_createInvalid(t *testing.T) {
 }
 
 func TestWorkspace_createWithState(t *testing.T) {
-	td := t.TempDir()
-	testCopyDir(t, testFixturePath("inmem-backend"), td)
-	t.Chdir(td)
-	defer inmem.Reset()
+	t.Run("success", func(t *testing.T) {
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("inmem-backend"), td)
+		t.Chdir(td)
+		defer inmem.Reset()
 
-	// init the backend
-	ui := testUiWrapped(t)
-	view, done := testView(t)
-	initCmd := &InitCommand{
-		Meta: Meta{
-			Ui:         ui,
-			View:       view,
-			WorkingDir: workdir.NewDir("."),
-		},
-	}
-	if code := initCmd.Run([]string{}); code != 0 {
-		t.Fatalf("bad: \n%s", done(t).All())
-	}
+		// init the backend
+		ui := testUiWrapped(t)
+		view, done := testView(t)
+		initCmd := &InitCommand{
+			Meta: Meta{
+				Ui:         ui,
+				View:       view,
+				WorkingDir: workdir.NewDir("."),
+			},
+		}
+		if code := initCmd.Run([]string{}); code != 0 {
+			t.Fatalf("bad: \n%s", done(t).All())
+		}
 
-	originalState := states.BuildState(func(s *states.SyncState) {
-		s.SetResourceInstanceCurrent(
-			addrs.Resource{
-				Mode: addrs.ManagedResourceMode,
-				Type: "test_instance",
-				Name: "foo",
-			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-			&states.ResourceInstanceObjectSrc{
-				AttrsJSON: []byte(`{"id":"bar"}`),
-				Status:    states.ObjectReady,
+		originalState := states.BuildState(func(s *states.SyncState) {
+			s.SetResourceInstanceCurrent(
+				addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "test_instance",
+					Name: "foo",
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+				&states.ResourceInstanceObjectSrc{
+					AttrsJSON: []byte(`{"id":"bar"}`),
+					Status:    states.ObjectReady,
+				},
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewDefaultProvider("test"),
+					Module:   addrs.RootModule,
+				},
+			)
+		})
+
+		err := statemgr.NewFilesystem("test.tfstate").WriteState(originalState)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		workspace := "test_workspace"
+
+		args := []string{"-state", "test.tfstate", workspace}
+		view, done = testView(t)
+		newCmd := &WorkspaceNewCommand{
+			Meta: Meta{
+				View:       view,
+				WorkingDir: workdir.NewDir("."),
 			},
-			addrs.AbsProviderConfig{
-				Provider: addrs.NewDefaultProvider("test"),
-				Module:   addrs.RootModule,
-			},
-		)
+		}
+		if code := newCmd.Run(args); code != 0 {
+			t.Fatalf("bad: %d\n\n%s", code, done(t).All())
+		}
+
+		newPath := filepath.Join(local.DefaultWorkspaceDir, "test", DefaultStateFilename)
+		envState := statemgr.NewFilesystem(newPath)
+		err = envState.RefreshState()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b := backend.TestBackendConfig(t, inmem.New(), nil)
+		sMgr, sDiags := b.StateMgr(workspace)
+		if sDiags.HasErrors() {
+			t.Fatal(sDiags)
+		}
+
+		newState := sMgr.State()
+
+		if got, want := newState.String(), originalState.String(); got != want {
+			t.Fatalf("states not equal\ngot: %s\nwant: %s", got, want)
+		}
 	})
 
-	err := statemgr.NewFilesystem("test.tfstate").WriteState(originalState)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("failure due to invalid -state value", func(t *testing.T) {
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("inmem-backend"), td)
+		t.Chdir(td)
+		defer inmem.Reset()
 
-	workspace := "test_workspace"
+		// init the backend
+		ui := testUiWrapped(t)
+		view, done := testView(t)
+		initCmd := &InitCommand{
+			Meta: Meta{
+				Ui:         ui,
+				View:       view,
+				WorkingDir: workdir.NewDir("."),
+			},
+		}
+		if code := initCmd.Run([]string{}); code != 0 {
+			t.Fatalf("bad: \n%s", done(t).All())
+		}
 
-	args := []string{"-state", "test.tfstate", workspace}
-	view, done = testView(t)
-	newCmd := &WorkspaceNewCommand{
-		Meta: Meta{
-			View:       view,
-			WorkingDir: workdir.NewDir("."),
-		},
-	}
-	if code := newCmd.Run(args); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
-	}
+		workspace := "test_workspace"
 
-	newPath := filepath.Join(local.DefaultWorkspaceDir, "test", DefaultStateFilename)
-	envState := statemgr.NewFilesystem(newPath)
-	err = envState.RefreshState()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	b := backend.TestBackendConfig(t, inmem.New(), nil)
-	sMgr, sDiags := b.StateMgr(workspace)
-	if sDiags.HasErrors() {
-		t.Fatal(sDiags)
-	}
-
-	newState := sMgr.State()
-
-	if got, want := newState.String(), originalState.String(); got != want {
-		t.Fatalf("states not equal\ngot: %s\nwant: %s", got, want)
-	}
+		args := []string{
+			"-state", "test.tfstate", // state doesn't exist
+			workspace,
+		}
+		view, done = testView(t)
+		newCmd := &WorkspaceNewCommand{
+			Meta: Meta{
+				View:       view,
+				WorkingDir: workdir.NewDir("."),
+			},
+		}
+		if code := newCmd.Run(args); code != 1 {
+			t.Fatalf("expected code 1 but got %s: %d\n\n%s", args, code, done(t).All())
+		}
+		output := done(t)
+		expectedErrSnippet := fmt.Sprintf("Created and switched to workspace \"%s\", but failed to initialize the state.", workspace)
+		if !strings.Contains(output.All(), expectedErrSnippet) {
+			t.Fatalf("expected error message about missing state file, got: %s", output.All())
+		}
+	})
 }
 
 func TestWorkspace_delete(t *testing.T) {

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -135,10 +135,9 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	view.LogWorkspaceCreationSuccess(workspace, diags)
-
 	if args.StatePath == "" {
 		// if we're not loading a state, then we're done
+		view.LogWorkspaceCreationSuccess(workspace, diags)
 		return 0
 	}
 
@@ -146,14 +145,14 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 	stateMgr, sDiags := b.StateMgr(workspace)
 	diags = diags.Append(sDiags)
 	if sDiags.HasErrors() {
-		view.Diagnostics(diags)
+		view.LogWorkspaceCreationFromStateFailure(workspace, diags)
 		return 1
 	}
 
 	if args.Lock {
 		stateLocker := clistate.NewLocker(args.LockTimeout, views.NewStateLocker(arguments.ViewHuman, c.View))
 		if diags := stateLocker.Lock(stateMgr, "workspace-new"); diags.HasErrors() {
-			view.Diagnostics(diags)
+			view.LogWorkspaceCreationFromStateFailure(workspace, diags)
 			return 1
 		}
 		defer func() {
@@ -167,7 +166,7 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 	f, err := os.Open(args.StatePath)
 	if err != nil {
 		diags = diags.Append(err)
-		view.Diagnostics(diags)
+		view.LogWorkspaceCreationFromStateFailure(workspace, diags)
 		return 1
 	}
 	defer f.Close()
@@ -175,7 +174,7 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 	stateFile, err := statefile.Read(f)
 	if err != nil {
 		diags = diags.Append(err)
-		view.Diagnostics(diags)
+		view.LogWorkspaceCreationFromStateFailure(workspace, diags)
 		return 1
 	}
 
@@ -183,16 +182,17 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 	err = stateMgr.WriteState(stateFile.State)
 	if err != nil {
 		diags = diags.Append(err)
-		view.Diagnostics(diags)
+		view.LogWorkspaceCreationFromStateFailure(workspace, diags)
 		return 1
 	}
 	err = stateMgr.PersistState(nil)
 	if err != nil {
 		diags = diags.Append(err)
-		view.Diagnostics(diags)
+		view.LogWorkspaceCreationFromStateFailure(workspace, diags)
 		return 1
 	}
 
+	view.LogWorkspaceCreationSuccess(workspace, diags)
 	return 0
 }
 


### PR DESCRIPTION
This PR is intended to prevent a scenario where this command that declares success when creating the (empty) workspace but then logs additional errors that show the `-state` flag wasn't able to be used successfully. The change in output makes it clearer to users about the impacts of the command before it experienced an error.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.18.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
