### PR TITLE
genconfig(hclEscapeString): use hcl-native string quoting in place of go fallback 🤖 

### DIFF
--- a/.changes/v1.18/ENHANCEMENTS-20260911-102213.yaml
+++ b/.changes/v1.18/ENHANCEMENTS-20260911-102213.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'genconfig: use hcl-native printing instead of falling back to go string'
+time: 2026-09-11T10:22:13.113278-04:00
+custom:
+    Issue: "39193"

--- a/internal/genconfig/generate_config.go
+++ b/internal/genconfig/generate_config.go
@@ -645,20 +645,11 @@ func writeBlockTypeConstraint(buf *strings.Builder, schema *configschema.NestedB
 
 // hclEscapeString formats the input string into a format that is safe for
 // rendering within HCL.
-//
-// Note, this function doesn't actually do a very good job of this currently. We
-// need to expose some internal functions from HCL in a future version and call
-// them from here. For now, just use "%q" formatting.
-//
-// Note, the similar function in jsonformat/computed/renderers/map.go is doing
-// something similar.
 func hclEscapeString(str string) string {
-	// TODO: Replace this with more complete HCL logic instead of the simple
-	// go workaround.
-	if !hclsyntax.ValidIdentifier(str) {
-		return fmt.Sprintf("%q", str)
+	if hclsyntax.ValidIdentifier(str) {
+		return str
 	}
-	return str
+	return string(hclwrite.TokensForValue(cty.StringVal(str)).Bytes())
 }
 
 // ExtractLegacyConfigFromState takes the state value of a resource, and filters the

--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcldec"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -842,6 +845,81 @@ resource "tfcoremock_sensitive_values" "values" {
 			want := strings.TrimSpace(tc.expected)
 			if diff := cmp.Diff(got, want); len(diff) > 0 {
 				t.Errorf("got:\n%s\nwant:\n%s\ndiff:\n%s", got, want, diff)
+			}
+		})
+	}
+}
+
+func TestGenerateResourceContentsNestedMapKeysRoundTrip(t *testing.T) {
+	schema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"map": {
+				NestedType: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {
+							Type:     cty.String,
+							Required: true,
+						},
+					},
+					Nesting: configschema.NestingMap,
+				},
+				Required: true,
+			},
+		},
+	}
+	if err := schema.InternalValidate(); err != nil {
+		t.Fatalf("schema failed InternalValidate: %s", err)
+	}
+
+	tests := map[string]string{
+		"template interpolation": `${1 + 1}`,
+		"template directive":     `%{if true}changed%{endif}`,
+		"quote":                  `quote"key`,
+		"backslash":              `backslash\key`,
+		"newline":                "line\nbreak",
+	}
+	for name, key := range tests {
+		t.Run(name, func(t *testing.T) {
+			want := cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					key: cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("test"),
+					}),
+				}),
+			})
+
+			generated, diags := GenerateResourceContents(
+				addrs.AbsResourceInstance{
+					Module: addrs.RootModuleInstance,
+					Resource: addrs.ResourceInstance{
+						Resource: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "testing_resource",
+							Name: "resource",
+						},
+						Key: addrs.NoKey,
+					},
+				},
+				schema,
+				addrs.LocalProviderConfig{LocalName: "testing"},
+				want,
+				false,
+			)
+			if diags.HasErrors() {
+				t.Fatalf("unexpected generation diagnostics: %s", diags.Err())
+			}
+
+			file, parseDiags := hclsyntax.ParseConfig(generated.Body, "generated.tf", hcl.InitialPos)
+			if parseDiags.HasErrors() {
+				t.Fatalf("generated configuration did not parse:\n%s\n%s", generated.Body, parseDiags.Error())
+			}
+
+			got, decodeDiags := hcldec.Decode(file.Body, schema.DecoderSpec(), nil)
+			if decodeDiags.HasErrors() {
+				t.Fatalf("generated configuration did not evaluate:\n%s\n%s", generated.Body, decodeDiags.Error())
+			}
+			if !got.RawEquals(want) {
+				t.Errorf("generated configuration did not round-trip\ngot:  %#v\nwant: %#v\nHCL:\n%s", got, want, generated.Body)
 			}
 		})
 	}


### PR DESCRIPTION
This swaps out the go string handling for HCL native string escaping, fixing (unreported) issues with generated configuration. 

This was found and fixed by copilot and came about while probing for other bugs in the import+genconfig area. This was the only really actionable issue it found and the solution was simple, so here we are.    

Fixes # <no open issues>

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

This updates 

-->

1.18.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
