### PR TITLE
query: forward-port -policies help text and experimental cleanup to main

### DIFF
--- a/.changes/footer-with-experiments.md
+++ b/.changes/footer-with-experiments.md
@@ -7,7 +7,6 @@ Experiments are only enabled in alpha releases of Terraform CLI. The following f
 - `terraform test`: `backend` blocks and `skip_cleanup` attributes:
   - Test authors can now specify `backend` blocks within `run` blocks in Terraform Test files. Run blocks with `backend` blocks will load state from the specified backend instead of starting from empty state on every execution. This allows test authors to keep long-running test infrastructure alive between test operations, saving time during regular test operations.
   - Test authors can now specify `skip_cleanup` attributes within test files and within run blocks. The `skip_cleanup` attribute tells `terraform test` not to clean up state files produced by run blocks with this attribute set to true. The state files for affected run blocks will be written to disk within the `.terraform` directory, where they can then be cleaned up manually using the also experimental `terraform test cleanup` command.
-- `terraform query`: The experimental `-policies` flag permits specifying one or more policy set directory paths to evaluate policies against resources discovered by list blocks during a query operation.
 
 ## Previous Releases
 

--- a/internal/command/arguments/query.go
+++ b/internal/command/arguments/query.go
@@ -22,7 +22,6 @@ type Query struct {
 	// be written to.
 	GenerateConfigPath string
 
-	// EXPERIMENTAL
 	// PolicyPaths contains optional paths to policy set directories that should
 	// be evaluated during this query operation.
 	PolicyPaths []string

--- a/internal/command/arguments/query_test.go
+++ b/internal/command/arguments/query_test.go
@@ -30,6 +30,18 @@ func TestParseQuery_policies(t *testing.T) {
 			args:         []string{"-policies=/path/one", "-policies=/path/two"},
 			wantPolicies: []string{"/path/one", "/path/two"},
 		},
+		"double dash equals syntax": {
+			args:         []string{"--policies=/some/path"},
+			wantPolicies: []string{"/some/path"},
+		},
+		"double dash space syntax": {
+			args:         []string{"--policies", "/some/path"},
+			wantPolicies: []string{"/some/path"},
+		},
+		"mixed spellings preserve path order": {
+			args:         []string{"--policies=/path/one", "-policies", "/path/two", "--policies", "/path/one"},
+			wantPolicies: []string{"/path/one", "/path/two", "/path/one"},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/command/query.go
+++ b/internal/command/query.go
@@ -34,6 +34,11 @@ Query Customization Options:
 
   The following options customize how Terraform will run the query.
 
+  -policies=path        Evaluate policies from a policy set directory against
+                        resources discovered by the query. Use this option more
+                        than once to include multiple policy set paths.
+                        The equivalent --policies=path spelling is also supported.
+
   -var 'foo=bar'        Set a value for one of the input variables in the query
                         file of the configuration. Use this option more than
                         once to set more than one variable.

--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -315,30 +315,24 @@ func TestQueryCommand_Validate(t *testing.T) {
 	missingPath := filepath.Join(t.TempDir(), "does-not-exist")
 
 	tests := []struct {
-		name             string
-		policyPaths      []string
-		allowExperiments bool
-		wantDiags        tfdiags.Diagnostics
+		name        string
+		policyPaths []string
+		wantDiags   tfdiags.Diagnostics
 	}{
 		{
-			name:             "no policies, flag omitted",
-			policyPaths:      nil,
-			allowExperiments: true,
+			name: "no policies, flag omitted",
 		},
 		{
-			name:             "single valid path",
-			policyPaths:      []string{td},
-			allowExperiments: true,
+			name:        "single valid path",
+			policyPaths: []string{td},
 		},
 		{
-			name:             "multiple valid paths",
-			policyPaths:      []string{td, td2},
-			allowExperiments: true,
+			name:        "multiple valid paths",
+			policyPaths: []string{td, td2},
 		},
 		{
-			name:             "non-existent path",
-			policyPaths:      []string{missingPath},
-			allowExperiments: true,
+			name:        "non-existent path",
+			policyPaths: []string{missingPath},
 			wantDiags: tfdiags.Diagnostics{
 				tfdiags.Sourceless(
 					tfdiags.Error,
@@ -351,7 +345,7 @@ func TestQueryCommand_Validate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := &QueryCommand{Meta: Meta{AllowExperimentalFeatures: tc.allowExperiments}}
+			cmd := &QueryCommand{}
 			got := cmd.Validate(&arguments.Query{PolicyPaths: tc.policyPaths})
 			if tc.wantDiags == nil {
 				tfdiags.AssertNoDiagnostics(t, got)
@@ -398,8 +392,7 @@ func TestQueryCommand_policyClientRouting(t *testing.T) {
 
 			client := policy.NewTestMockClient(t)
 			cmd := &QueryCommand{Meta: Meta{
-				AllowExperimentalFeatures: true,
-				testingOverrides:          &testingOverrides{PolicyClient: client},
+				testingOverrides: &testingOverrides{PolicyClient: client},
 			}}
 			op := &backendrun.Operation{PolicyPaths: tc.policyPaths}
 			stop := cmd.configureQueryPolicyClient(be, op)
@@ -678,10 +671,9 @@ func TestQueryPolicyStatusReporting(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	view, done := testView(t)
 	meta := Meta{
-		testingOverrides:          overrides,
-		View:                      view,
-		AllowExperimentalFeatures: true,
-		ProviderSource:            providerSource,
+		testingOverrides: overrides,
+		View:             view,
+		ProviderSource:   providerSource,
 	}
 
 	init := &InitCommand{Meta: meta}
@@ -794,10 +786,9 @@ func TestQueryPolicyStatusReporting_NoPoliciesArgument(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	view, done := testView(t)
 	meta := Meta{
-		testingOverrides:          overrides,
-		View:                      view,
-		AllowExperimentalFeatures: true,
-		ProviderSource:            providerSource,
+		testingOverrides: overrides,
+		View:             view,
+		ProviderSource:   providerSource,
 	}
 
 	init := &InitCommand{Meta: meta}


### PR DESCRIPTION
Forward-ports the non-changelog portion of #39155 (which merged into the `v1.17` release branch) to `main`, so the fix does not regress in 1.18.

#39155 had to target `v1.17` directly because `scripts/changelog.sh nextminor` runs `rm ./.changes/v*/*.yaml` on `main` after a release branch is cut, so the `.changes/v1.17/NEW FEATURES-20260810-122653.yaml` fragment it edits no longer exists here. The backport bot could not be used for the same reason.

### What this carries over

- `internal/command/query.go`: adds the missing `-policies=path` entry to the `query` help text, documenting repeatable paths and the equivalent `--policies` spelling. `main` had no `-policies` entry at all.
- `internal/command/arguments/query.go`: removes the stale `// EXPERIMENTAL` annotation on `Query.PolicyPaths`.
- `.changes/footer-with-experiments.md`: drops the `terraform query -policies` bullet. This footer is only applied by the `dev` and `alpha` release types (`scripts/changelog.sh:53,75`), so it matters on `main` — it currently renders under `## 1.18.0 (Unreleased)` in `CHANGELOG.md` and would keep advertising query policies as experimental.
- `internal/command/query_test.go`: removes `AllowExperimentalFeatures` from the query policy tests. The gating is already gone from `QueryCommand.Validate`, so the tests were asserting against dead scaffolding.
- `internal/command/arguments/query_test.go`: adds coverage for `--policies=path`, `--policies path`, and mixed spellings preserving path order.

Runtime behavior is unchanged.

## Target Release

1.18.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None. This changes help text, a changelog footer, and tests. No changes to policy enforcement, access controls, encryption, or logging.

## CHANGELOG entry

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.

Labelled `no-changelog-needed`. The user-facing announcement already shipped in the v1.17 fragment updated by #39155; adding a `.changes/v1.18/` entry here would duplicate it.
