### PR TITLE
refactor: Let JSON output from `workspace list` be achieved via a distinct `LogErrorDiagnostics` method.

### DIFF
--- a/internal/command/views/workspace_list.go
+++ b/internal/command/views/workspace_list.go
@@ -16,7 +16,17 @@ import (
 
 // The WorkspaceList view is used for the `workspace list` subcommand.
 type WorkspaceList interface {
+	// List is used to log the list of present workspaces and indicate which is currently selected
+	//
+	// This method is intended to be used when the command is successfully listing workspaces, and
+	// any diagnostics present will only be warnings.
 	List(selected string, list []string, diags tfdiags.Diagnostics)
+
+	// LogErrorDiagnostics renders any supplied diagnostics, but expects at least one error.
+	//
+	// This method is intended to only be used to display error diagnostics
+	// prior to the command returning early with a non-0 code.
+	LogErrorDiagnostics(diags tfdiags.Diagnostics)
 }
 
 func NewWorkspaceList(viewType arguments.ViewType, view *View) WorkspaceList {
@@ -65,6 +75,10 @@ func (v *WorkspaceListHuman) List(selected string, list []string, diags tfdiags.
 	}
 }
 
+func (v *WorkspaceListHuman) LogErrorDiagnostics(diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
+}
+
 // The WorkspaceListJSON implementation renders machine-readable logs, suitable for
 // integrating with other software.
 //
@@ -72,6 +86,11 @@ func (v *WorkspaceListHuman) List(selected string, list []string, diags tfdiags.
 type WorkspaceListJSON struct {
 	view *View
 }
+
+// WorkspaceListJSONFormatVersion represents the version of the json format and will be
+// incremented for any change to this format that requires changes to a
+// consuming parser.
+const WorkspaceListJSONFormatVersion = "1.0"
 
 var _ WorkspaceList = (*WorkspaceListJSON)(nil)
 
@@ -86,18 +105,9 @@ type WorkspaceOutput struct {
 	IsCurrent bool   `json:"is_current,omitempty"`
 }
 
-// List is used to log the list of present workspaces and indicate which is currently selected
-//
-// If `workspace list` errors must return early with error diagnostics then the list will be empty and accompanied by errors.
-// If the command succeeds then the list will be populated and the diagnostics list will be either empty or contain warnings.
 func (v *WorkspaceListJSON) List(current string, list []string, diags tfdiags.Diagnostics) {
-	// FormatVersion represents the version of the json format and will be
-	// incremented for any change to this format that requires changes to a
-	// consuming parser.
-	const FormatVersion = "1.0"
-
 	output := WorkspaceListOutput{
-		FormatVersion: FormatVersion,
+		FormatVersion: WorkspaceListJSONFormatVersion,
 	}
 
 	for _, item := range list {
@@ -113,6 +123,34 @@ func (v *WorkspaceListJSON) List(current string, list []string, diags tfdiags.Di
 		// Zero workspaces being returned is a valid outcome. In that scenario a warning diagnostic is included,
 		// and that'll be easier to understand next to an empty workspace list.
 		output.Workspaces = []WorkspaceOutput{}
+	}
+
+	configSources := v.view.configSources()
+	for _, diag := range diags {
+		output.Diagnostics = append(output.Diagnostics, viewsjson.NewDiagnostic(diag, configSources))
+	}
+
+	if output.Diagnostics == nil {
+		// Make sure this always appears as an array in our output, since
+		// this is easier to consume for dynamically-typed languages.
+		output.Diagnostics = []*viewsjson.Diagnostic{}
+	}
+
+	jsonOutput, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		// Should never happen because we fully-control the input here
+		panic(fmt.Sprintf("failed to marshal workspace list json output: %v", err))
+	}
+
+	v.view.streams.Println(string(jsonOutput))
+}
+
+func (v *WorkspaceListJSON) LogErrorDiagnostics(diags tfdiags.Diagnostics) {
+	output := WorkspaceListOutput{
+		FormatVersion: WorkspaceListJSONFormatVersion,
+
+		// Make sure this always appears as an array in our output
+		Workspaces: []WorkspaceOutput{},
 	}
 
 	configSources := v.view.configSources()

--- a/internal/command/views/workspace_list_test.go
+++ b/internal/command/views/workspace_list_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-func TestWorkspaceListHuman(t *testing.T) {
+func TestWorkspaceListHuman_List(t *testing.T) {
 	testCases := map[string]struct {
 		selected   string
 		list       []string
@@ -85,7 +85,7 @@ func TestWorkspaceListHuman(t *testing.T) {
 	}
 }
 
-func TestWorkspaceListJSON(t *testing.T) {
+func TestWorkspaceListJSON_List(t *testing.T) {
 	testCases := map[string]struct {
 		selected string
 		list     []string
@@ -140,9 +140,37 @@ func TestWorkspaceListJSON(t *testing.T) {
 				},
 			},
 		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			view := NewView(streams)
+			view.Configure(&arguments.View{NoColor: true})
+			v := NewWorkspaceList(arguments.ViewJSON, view)
+
+			v.List(tc.selected, tc.list, tc.diags)
+
+			got := done(t).Stdout()
+
+			var result map[string]interface{}
+			if err := json.Unmarshal([]byte(got), &result); err != nil {
+				t.Fatal("expected to be able to unmarshal JSON, got error:", err)
+			}
+
+			// Assert contents
+			if diff := cmp.Diff(tc.wantLog, result); diff != "" {
+				t.Fatalf("unexpected diff in JSON output:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkspaceListJSON_LogErrorDiagnostics(t *testing.T) {
+	testCases := map[string]struct {
+		diags   tfdiags.Diagnostics
+		wantLog map[string]interface{}
+	}{
 		"error": {
-			"foobar",
-			[]string{},
 			tfdiags.Diagnostics{
 				tfdiags.Sourceless(
 					tfdiags.Error,
@@ -170,7 +198,7 @@ func TestWorkspaceListJSON(t *testing.T) {
 			view.Configure(&arguments.View{NoColor: true})
 			v := NewWorkspaceList(arguments.ViewJSON, view)
 
-			v.List(tc.selected, tc.list, tc.diags)
+			v.LogErrorDiagnostics(tc.diags)
 
 			got := done(t).Stdout()
 

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -35,7 +35,7 @@ func (c *WorkspaceListCommand) Run(rawArgs []string) int {
 
 	// Now the view is ready, process any error diagnostics from parsing arguments.
 	if diags.HasErrors() {
-		view.List("", nil, diags)
+		view.LogErrorDiagnostics(diags)
 		return 1
 	}
 
@@ -44,7 +44,7 @@ func (c *WorkspaceListCommand) Run(rawArgs []string) int {
 	b, bDiags := c.backend(configPath, args.ViewType)
 	diags = diags.Append(bDiags)
 	if bDiags.HasErrors() {
-		view.List("", nil, diags)
+		view.LogErrorDiagnostics(diags)
 		return 1
 	}
 
@@ -54,14 +54,14 @@ func (c *WorkspaceListCommand) Run(rawArgs []string) int {
 	states, wDiags := b.Workspaces()
 	diags = diags.Append(wDiags)
 	if wDiags.HasErrors() {
-		view.List("", nil, diags)
+		view.LogErrorDiagnostics(diags)
 		return 1
 	}
 
 	env, isOverridden, err := c.WorkspaceOverridden()
 	if err != nil {
 		diags = diags.Append(err)
-		view.List("", nil, diags)
+		view.LogErrorDiagnostics(diags)
 		return 1
 	}
 


### PR DESCRIPTION
WIP

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.18.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
