### PR TITLE
refactor: Make `workspace show` use the views package for producing terminal output 🤖 

### DIFF
--- a/internal/command/views/workspace_show.go
+++ b/internal/command/views/workspace_show.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// The WorkspaceShow view is used for the `workspace show` subcommand.
+type WorkspaceShow interface {
+	Show(workspace string, diags tfdiags.Diagnostics)
+}
+
+func NewWorkspaceShow(viewType arguments.ViewType, view *View) WorkspaceShow {
+	switch viewType {
+	case arguments.ViewHuman:
+		return &WorkspaceShowHuman{view: view}
+	default:
+		panic(fmt.Sprintf("unsupported view type: %s", viewType))
+	}
+}
+
+// The WorkspaceShowHuman implementation renders human-readable output.
+type WorkspaceShowHuman struct {
+	view *View
+}
+
+var _ WorkspaceShow = (*WorkspaceShowHuman)(nil)
+
+func (v *WorkspaceShowHuman) Show(workspace string, diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
+	if workspace != "" {
+		v.view.streams.Println(workspace)
+	}
+}

--- a/internal/command/views/workspace_show_test.go
+++ b/internal/command/views/workspace_show_test.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/terminal"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestWorkspaceShowHuman(t *testing.T) {
+	testCases := map[string]struct {
+		workspace string
+		diags     tfdiags.Diagnostics
+		wantOut   string
+		wantErr   string
+	}{
+		"success": {
+			workspace: "default",
+			wantOut:   "default\n",
+		},
+		"success with warning": {
+			workspace: "default",
+			diags: tfdiags.Diagnostics{
+				tfdiags.Sourceless(tfdiags.Warning, "Example warning", "This is an example warning message."),
+			},
+			wantOut: "Warning: Example warning\n\nThis is an example warning message.\ndefault\n",
+		},
+		"error": {
+			diags: tfdiags.Diagnostics{
+				tfdiags.Sourceless(tfdiags.Error, "Example error", "This is an example error message."),
+			},
+			wantErr: "Error: Example error\n\nThis is an example error message.\n\n",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			streams, done := terminal.StreamsForTesting(t)
+			view := NewView(streams)
+			view.Configure(&arguments.View{NoColor: true})
+			v := NewWorkspaceShow(arguments.ViewHuman, view)
+
+			v.Show(tc.workspace, tc.diags)
+
+			output := done(t)
+			if diff := cmp.Diff(strings.TrimSpace(tc.wantOut), strings.TrimSpace(output.Stdout())); diff != "" {
+				t.Fatalf("unexpected stdout:\n%s", diff)
+			}
+			if diff := cmp.Diff(strings.TrimSpace(tc.wantErr), strings.TrimSpace(output.Stderr())); diff != "" {
+				t.Fatalf("unexpected stderr:\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -163,18 +163,20 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 
 	//// Show Workspace
 	ui = testUiWrapped(t)
+	view, done = testView(t)
 	meta.Ui = ui
+	meta.View = view
 	showCmd := &WorkspaceShowCommand{
 		Meta: meta,
 	}
 	args = []string{}
 	code = showCmd.Run(args)
 	if code != 0 {
-		t.Fatalf("bad: %d\n\n%s\n%s", code, ui.ErrorWriter, ui.OutputWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
 	expectedMsg = fmt.Sprintf("%s\n", selectedWorkspace)
-	if !strings.Contains(ui.OutputWriter.String(), expectedMsg) {
-		t.Errorf("unexpected output, expected %q, but got:\n%s", expectedMsg, ui.OutputWriter)
+	if !strings.Contains(done(t).Stdout(), expectedMsg) {
+		t.Errorf("unexpected output, expected %q, but got:\n%s", expectedMsg, done(t).Stdout())
 	}
 
 	current, _ = newCmd.Workspace()
@@ -459,19 +461,17 @@ func TestWorkspace_createAndShow(t *testing.T) {
 
 	// make sure current workspace show outputs "default"
 	showCmd := &WorkspaceShowCommand{}
-	ui := testUiWrapped(t)
-	view, _ := testView(t)
+	view, done := testView(t)
 	showCmd.Meta = Meta{
-		Ui:         ui,
 		View:       view,
 		WorkingDir: workdir.NewDir("."),
 	}
 
 	if code := showCmd.Run(nil); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
 
-	actual := strings.TrimSpace(ui.OutputWriter.String())
+	actual := strings.TrimSpace(done(t).Stdout())
 	expected := "default"
 
 	if actual != expected {
@@ -483,7 +483,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	env := []string{"test_a"}
 
 	// create test_a workspace
-	ui = testUiWrapped(t)
+	ui := testUiWrapped(t)
 	newCmd.Meta = Meta{
 		Ui:         ui,
 		View:       view,
@@ -491,11 +491,11 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	}
 
 	if code := newCmd.Run(env); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
 
 	selCmd := &WorkspaceSelectCommand{}
-	ui = testUiWrapped(t)
+	ui := testUiWrapped(t)
 	selCmd.Meta = Meta{
 		Ui:         ui,
 		View:       view,
@@ -506,14 +506,14 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	}
 
 	showCmd = &WorkspaceShowCommand{}
-	ui = testUiWrapped(t)
-	showCmd.Meta = Meta{Ui: ui, View: view}
+	view, done = testView(t)
+	showCmd.Meta = Meta{View: view}
 
 	if code := showCmd.Run(nil); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
 
-	actual = strings.TrimSpace(ui.OutputWriter.String())
+	actual = strings.TrimSpace(done(t).Stdout())
 	expected = "test_a"
 
 	if actual != expected {
@@ -1181,13 +1181,13 @@ func TestWorkspace_extraArgError(t *testing.T) {
 	}
 
 	// Show
-	meta, ui, _, _ = newMeta(false)
+	meta, _, _, done = newMeta(false)
 	showCmd := &WorkspaceShowCommand{
 		Meta: meta,
 	}
 	args = []string{"extra-arg"} // The show subcommand does not accept any arguments, and doesn't have any logic detecting unexpected args.
 	if code := showCmd.Run(args); code != 0 {
-		t.Fatalf("expected command to succeed, got: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("expected command to succeed, got: %d\n\n%s", code, done(t).All())
 	}
 
 	// Select
@@ -1307,14 +1307,14 @@ func TestWorkspace_humanOutput(t *testing.T) {
 
 	// Assert output from showing the current workspace with color enabled
 	useColor = true
-	meta, ui, _, _ := newMeta(useColor)
+	meta, ui, _, done := newMeta(useColor)
 	showCmd := &WorkspaceShowCommand{
 		Meta: meta,
 	}
 	if code := showCmd.Run(nil); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
-	actual = ui.OutputWriter.String()
+	actual = done(t).Stdout()
 	expectedOutput = "test_f\n"
 	if actual != expectedOutput {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expectedOutput, actual)
@@ -1322,14 +1322,14 @@ func TestWorkspace_humanOutput(t *testing.T) {
 
 	// Assert output from showing the current workspace with color disabled
 	useColor = false
-	meta, ui, _, _ = newMeta(useColor)
+	meta, _, _, done = newMeta(useColor)
 	showCmd = &WorkspaceShowCommand{
 		Meta: meta,
 	}
 	if code := showCmd.Run(nil); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
 	}
-	actual = ui.OutputWriter.String()
+	actual = done(t).Stdout()
 	expectedOutput = "test_f\n"
 	if actual != expectedOutput {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expectedOutput, actual)

--- a/internal/command/workspace_show.go
+++ b/internal/command/workspace_show.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/posener/complete"
 )
 
@@ -17,23 +18,33 @@ type WorkspaceShowCommand struct {
 }
 
 func (c *WorkspaceShowCommand) Run(rawArgs []string) int {
-	// Process global flags and configure the view/UI.
-	rawArgs = c.Meta.process(rawArgs)
+	var diags tfdiags.Diagnostics
 
-	// Process command-specific arguments.
-	// Currently there are no arguments for this command, so ignore the returned value for now.
-	_, diags := arguments.ParseWorkspaceShow(rawArgs)
+	// Parse and apply global view arguments
+	common, rawArgs := arguments.ParseView(rawArgs)
+	c.View.Configure(common)
+
+	// Parse command-specific arguments.
+	args, parseDiags := arguments.ParseWorkspaceShow(rawArgs)
+	diags = diags.Append(parseDiags)
+
+	// Prepare the view
+	view := views.NewWorkspaceShow(args.ViewType, c.View)
+
+	// Now the view is ready, process any error diagnostics from parsing arguments.
 	if diags.HasErrors() {
-		c.showDiagnostics(diags)
-		return cli.RunResultHelp
+		view.Show("", diags)
+		return 1
 	}
 
 	workspace, err := c.Workspace()
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		diags = diags.Append(fmt.Errorf("Error selecting workspace: %s", err))
+		view.Show("", diags)
 		return 1
 	}
-	c.Ui.Output(workspace)
+
+	view.Show(workspace, diags)
 
 	return 0
 }


### PR DESCRIPTION
WIP

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.18.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
